### PR TITLE
Extract reporting

### DIFF
--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -24,6 +24,48 @@ NSVLISTFILE = 'nsvlist.txt'
 TMPDIR = '/tmp/'
 
 
+def output_report(n_total_clinvar_records, evidence_string_list, n_processed_clinvar_records, unrecognised_clin_sigs,
+                  n_same_ref_alt, ensembl_gene_id_uris, traits, n_pathogenic_no_rs, n_multiple_evidence_strings,
+                  n_germline_somatic, n_multiple_allele_origin, n_unrecognised_allele_origin,
+                  no_variant_to_ensg_mapping, n_missed_strings_unmapped_traits, n_records_no_recognised_allele_origin,
+                  n_more_than_one_efo_term, unavailable_efo_dict, n_valid_rs_and_nsv, n_nsvs, n_nsv_skipped_clin_sig,
+                  n_nsv_skipped_wrong_ref_alt):
+
+    report_strings = [
+        str(n_total_clinvar_records) + ' ClinVar records in total',
+        str(len(evidence_string_list)) + ' evidence string jsons generated',
+        str(n_processed_clinvar_records) + ' ClinVar records generated at least one evidence string',
+        str(len(unrecognised_clin_sigs)) + " Clinical significance string(s) not found among those described in ClinVar documentation:",
+        str(unrecognised_clin_sigs),
+        str(n_same_ref_alt) + ' ClinVar records with allowed clinical significance did present the same reference and alternate and were skipped',
+        'Activities of those ClinVar records with unrecognized clinical significances were set to "unknown".',
+        str(len(ensembl_gene_id_uris)) + ' distinct ensembl gene ids appear in generated evidence string json objects',
+            str(len(traits)) + ' distinct trait names found to include in generated evidence string json objects',
+        str(n_pathogenic_no_rs) + ' ClinVar records with allowed clinical significance DO NOT have an rs id',
+        str(n_multiple_evidence_strings) + ' ClinVar records generated more than one evidence_string',
+        str(n_germline_somatic) + ' ClinVar records with germline and somatic origins',
+        str(n_multiple_allele_origin) + ' ClinVar records with more than one allele origin',
+        'Number valid ClinVar records with unprocessed allele origins:'
+    ]
+
+    report_strings.extend([' ' + alleleOrigin + ': ' + str(n_unrecognised_allele_origin[alleleOrigin]) for alleleOrigin in n_unrecognised_allele_origin])
+
+    report_strings.extend([
+        str(no_variant_to_ensg_mapping) + ' ClinVar records with allowed clinical significance and valid rs id were skipped due to a lack of Variant->ENSG mapping.',
+        str(n_missed_strings_unmapped_traits) + ' ClinVar records with allowed clinical significance, valid rs id and Variant->ENSG mapping were skipped due to a lack of EFO mapping (see ' + UNMAPPEDTRAITSFILENAME + ').',
+        str(n_records_no_recognised_allele_origin) + ' ClinVar records with allowed clinical significance, valid rs id, valid Variant->ENSG mapping and valid EFO mapping were skipped due to a lack of a valid alleleOrigin.',
+        str(n_more_than_one_efo_term) + ' evidence strings with more than one trait mapped to EFO terms',
+        str(len(unavailable_efo_dict)) + ' evidence strings were generated with traits without EFO correspondence',
+        str(n_valid_rs_and_nsv) + ' evidence strings were generated from ClinVar records with rs and nsv ids',
+        str(n_nsvs) + ' total nsvs found',
+        str(n_nsv_skipped_clin_sig) + ' ClinVar nsvs were skipped because of a different clinical significance',
+        str(n_nsv_skipped_wrong_ref_alt) + ' ClinVar nsvs were skipped because of same ref and alt'
+    ])
+
+    for line in report_strings:
+        print(line)
+
+
 def clinvar_to_evidence_strings(dir_out, allowed_clinical_significance=None, ignore_terms_file=None,
                                 adapt_terms_file=None, efo_mapping_file=None, snp_2_gene_file=None,
                                 variant_summary_file=None):
@@ -223,37 +265,12 @@ def clinvar_to_evidence_strings(dir_out, allowed_clinical_significance=None, ign
         fdw.write('\t'.join(evidenceRecord) + '\n')
     fdw.close()
 
-    print(str(n_total_clinvar_records) + ' ClinVar records in total')
-    print(str(len(evidence_string_list)) + ' evidence string jsons generated')
-    print(str(n_processed_clinvar_records) + ' ClinVar records generated at least one evidence string')
-    print(str(len(
-        unrecognised_clin_sigs)) + " Clinical significance string(s) not found among those described in ClinVar documentation:")
-    print(str(unrecognised_clin_sigs))
-    print(str(
-        n_same_ref_alt) + ' ClinVar records with allowed clinical significance did present the same reference and alternate and were skipped')
-    print('Activities of those ClinVar records with unrecognized clinical significances were set to "unknown".')
-    print(str(len(ensembl_gene_id_uris)) + ' distinct ensembl gene ids appear in generated evidence string json objects')
-    print(str(len(traits)) + ' distinct trait names found to include in generated evidence string json objects')
-    print(str(n_pathogenic_no_rs) + ' ClinVar records with allowed clinical significance DO NOT have an rs id')
-    print(str(n_multiple_evidence_strings) + ' ClinVar records generated more than one evidence_string')
-    print(str(n_germline_somatic) + ' ClinVar records with germline and somatic origins')
-    print(str(n_multiple_allele_origin) + ' ClinVar records with more than one allele origin')
-    print('Number valid ClinVar records with unprocessed allele origins:')
-    for alleleOrigin in n_unrecognised_allele_origin:
-        print(' ' + alleleOrigin + ': ' + str(n_unrecognised_allele_origin[alleleOrigin]))
-    print(str(
-        no_variant_to_ensg_mapping) + ' ClinVar records with allowed clinical significance and valid rs id were skipped due to a lack of Variant->ENSG mapping.')
-    print(str(
-        n_missed_strings_unmapped_traits) + ' ClinVar records with allowed clinical significance, valid rs id and Variant->ENSG mapping were skipped due to a lack of EFO mapping (see ' + UNMAPPEDTRAITSFILENAME + ').')
-    print(str(
-        n_records_no_recognised_allele_origin) + ' ClinVar records with allowed clinical significance, valid rs id, valid Variant->ENSG mapping and valid EFO mapping were skipped due to a lack of a valid alleleOrigin.')
-    print(str(n_more_than_one_efo_term) + ' evidence strings with more than one trait mapped to EFO terms')
-    print(str(len(unavailable_efo_dict)) + ' evidence strings were generated with traits without EFO correspondence')
-    print(str(n_valid_rs_and_nsv) + ' evidence strings were generated from ClinVar records with rs and nsv ids')
-    print(str(n_nsvs) + ' total nsvs found')
-    print(str(
-        n_nsv_skipped_clin_sig) + ' ClinVar nsvs were skipped because of a different clinical significance')
-    print(str(n_nsv_skipped_wrong_ref_alt) + ' ClinVar nsvs were skipped because of same ref and alt')
+    output_report(n_total_clinvar_records, evidence_string_list, n_processed_clinvar_records, unrecognised_clin_sigs,
+                  n_same_ref_alt, ensembl_gene_id_uris, traits, n_pathogenic_no_rs, n_multiple_evidence_strings,
+                  n_germline_somatic, n_multiple_allele_origin, n_unrecognised_allele_origin,
+                  no_variant_to_ensg_mapping, n_missed_strings_unmapped_traits, n_records_no_recognised_allele_origin,
+                  n_more_than_one_efo_term, unavailable_efo_dict, n_valid_rs_and_nsv, n_nsvs, n_nsv_skipped_clin_sig,
+                  n_nsv_skipped_wrong_ref_alt)
 
 
 def add_evidence_string(clinvarRecord, ev_string, evidence_string_list, n_evidence_strings_per_record):

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -24,48 +24,6 @@ NSVLISTFILE = 'nsvlist.txt'
 TMPDIR = '/tmp/'
 
 
-def output_report(n_total_clinvar_records, evidence_string_list, n_processed_clinvar_records, unrecognised_clin_sigs,
-                  n_same_ref_alt, ensembl_gene_id_uris, traits, n_pathogenic_no_rs, n_multiple_evidence_strings,
-                  n_germline_somatic, n_multiple_allele_origin, n_unrecognised_allele_origin,
-                  no_variant_to_ensg_mapping, n_missed_strings_unmapped_traits, n_records_no_recognised_allele_origin,
-                  n_more_than_one_efo_term, unavailable_efo_dict, n_valid_rs_and_nsv, n_nsvs, n_nsv_skipped_clin_sig,
-                  n_nsv_skipped_wrong_ref_alt):
-
-    report_strings = [
-        str(n_total_clinvar_records) + ' ClinVar records in total',
-        str(len(evidence_string_list)) + ' evidence string jsons generated',
-        str(n_processed_clinvar_records) + ' ClinVar records generated at least one evidence string',
-        str(len(unrecognised_clin_sigs)) + " Clinical significance string(s) not found among those described in ClinVar documentation:",
-        str(unrecognised_clin_sigs),
-        str(n_same_ref_alt) + ' ClinVar records with allowed clinical significance did present the same reference and alternate and were skipped',
-        'Activities of those ClinVar records with unrecognized clinical significances were set to "unknown".',
-        str(len(ensembl_gene_id_uris)) + ' distinct ensembl gene ids appear in generated evidence string json objects',
-            str(len(traits)) + ' distinct trait names found to include in generated evidence string json objects',
-        str(n_pathogenic_no_rs) + ' ClinVar records with allowed clinical significance DO NOT have an rs id',
-        str(n_multiple_evidence_strings) + ' ClinVar records generated more than one evidence_string',
-        str(n_germline_somatic) + ' ClinVar records with germline and somatic origins',
-        str(n_multiple_allele_origin) + ' ClinVar records with more than one allele origin',
-        'Number valid ClinVar records with unprocessed allele origins:'
-    ]
-
-    report_strings.extend([' ' + alleleOrigin + ': ' + str(n_unrecognised_allele_origin[alleleOrigin]) for alleleOrigin in n_unrecognised_allele_origin])
-
-    report_strings.extend([
-        str(no_variant_to_ensg_mapping) + ' ClinVar records with allowed clinical significance and valid rs id were skipped due to a lack of Variant->ENSG mapping.',
-        str(n_missed_strings_unmapped_traits) + ' ClinVar records with allowed clinical significance, valid rs id and Variant->ENSG mapping were skipped due to a lack of EFO mapping (see ' + UNMAPPEDTRAITSFILENAME + ').',
-        str(n_records_no_recognised_allele_origin) + ' ClinVar records with allowed clinical significance, valid rs id, valid Variant->ENSG mapping and valid EFO mapping were skipped due to a lack of a valid alleleOrigin.',
-        str(n_more_than_one_efo_term) + ' evidence strings with more than one trait mapped to EFO terms',
-        str(len(unavailable_efo_dict)) + ' evidence strings were generated with traits without EFO correspondence',
-        str(n_valid_rs_and_nsv) + ' evidence strings were generated from ClinVar records with rs and nsv ids',
-        str(n_nsvs) + ' total nsvs found',
-        str(n_nsv_skipped_clin_sig) + ' ClinVar nsvs were skipped because of a different clinical significance',
-        str(n_nsv_skipped_wrong_ref_alt) + ' ClinVar nsvs were skipped because of same ref and alt'
-    ])
-
-    for line in report_strings:
-        print(line)
-
-
 def clinvar_to_evidence_strings(dir_out, allowed_clinical_significance=None, ignore_terms_file=None,
                                 adapt_terms_file=None, efo_mapping_file=None, snp_2_gene_file=None,
                                 variant_summary_file=None):
@@ -271,6 +229,48 @@ def clinvar_to_evidence_strings(dir_out, allowed_clinical_significance=None, ign
                   no_variant_to_ensg_mapping, n_missed_strings_unmapped_traits, n_records_no_recognised_allele_origin,
                   n_more_than_one_efo_term, unavailable_efo_dict, n_valid_rs_and_nsv, n_nsvs, n_nsv_skipped_clin_sig,
                   n_nsv_skipped_wrong_ref_alt)
+
+
+def output_report(n_total_clinvar_records, evidence_string_list, n_processed_clinvar_records, unrecognised_clin_sigs,
+                  n_same_ref_alt, ensembl_gene_id_uris, traits, n_pathogenic_no_rs, n_multiple_evidence_strings,
+                  n_germline_somatic, n_multiple_allele_origin, n_unrecognised_allele_origin,
+                  no_variant_to_ensg_mapping, n_missed_strings_unmapped_traits, n_records_no_recognised_allele_origin,
+                  n_more_than_one_efo_term, unavailable_efo_dict, n_valid_rs_and_nsv, n_nsvs, n_nsv_skipped_clin_sig,
+                  n_nsv_skipped_wrong_ref_alt):
+
+    report_strings = [
+        str(n_total_clinvar_records) + ' ClinVar records in total',
+        str(len(evidence_string_list)) + ' evidence string jsons generated',
+        str(n_processed_clinvar_records) + ' ClinVar records generated at least one evidence string',
+        str(len(unrecognised_clin_sigs)) + " Clinical significance string(s) not found among those described in ClinVar documentation:",
+        str(unrecognised_clin_sigs),
+        str(n_same_ref_alt) + ' ClinVar records with allowed clinical significance did present the same reference and alternate and were skipped',
+        'Activities of those ClinVar records with unrecognized clinical significances were set to "unknown".',
+        str(len(ensembl_gene_id_uris)) + ' distinct ensembl gene ids appear in generated evidence string json objects',
+            str(len(traits)) + ' distinct trait names found to include in generated evidence string json objects',
+        str(n_pathogenic_no_rs) + ' ClinVar records with allowed clinical significance DO NOT have an rs id',
+        str(n_multiple_evidence_strings) + ' ClinVar records generated more than one evidence_string',
+        str(n_germline_somatic) + ' ClinVar records with germline and somatic origins',
+        str(n_multiple_allele_origin) + ' ClinVar records with more than one allele origin',
+        'Number valid ClinVar records with unprocessed allele origins:'
+    ]
+
+    report_strings.extend([' ' + alleleOrigin + ': ' + str(n_unrecognised_allele_origin[alleleOrigin]) for alleleOrigin in n_unrecognised_allele_origin])
+
+    report_strings.extend([
+        str(no_variant_to_ensg_mapping) + ' ClinVar records with allowed clinical significance and valid rs id were skipped due to a lack of Variant->ENSG mapping.',
+        str(n_missed_strings_unmapped_traits) + ' ClinVar records with allowed clinical significance, valid rs id and Variant->ENSG mapping were skipped due to a lack of EFO mapping (see ' + UNMAPPEDTRAITSFILENAME + ').',
+        str(n_records_no_recognised_allele_origin) + ' ClinVar records with allowed clinical significance, valid rs id, valid Variant->ENSG mapping and valid EFO mapping were skipped due to a lack of a valid alleleOrigin.',
+        str(n_more_than_one_efo_term) + ' evidence strings with more than one trait mapped to EFO terms',
+        str(len(unavailable_efo_dict)) + ' evidence strings were generated with traits without EFO correspondence',
+        str(n_valid_rs_and_nsv) + ' evidence strings were generated from ClinVar records with rs and nsv ids',
+        str(n_nsvs) + ' total nsvs found',
+        str(n_nsv_skipped_clin_sig) + ' ClinVar nsvs were skipped because of a different clinical significance',
+        str(n_nsv_skipped_wrong_ref_alt) + ' ClinVar nsvs were skipped because of same ref and alt'
+    ])
+
+    for line in report_strings:
+        print(line)
 
 
 def add_evidence_string(clinvarRecord, ev_string, evidence_string_list, n_evidence_strings_per_record):

--- a/eva_cttv_pipeline/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_strings.py
@@ -284,14 +284,9 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
         self['evidence']['variant2disease']['is_associated'] = is_associated
 
     def validate(self):
-        # try:
         jsonschema.validate(self, CTTVGeneticsEvidenceString.schema, format_checker=jsonschema.FormatChecker())
-        # except Exception as e:
-        #     print(str(self))
-        #     print(e)
-        #     traceback.print_stack()
-        #     sys.exit()
         self.disease.is_obsolete()
+        return True
 
     def _clear_variant(self):
         self['variant']['id'] = []
@@ -430,6 +425,7 @@ class CTTVSomaticEvidenceString(CTTVEvidenceString):
     def validate(self):
         jsonschema.validate(self, CTTVSomaticEvidenceString.schema, format_checker=jsonschema.FormatChecker())
         self.disease.is_obsolete()
+        return True
 
     @property
     def date(self):

--- a/eva_cttv_pipeline/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_strings.py
@@ -48,11 +48,11 @@ def get_cttv_variant_type(ref, alt):
     return cttv_variant_type
 
 
-class CTTVEvidenceString(UserDict):
+class CTTVEvidenceString(dict):
     def __init__(self, a_dictionary, ensembl_gene_id=None, clinvar_record=None, ensembl_gene_id_uri=None, clin_sig=None,
                  efo_list=None, ref_list=None):
-        super().__init__(a_dictionary)
-        # dict.__init__(a_dictionary)
+        # super().__init__(a_dictionary)
+        dict.__init__(self, a_dictionary)
 
         if ensembl_gene_id:
             self.add_unique_association_field('gene', ensembl_gene_id)
@@ -204,11 +204,10 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
                                      }
                                      }
 
-        # CTTVEvidenceString.__init__(self, a_dictionary)
-
         ref_list = list(set(traits_ref_list[trait_counter] + observed_refs_list + measure_set_refs_list))
 
-        super().__init__(a_dictionary, ensembl_gene_id, clinvarRecord, ensembl_gene_id_uri, clin_sig, efo_list, ref_list)
+        # super().__init__(a_dictionary, ensembl_gene_id, clinvarRecord, ensembl_gene_id_uri, clin_sig, efo_list, ref_list)
+        CTTVEvidenceString.__init__(self, a_dictionary, ensembl_gene_id, clinvarRecord, ensembl_gene_id_uri, clin_sig, efo_list, ref_list)
 
         self.add_unique_association_field('alleleOrigin', 'germline')
         self.set_variant('http://identifiers.org/dbsnp/' + rs, get_cttv_variant_type(record['reference'], record['alternate']))
@@ -381,11 +380,11 @@ class CTTVSomaticEvidenceString(CTTVEvidenceString):
                                          'id': [],  # EFO terms
                                      }
                                      }
-        # CTTVEvidenceString.__init__(self,a_dictionary)
 
         ref_list = list(set(trait_refs_list[trait_counter] + observed_refs_list + measure_set_refs_list))
 
-        super().__init__(a_dictionary, ensembl_gene_id, clinvarRecord, ensembl_gene_id_uri, clin_sig, efo_list, ref_list)
+        CTTVEvidenceString.__init__(self, a_dictionary, ensembl_gene_id, clinvarRecord, ensembl_gene_id_uri, clin_sig, efo_list, ref_list)
+        # super().__init__(a_dictionary, ensembl_gene_id, clinvarRecord, ensembl_gene_id_uri, clin_sig, efo_list, ref_list)
 
         self.add_unique_association_field('alleleOrigin', 'somatic')
 

--- a/eva_cttv_pipeline/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_strings.py
@@ -51,8 +51,7 @@ def get_cttv_variant_type(ref, alt):
 class CTTVEvidenceString(dict):
     def __init__(self, a_dictionary, ensembl_gene_id=None, clinvar_record=None, ensembl_gene_id_uri=None, clin_sig=None,
                  efo_list=None, ref_list=None):
-        # super().__init__(a_dictionary)
-        dict.__init__(self, a_dictionary)
+        super().__init__(a_dictionary)
 
         if ensembl_gene_id:
             self.add_unique_association_field('gene', ensembl_gene_id)
@@ -206,8 +205,7 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
 
         ref_list = list(set(traits_ref_list[trait_counter] + observed_refs_list + measure_set_refs_list))
 
-        # super().__init__(a_dictionary, ensembl_gene_id, clinvarRecord, ensembl_gene_id_uri, clin_sig, efo_list, ref_list)
-        CTTVEvidenceString.__init__(self, a_dictionary, ensembl_gene_id, clinvarRecord, ensembl_gene_id_uri, clin_sig, efo_list, ref_list)
+        super().__init__(a_dictionary, ensembl_gene_id, clinvarRecord, ensembl_gene_id_uri, clin_sig, efo_list, ref_list)
 
         self.add_unique_association_field('alleleOrigin', 'germline')
         self.set_variant('http://identifiers.org/dbsnp/' + rs, get_cttv_variant_type(record['reference'], record['alternate']))
@@ -383,8 +381,7 @@ class CTTVSomaticEvidenceString(CTTVEvidenceString):
 
         ref_list = list(set(trait_refs_list[trait_counter] + observed_refs_list + measure_set_refs_list))
 
-        CTTVEvidenceString.__init__(self, a_dictionary, ensembl_gene_id, clinvarRecord, ensembl_gene_id_uri, clin_sig, efo_list, ref_list)
-        # super().__init__(a_dictionary, ensembl_gene_id, clinvarRecord, ensembl_gene_id_uri, clin_sig, efo_list, ref_list)
+        super().__init__(a_dictionary, ensembl_gene_id, clinvarRecord, ensembl_gene_id_uri, clin_sig, efo_list, ref_list)
 
         self.add_unique_association_field('alleleOrigin', 'somatic')
 

--- a/tests/test_evidence_strings.py
+++ b/tests/test_evidence_strings.py
@@ -247,7 +247,7 @@ class CTTVGeneticsEvidenceStringTest(unittest.TestCase):
     def test_validate(self):
         test_args = get_args_CTTVGeneticsEvidenceString_init()
         test_evidence_string = ES.CTTVGeneticsEvidenceString(*test_args)
-        test_evidence_string.validate()
+        self.assertTrue(test_evidence_string.validate())
 
 
 class CTTVSomaticEvidenceStringTest(unittest.TestCase):
@@ -315,6 +315,6 @@ class CTTVSomaticEvidenceStringTest(unittest.TestCase):
     def test_validate(self):
         test_args = get_args_CTTVSomaticEvidenceString_init()
         test_evidence_string = ES.CTTVSomaticEvidenceString(*test_args)
-        test_evidence_string.validate()
+        self.assertTrue(test_evidence_string.validate())
 
 


### PR DESCRIPTION
-Moved reporting to different 
-Fixed calls to superclasses and changed super of CTTVEvidenceString from UserDict back to dict
-Tests for validate functions
-Calls to "super" rather than explicitly mentioning class