### PR TITLE
Centralise config

### DIFF
--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -58,9 +58,8 @@ def clinvar_to_evidence_strings(dir_out, allowed_clinical_significance=None, ign
     record_counter = 0
     n_total_clinvar_records = 0
     skip = 0
-    limit = config.BATCH_SIZE
 
-    answer = urllib.request.urlopen('http://' + config.HOST + '/cellbase/webservices/rest/v3/hsapiens/feature/clinical/all?source=clinvar&skip=' + str(skip) + '&limit=' + str(limit))
+    answer = urllib.request.urlopen('http://' + config.HOST + '/cellbase/webservices/rest/v3/hsapiens/feature/clinical/all?source=clinvar&skip=' + str(skip) + '&limit=' + str(config.BATCH_SIZE))
     reader = codecs.getreader("utf-8")
     curr_response = json.load(reader(answer))['response'][0]
     curr_result_list = curr_response['result']
@@ -183,7 +182,7 @@ def clinvar_to_evidence_strings(dir_out, allowed_clinical_significance=None, ign
             record_counter += 1
         skip += config.BATCH_SIZE
 
-        answer = urllib.request.urlopen('http://' + config.HOST + '/cellbase/webservices/rest/v3/hsapiens/feature/clinical/all?source=clinvar&skip=' + str(skip) + '&limit=' + str(limit))
+        answer = urllib.request.urlopen('http://' + config.HOST + '/cellbase/webservices/rest/v3/hsapiens/feature/clinical/all?source=clinvar&skip=' + str(skip) + '&limit=' + str(config.BATCH_SIZE))
         reader = codecs.getreader("utf-8")
         curr_response = json.load(reader(answer))['response'][0]
         curr_result_list = curr_response['result']
@@ -200,27 +199,27 @@ def clinvar_to_evidence_strings(dir_out, allowed_clinical_significance=None, ign
 
 
 def write_output(dir_out, nsv_list, unmapped_traits, unavailable_efo_dict, evidence_string_list, evidence_list):
-    write_string_list_to_file(nsv_list, dir_out + '/' + config.NSVLISTFILE)
+    write_string_list_to_file(nsv_list, dir_out + '/' + config.NSV_LIST_FILE)
 
-    fdw = open(dir_out + '/' + config.UNMAPPEDTRAITSFILENAME, 'w')  # Contains traits without a mapping in Gary's xls
+    fdw = open(dir_out + '/' + config.UNMAPPED_TRAITS_FILE_NAME, 'w')  # Contains traits without a mapping in Gary's xls
     fdw.write('Trait\tCount\n')
     for trait_list in unmapped_traits:
         fdw.write(str(trait_list.encode('utf8')) + '\t' + str(unmapped_traits[trait_list]) + '\n')
     fdw.close()
 
-    fdw = open(dir_out + '/' + config.UNAVAILABLEEFOFILENAME,
+    fdw = open(dir_out + '/' + config.UNAVAILABLE_EFO_FILE_NAME,
                'w')  # Contains urls provided by Gary which are not yet included within EFO
     fdw.write('Trait\tCount\n')
     for url in unavailable_efo_dict:
         fdw.write(url.encode('utf8') + '\t' + str(unavailable_efo_dict[url]) + '\n')
     fdw.close()
 
-    fdw = open(dir_out + '/' + config.EVIDENCESTRINGSFILENAME, 'w')
+    fdw = open(dir_out + '/' + config.EVIDENCE_STRINGS_FILE_NAME, 'w')
     for evidence_string in evidence_string_list:
         fdw.write(json.dumps(evidence_string) + '\n')
     fdw.close()
 
-    fdw = open(dir_out + '/' + config.EVIDENCERECORDSFILENAME, 'w')
+    fdw = open(dir_out + '/' + config.EVIDENCE_RECORDS_FILE_NAME, 'w')
     for evidenceRecord in evidence_list:
         fdw.write('\t'.join(evidenceRecord) + '\n')
     fdw.close()
@@ -254,7 +253,7 @@ def output_report(n_total_clinvar_records, evidence_string_list, n_processed_cli
 
     report_strings.extend([
         str(no_variant_to_ensg_mapping) + ' ClinVar records with allowed clinical significance and valid rs id were skipped due to a lack of Variant->ENSG mapping.',
-        str(n_missed_strings_unmapped_traits) + ' ClinVar records with allowed clinical significance, valid rs id and Variant->ENSG mapping were skipped due to a lack of EFO mapping (see ' + config.UNMAPPEDTRAITSFILENAME + ').',
+        str(n_missed_strings_unmapped_traits) + ' ClinVar records with allowed clinical significance, valid rs id and Variant->ENSG mapping were skipped due to a lack of EFO mapping (see ' + config.UNMAPPED_TRAITS_FILE_NAME + ').',
         str(n_records_no_recognised_allele_origin) + ' ClinVar records with allowed clinical significance, valid rs id, valid Variant->ENSG mapping and valid EFO mapping were skipped due to a lack of a valid alleleOrigin.',
         str(n_more_than_one_efo_term) + ' evidence strings with more than one trait mapped to EFO terms',
         str(len(unavailable_efo_dict)) + ' evidence strings were generated with traits without EFO correspondence',

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -11,16 +11,8 @@ import xlrd
 from eva_cttv_pipeline import efo_term, clinvar_record, consequence_type, config
 from eva_cttv_pipeline import evidence_strings as ES
 
-__author__ = 'Javier Lopez: javild@gmail.com'
 
-BATCH_SIZE = config.BATCH_SIZE
-HOST = config.HOST
-EVIDENCESTRINGSFILENAME = config.EVIDENCESTRINGSFILENAME
-EVIDENCERECORDSFILENAME = config.EVIDENCERECORDSFILENAME
-UNMAPPEDTRAITSFILENAME = config.UNMAPPEDTRAITSFILENAME
-UNAVAILABLEEFOFILENAME = config.UNAVAILABLEEFOFILENAME
-NSVLISTFILE = config.NSVLISTFILE
-TMPDIR = config.TMPDIR
+__author__ = 'Javier Lopez: javild@gmail.com'
 
 
 def clinvar_to_evidence_strings(dir_out, allowed_clinical_significance=None, ignore_terms_file=None,
@@ -66,9 +58,9 @@ def clinvar_to_evidence_strings(dir_out, allowed_clinical_significance=None, ign
     record_counter = 0
     n_total_clinvar_records = 0
     skip = 0
-    limit = BATCH_SIZE
+    limit = config.BATCH_SIZE
 
-    answer = urllib.request.urlopen('http://' + HOST + '/cellbase/webservices/rest/v3/hsapiens/feature/clinical/all?source=clinvar&skip=' + str(skip) + '&limit=' + str(limit))
+    answer = urllib.request.urlopen('http://' + config.HOST + '/cellbase/webservices/rest/v3/hsapiens/feature/clinical/all?source=clinvar&skip=' + str(skip) + '&limit=' + str(limit))
     reader = codecs.getreader("utf-8")
     curr_response = json.load(reader(answer))['response'][0]
     curr_result_list = curr_response['result']
@@ -189,9 +181,9 @@ def clinvar_to_evidence_strings(dir_out, allowed_clinical_significance=None, ign
 
             # pbar.update(record_counter)
             record_counter += 1
-        skip += BATCH_SIZE
+        skip += config.BATCH_SIZE
 
-        answer = urllib.request.urlopen('http://' + HOST + '/cellbase/webservices/rest/v3/hsapiens/feature/clinical/all?source=clinvar&skip=' + str(skip) + '&limit=' + str(limit))
+        answer = urllib.request.urlopen('http://' + config.HOST + '/cellbase/webservices/rest/v3/hsapiens/feature/clinical/all?source=clinvar&skip=' + str(skip) + '&limit=' + str(limit))
         reader = codecs.getreader("utf-8")
         curr_response = json.load(reader(answer))['response'][0]
         curr_result_list = curr_response['result']
@@ -208,27 +200,27 @@ def clinvar_to_evidence_strings(dir_out, allowed_clinical_significance=None, ign
 
 
 def write_output(dir_out, nsv_list, unmapped_traits, unavailable_efo_dict, evidence_string_list, evidence_list):
-    write_string_list_to_file(nsv_list, dir_out + '/' + NSVLISTFILE)
+    write_string_list_to_file(nsv_list, dir_out + '/' + config.NSVLISTFILE)
 
-    fdw = open(dir_out + '/' + UNMAPPEDTRAITSFILENAME, 'w')  # Contains traits without a mapping in Gary's xls
+    fdw = open(dir_out + '/' + config.UNMAPPEDTRAITSFILENAME, 'w')  # Contains traits without a mapping in Gary's xls
     fdw.write('Trait\tCount\n')
     for trait_list in unmapped_traits:
         fdw.write(str(trait_list.encode('utf8')) + '\t' + str(unmapped_traits[trait_list]) + '\n')
     fdw.close()
 
-    fdw = open(dir_out + '/' + UNAVAILABLEEFOFILENAME,
+    fdw = open(dir_out + '/' + config.UNAVAILABLEEFOFILENAME,
                'w')  # Contains urls provided by Gary which are not yet included within EFO
     fdw.write('Trait\tCount\n')
     for url in unavailable_efo_dict:
         fdw.write(url.encode('utf8') + '\t' + str(unavailable_efo_dict[url]) + '\n')
     fdw.close()
 
-    fdw = open(dir_out + '/' + EVIDENCESTRINGSFILENAME, 'w')
+    fdw = open(dir_out + '/' + config.EVIDENCESTRINGSFILENAME, 'w')
     for evidence_string in evidence_string_list:
         fdw.write(json.dumps(evidence_string) + '\n')
     fdw.close()
 
-    fdw = open(dir_out + '/' + EVIDENCERECORDSFILENAME, 'w')
+    fdw = open(dir_out + '/' + config.EVIDENCERECORDSFILENAME, 'w')
     for evidenceRecord in evidence_list:
         fdw.write('\t'.join(evidenceRecord) + '\n')
     fdw.close()
@@ -262,7 +254,7 @@ def output_report(n_total_clinvar_records, evidence_string_list, n_processed_cli
 
     report_strings.extend([
         str(no_variant_to_ensg_mapping) + ' ClinVar records with allowed clinical significance and valid rs id were skipped due to a lack of Variant->ENSG mapping.',
-        str(n_missed_strings_unmapped_traits) + ' ClinVar records with allowed clinical significance, valid rs id and Variant->ENSG mapping were skipped due to a lack of EFO mapping (see ' + UNMAPPEDTRAITSFILENAME + ').',
+        str(n_missed_strings_unmapped_traits) + ' ClinVar records with allowed clinical significance, valid rs id and Variant->ENSG mapping were skipped due to a lack of EFO mapping (see ' + config.UNMAPPEDTRAITSFILENAME + ').',
         str(n_records_no_recognised_allele_origin) + ' ClinVar records with allowed clinical significance, valid rs id, valid Variant->ENSG mapping and valid EFO mapping were skipped due to a lack of a valid alleleOrigin.',
         str(n_more_than_one_efo_term) + ' evidence strings with more than one trait mapped to EFO terms',
         str(len(unavailable_efo_dict)) + ' evidence strings were generated with traits without EFO correspondence',

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -8,20 +8,19 @@ import codecs
 import jsonschema
 import xlrd
 
-from eva_cttv_pipeline import efo_term, clinvar_record, consequence_type
+from eva_cttv_pipeline import efo_term, clinvar_record, consequence_type, config
 from eva_cttv_pipeline import evidence_strings as ES
 
 __author__ = 'Javier Lopez: javild@gmail.com'
 
-BATCH_SIZE = 200
-# HOST = 'localhost:8080'
-HOST = 'www.ebi.ac.uk'
-EVIDENCESTRINGSFILENAME = 'evidence_strings.json'
-EVIDENCERECORDSFILENAME = 'evidence_records.tsv'
-UNMAPPEDTRAITSFILENAME = 'unmappedTraits.tsv'
-UNAVAILABLEEFOFILENAME = 'unavailableefo.tsv'
-NSVLISTFILE = 'nsvlist.txt'
-TMPDIR = '/tmp/'
+BATCH_SIZE = config.BATCH_SIZE
+HOST = config.HOST
+EVIDENCESTRINGSFILENAME = config.EVIDENCESTRINGSFILENAME
+EVIDENCERECORDSFILENAME = config.EVIDENCERECORDSFILENAME
+UNMAPPEDTRAITSFILENAME = config.UNMAPPEDTRAITSFILENAME
+UNAVAILABLEEFOFILENAME = config.UNAVAILABLEEFOFILENAME
+NSVLISTFILE = config.NSVLISTFILE
+TMPDIR = config.TMPDIR
 
 
 def clinvar_to_evidence_strings(dir_out, allowed_clinical_significance=None, ignore_terms_file=None,

--- a/eva_cttv_pipeline/config.py
+++ b/eva_cttv_pipeline/config.py
@@ -1,5 +1,21 @@
 local_schema = "resources/schema_local"
 
+#########################################
+# clinvar_to_evidence_strings.py settings
+#########################################
+# cellbase
+BATCH_SIZE = 200
+HOST = 'www.ebi.ac.uk'
+
+# output settings
+EVIDENCESTRINGSFILENAME = 'evidence_strings.json'
+EVIDENCERECORDSFILENAME = 'evidence_records.tsv'
+UNMAPPEDTRAITSFILENAME = 'unmappedTraits.tsv'
+UNAVAILABLEEFOFILENAME = 'unavailableefo.tsv'
+NSVLISTFILE = 'nsvlist.txt'
+TMPDIR = '/tmp/'
+
+
 sparqlep = ""
 sparql_user = ""
 sparql_password = ""

--- a/eva_cttv_pipeline/config.py
+++ b/eva_cttv_pipeline/config.py
@@ -1,5 +1,11 @@
 local_schema = "resources/schema_local"
 
+
+sparqlep = ""
+sparql_user = ""
+sparql_password = ""
+
+
 #########################################
 # clinvar_to_evidence_strings.py settings
 #########################################
@@ -13,9 +19,16 @@ EVIDENCERECORDSFILENAME = 'evidence_records.tsv'
 UNMAPPEDTRAITSFILENAME = 'unmappedTraits.tsv'
 UNAVAILABLEEFOFILENAME = 'unavailableefo.tsv'
 NSVLISTFILE = 'nsvlist.txt'
-TMPDIR = '/tmp/'
+
+######
 
 
-sparqlep = ""
-sparql_user = ""
-sparql_password = ""
+##############################
+# evidence_strings.py settings
+##############################
+GEN_EV_STRING_JSON = "resources/CTTVGeneticsEvidenceString.json"
+SOM_EV_STRING_JSON = "resources/CTTVSomaticEvidenceString.json"
+GEN_SCHEMA_FILE = local_schema + "/src/genetics.json"
+SOM_SCHEMA_FILE = local_schema + "/src/literature_curated.json"
+
+#############

--- a/eva_cttv_pipeline/config.py
+++ b/eva_cttv_pipeline/config.py
@@ -1,9 +1,9 @@
-local_schema = "resources/schema_local"
+LOCAL_SCHEMA = "resources/schema_local"
 
 
-sparqlep = ""
-sparql_user = ""
-sparql_password = ""
+SPARQLEP = ""
+SPARQL_USER = ""
+SPARQL_PASSWORD = ""
 
 
 #########################################
@@ -14,11 +14,11 @@ BATCH_SIZE = 200
 HOST = 'www.ebi.ac.uk'
 
 # output settings
-EVIDENCESTRINGSFILENAME = 'evidence_strings.json'
-EVIDENCERECORDSFILENAME = 'evidence_records.tsv'
-UNMAPPEDTRAITSFILENAME = 'unmappedTraits.tsv'
-UNAVAILABLEEFOFILENAME = 'unavailableefo.tsv'
-NSVLISTFILE = 'nsvlist.txt'
+EVIDENCE_STRINGS_FILE_NAME = 'evidence_strings.json'
+EVIDENCE_RECORDS_FILE_NAME = 'evidence_records.tsv'
+UNMAPPED_TRAITS_FILE_NAME = 'unmappedTraits.tsv'
+UNAVAILABLE_EFO_FILE_NAME = 'unavailableefo.tsv'
+NSV_LIST_FILE = 'nsvlist.txt'
 
 ######
 
@@ -28,7 +28,7 @@ NSVLISTFILE = 'nsvlist.txt'
 ##############################
 GEN_EV_STRING_JSON = "resources/CTTVGeneticsEvidenceString.json"
 SOM_EV_STRING_JSON = "resources/CTTVSomaticEvidenceString.json"
-GEN_SCHEMA_FILE = local_schema + "/src/genetics.json"
-SOM_SCHEMA_FILE = local_schema + "/src/literature_curated.json"
+GEN_SCHEMA_FILE = LOCAL_SCHEMA + "/src/genetics.json"
+SOM_SCHEMA_FILE = LOCAL_SCHEMA + "/src/literature_curated.json"
 
 #############

--- a/eva_cttv_pipeline/efo_term.py
+++ b/eva_cttv_pipeline/efo_term.py
@@ -47,9 +47,9 @@ def execute_query(sparqlep, user, password, query):
 class EFOTerm:
     print('Querying EFO  web services for valid terms...')
     # CONNECTION PARAMETERS
-    sparqlep = config.sparqlep
-    user = config.sparql_user
-    password = config.sparql_password
+    sparqlep = config.SPARQLEP
+    user = config.SPARQL_USER
+    password = config.SPARQL_PASSWORD
 
     obsolete_terms = get_obsolete_terms(sparqlep, user, password)
     cttv_available_terms = get_available_terms(sparqlep, user, password)

--- a/eva_cttv_pipeline/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_strings.py
@@ -11,10 +11,6 @@ __author__ = 'Javier Lopez: javild@gmail.com'
 
 
 utilities.check_for_local_schema()
-GEN_EV_STRING_JSON = utilities.get_resource_file(__package__, "resources/CTTVGeneticsEvidenceString.json")
-SOM_EV_STRING_JSON = utilities.get_resource_file(__package__, "resources/CTTVSomaticEvidenceString.json")
-GEN_SCHEMA_FILE = utilities.get_resource_file(__package__, config.local_schema + "/src/genetics.json")
-SOM_SCHEMA_FILE = utilities.get_resource_file(__package__, config.local_schema + "/src/literature_curated.json")
 
 
 clin_sig_2_activity = {'other': 'http://identifiers.org/cttv.activity/unknown',
@@ -113,13 +109,13 @@ class CTTVEvidenceString(dict):
 
 
 class CTTVGeneticsEvidenceString(CTTVEvidenceString):
-    schema = json.loads(open(GEN_SCHEMA_FILE, 'r').read())
+    schema = json.loads(open(utilities.get_resource_file(__package__, config.GEN_SCHEMA_FILE), 'r').read())
 
     def __init__(self, efo_list, clin_sig, clinvarRecord, consequenceType, ensembl_gene_id,
                  ensembl_gene_id_uri, measure_set_refs_list, observed_refs_list, rcv_to_gene_evidence_codes, record, rs,
                  trait_counter, traits_ref_list, unrecognised_clin_sigs):
 
-        with open(GEN_EV_STRING_JSON) as gen_json_file:
+        with open(utilities.get_resource_file(__package__, config.GEN_EV_STRING_JSON)) as gen_json_file:
             a_dictionary = json.load(gen_json_file)
 
         # CTTVEvidenceString.__init__(self, a_dictionary)
@@ -238,14 +234,14 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
 
 
 class CTTVSomaticEvidenceString(CTTVEvidenceString):
-    schema = json.loads(open(SOM_SCHEMA_FILE, 'r').read())
+    schema = json.loads(open(utilities.get_resource_file(__package__, config.SOM_SCHEMA_FILE), 'r').read())
 
     def __init__(self, efo_list, clin_sig, clinvarRecord,
                                      ensembl_gene_id, ensembl_gene_id_uri, measure_set_refs_list,
                                      observed_refs_list, trait_counter, trait_refs_list,
                                      unrecognised_clin_sigs, consequenceType):
 
-        with open(SOM_EV_STRING_JSON) as som_json_file:
+        with open(utilities.get_resource_file(__package__, config.SOM_EV_STRING_JSON)) as som_json_file:
             a_dictionary = json.load(som_json_file)
 
         # CTTVEvidenceString.__init__(self,a_dictionary)

--- a/eva_cttv_pipeline/utilities.py
+++ b/eva_cttv_pipeline/utilities.py
@@ -72,7 +72,7 @@ def change_json_refs(local_schema_dir):
 def create_local_schema():
     json_schema_dir = get_resource_file(__package__, "resources/json_schema")
     # local_schema_dir = str(os.path.join(str(Path(json_schema_dir).parent), "schema_copy"))
-    local_schema_dir = str(os.path.join(os.path.dirname(os.path.dirname(json_schema_dir)), config.local_schema))
+    local_schema_dir = str(os.path.join(os.path.dirname(os.path.dirname(json_schema_dir)), config.LOCAL_SCHEMA))
 
     ready_file = local_schema_dir + "/READY"
     if os.path.exists(ready_file):
@@ -89,7 +89,7 @@ def create_local_schema():
 
 
 def check_for_local_schema():
-    local_schema = get_resource_file(__package__, config.local_schema)
+    local_schema = get_resource_file(__package__, config.LOCAL_SCHEMA)
     if not os.path.exists(local_schema):
         create_local_schema()
 


### PR DESCRIPTION
- Moved cellbase and output configuration to config.py
- Moved evidence_strings settings to config file. 
- Moved references to config variables from top of files, to where they're used.