### PR TITLE
EVA-495

### DIFF
--- a/eva_cttv_pipeline/clinvar.py
+++ b/eva_cttv_pipeline/clinvar.py
@@ -278,6 +278,6 @@ class ClinvarRecord(UserDict):
         allele_origins = set()
         for clinvar_assetion_document in self.data['clinVarAssertion']:
             for observed_in_document in clinvar_assetion_document['observedIn']:
-                allele_origins.add(observed_in_document['sample']['origin'])
+                allele_origins.add(observed_in_document['sample']['origin'].lower())
 
         return list(allele_origins)

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -436,10 +436,9 @@ def convert_allele_origins(orig_allele_origins):
     converted_allele_origins = []
     if "somatic" in orig_allele_origins:
         converted_allele_origins.append("somatic")
-    if len(set(orig_allele_origins).intersection({"germline", "unknown", "not provided", "de novo",
-                                                  "inherited", "maternal", "paternal",
-                                                  "biparental", "uniparental",
-                                                  "not applicable"})) > 0:
+    if set(orig_allele_origins).intersection({"germline", "unknown", "not provided", "de novo",
+                                              "inherited", "maternal", "paternal",
+                                              "biparental", "uniparental", "not applicable"}):
         converted_allele_origins.append("germline")
 
     return converted_allele_origins

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -216,8 +216,10 @@ def clinvar_to_evidence_strings(allowed_clinical_significance, mappings, json_fi
 
         traits = create_traits(clinvar_record.traits, mappings.trait_2_efo, report)
 
+        converted_allele_origins = convert_allele_origins(clinvar_record.allele_origins)
+
         for ensembl_gene_id, trait, allele_origin \
-                in itertools.product(clinvar_record.consequence_type.ensembl_gene_ids, traits, clinvar_record.allele_origins):
+                in itertools.product(clinvar_record.consequence_type.ensembl_gene_ids, traits, converted_allele_origins):
 
             if allele_origin not in ('germline', 'somatic'):
                 report.n_unrecognised_allele_origin[allele_origin] += 1
@@ -428,3 +430,19 @@ def get_default_allowed_clinical_significance():
             'likely benign', 'confers sensitivity', 'uncertain significance',
             'likely pathogenic', 'conflicting data from submitters', 'risk factor',
             'association']
+
+def convert_allele_origins(orig_allele_origins):
+    orig_allele_origins = [item.lower() for item in orig_allele_origins]
+    converted_allele_origins = []
+    if "somatic" in orig_allele_origins:
+        converted_allele_origins.append("somatic")
+    if len(set(orig_allele_origins).intersection({"germline", "unknown", "not provided", "de novo",
+                                                  "inherited", "maternal", "paternal",
+                                                  "biparental", "uniparental",
+                                                  "not applicable"})) > 0:
+        converted_allele_origins.append("germline")
+
+    return converted_allele_origins
+
+
+

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -438,8 +438,7 @@ def convert_allele_origins(orig_allele_origins):
         converted_allele_origins.append("somatic")
     if set(orig_allele_origins).intersection({"biparental", "de novo", "germline", "inherited",
                                               "maternal", "not applicable", "not provided",
-                                              "paternal", "uniparental", "unknown",
-                                              "uniparental"}):
+                                              "paternal", "uniparental", "unknown"}):
         converted_allele_origins.append("germline")
 
     return converted_allele_origins

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -436,9 +436,10 @@ def convert_allele_origins(orig_allele_origins):
     converted_allele_origins = []
     if "somatic" in orig_allele_origins:
         converted_allele_origins.append("somatic")
-    if set(orig_allele_origins).intersection({"germline", "unknown", "not provided", "de novo",
-                                              "inherited", "maternal", "paternal",
-                                              "biparental", "uniparental", "not applicable"}):
+    if set(orig_allele_origins).intersection({"biparental", "de novo", "germline", "inherited",
+                                              "maternal", "not applicable", "not provided",
+                                              "paternal", "uniparental", "unknown",
+                                              "uniparental"}):
         converted_allele_origins.append("germline")
 
     return converted_allele_origins

--- a/tests/test_clinvar_to_evidence_strings.py
+++ b/tests/test_clinvar_to_evidence_strings.py
@@ -170,3 +170,87 @@ class TestGetDefaultAllowedClincalSignificance(unittest.TestCase):
          'association']
         self.assertEqual(clinvar_to_evidence_strings.get_default_allowed_clinical_significance(),
                          correct_list)
+
+
+class TestConvertAlleleOrigins(unittest.TestCase):
+    def test_just_germline(self):
+        orig_allele_origins = ["germline"]
+        converted_allele_origins = clinvar_to_evidence_strings.convert_allele_origins(orig_allele_origins)
+        self.assertListEqual(["germline"], converted_allele_origins)
+
+    def test_just_somatic(self):
+        orig_allele_origins = ["somatic"]
+        converted_allele_origins = clinvar_to_evidence_strings.convert_allele_origins(orig_allele_origins)
+        self.assertListEqual(["somatic"], converted_allele_origins)
+
+    def test_just_tested_inconclusive(self):
+        orig_allele_origins = ["tested-inconclusive"]
+        converted_allele_origins = clinvar_to_evidence_strings.convert_allele_origins(orig_allele_origins)
+        self.assertListEqual([], converted_allele_origins)
+
+    def test_just_other_germline(self):
+        orig_allele_origins_list = [["unknown"],
+                                    ["inherited"],
+                                    ["maternal"]]
+        for orig_allele_origins in orig_allele_origins_list:
+            converted_allele_origins = clinvar_to_evidence_strings.convert_allele_origins(orig_allele_origins)
+            self.assertListEqual(["germline"], converted_allele_origins)
+
+    def test_nonsense(self):
+        orig_allele_origins_list = [["fgdsgfgs"],
+                                    ["notarealorigin"],
+                                    ["134312432:dasdfd"]]
+        for orig_allele_origins in orig_allele_origins_list:
+            converted_allele_origins = clinvar_to_evidence_strings.convert_allele_origins(orig_allele_origins)
+            self.assertListEqual([], converted_allele_origins)
+        orig_allele_origins = ["fgdsgfgs", "germline"]
+        converted_allele_origins = clinvar_to_evidence_strings.convert_allele_origins(orig_allele_origins)
+        self.assertListEqual(["germline"], converted_allele_origins)
+
+    def test_mixed_germline(self):
+        orig_allele_origins_list = [["germline", "de novo"],
+                                    ["germline", "inherited", "not applicable"]]
+        for orig_allele_origins in orig_allele_origins_list:
+            converted_allele_origins = clinvar_to_evidence_strings.convert_allele_origins(orig_allele_origins)
+            self.assertListEqual(["germline"], converted_allele_origins)
+
+    def test_duplicate(self):
+        orig_allele_origins = ["germline", "germline"]
+        converted_allele_origins = clinvar_to_evidence_strings.convert_allele_origins(
+            orig_allele_origins)
+        self.assertListEqual(["germline"], converted_allele_origins)
+        orig_allele_origins = ["inherited", "inherited", "germline"]
+        converted_allele_origins = clinvar_to_evidence_strings.convert_allele_origins(
+            orig_allele_origins)
+        self.assertListEqual(["germline"], converted_allele_origins)
+        orig_allele_origins = ["somatic", "somatic", "somatic"]
+        converted_allele_origins = clinvar_to_evidence_strings.convert_allele_origins(
+            orig_allele_origins)
+        self.assertListEqual(["somatic"], converted_allele_origins)
+
+
+    def test_stringcase(self):
+        orig_allele_origins_list = [["Germline"],
+                               ["InHerIted"],
+                               ["UNKNOWN"]]
+        for orig_allele_origins in orig_allele_origins_list:
+            converted_allele_origins = clinvar_to_evidence_strings.convert_allele_origins(orig_allele_origins)
+            self.assertListEqual(["germline"], converted_allele_origins)
+        orig_allele_origins_list = [["Somatic"],
+                                    ["SOMATIC"],
+                                    ["sOMatIc"]]
+        for orig_allele_origins in orig_allele_origins_list:
+            converted_allele_origins = clinvar_to_evidence_strings.convert_allele_origins(
+                orig_allele_origins)
+            self.assertListEqual(["somatic"], converted_allele_origins)
+
+    def test_mixed(self):
+        orig_allele_origins_list = [["germline", "somatic"],
+                                    ["somatic", "inherited", "not applicable"],
+                                    ["somatic", "unknown"]]
+        for orig_allele_origins in orig_allele_origins_list:
+            converted_allele_origins = clinvar_to_evidence_strings.convert_allele_origins(
+                orig_allele_origins)
+            self.assertListEqual(["somatic", "germline"], converted_allele_origins)
+
+


### PR DESCRIPTION
- Function for mapping/converting allele origins other than "somatic" and "germline" to "germline"
- Tests for this function
- Use these converted allele origins for evidence strings