### PR TITLE
EVA-479

### DIFF
--- a/bin/main.py
+++ b/bin/main.py
@@ -14,8 +14,6 @@ def main():
 
     clinvar_to_evidence_strings.launch_pipeline(parser.out,
                                                 allowed_clinical_significance=parser.clinical_significance,
-                                                ignore_terms_file=parser.ignore_terms_file,
-                                                adapt_terms_file=parser.adapt_terms_file,
                                                 efo_mapping_file=parser.efo_mapping_file,
                                                 snp_2_gene_file=parser.snp_2_gene_file,
                                                 variant_summary_file=parser.variant_summary_file,

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -240,9 +240,9 @@ def clinvar_to_evidence_strings(allowed_clinical_significance, mappings, json_fi
             report.evidence_list.append([clinvar_record.accession,
                                          clinvar_record.rs,
                                          trait.clinvar_name,
-                                         trait.ontology_name])
+                                         trait.ontology_id])
             report.counters["n_valid_rs_and_nsv"] += (clinvar_record.nsv is not None)
-            report.traits.add(trait.ontology_name)
+            report.traits.add(trait.ontology_id)
             report.ensembl_gene_id_uris.add(evidence_strings.get_ensembl_gene_id_uri(
                 ensembl_gene_id))
 
@@ -305,7 +305,7 @@ def create_trait(trait_counter, name_list, trait_2_efo_dict):
     trait = Trait(name_list, trait_counter, trait_2_efo_dict)
     # Only ClinVar records associated to a
     # trait with mapped EFO term will generate evidence_strings
-    if trait.ontology_name is None:
+    if trait.ontology_id is None:
         return None
     return trait
 

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -135,7 +135,7 @@ class Report:
         # Contains urls provided by Gary which are not yet included within EFO
         with utilities.open_file(dir_out + '/' + config.UNAVAILABLE_EFO_FILE_NAME, 'wt') as fdw:
             fdw.write('Trait\tCount\n')
-            for clinvar_name in list(self.unavailable_efo):
+            for clinvar_name in self.unavailable_efo:
                 fdw.write(clinvar_name + "\n")
 
         with utilities.open_file(dir_out + '/' + config.EVIDENCE_STRINGS_FILE_NAME, 'wt') as fdw:

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -239,11 +239,10 @@ def clinvar_to_evidence_strings(allowed_clinical_significance, mappings, json_fi
             report.add_evidence_string(evidence_string, clinvar_record, trait, ensembl_gene_id)
             report.evidence_list.append([clinvar_record.accession,
                                          clinvar_record.rs,
-                                         ','.join(trait.clinvar_trait_list),
-                                         ','.join(trait.efo_list)])
+                                         trait.clinvar_name,
+                                         trait.ontology_name])
             report.counters["n_valid_rs_and_nsv"] += (clinvar_record.nsv is not None)
-            report.counters["n_more_than_one_efo_term"] += (len(trait.efo_list) > 1)
-            report.traits.update(set(trait.efo_list))
+            report.traits.add(trait.ontology_name)
             report.ensembl_gene_id_uris.add(evidence_strings.get_ensembl_gene_id_uri(
                 ensembl_gene_id))
 

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -9,7 +9,7 @@ import xlrd
 
 from eva_cttv_pipeline import cellbase_records, efo_term, consequence_type, config, \
     evidence_strings, clinvar, utilities
-
+from eva_cttv_pipeline.trait import Trait
 
 __author__ = 'Javier Lopez: javild@gmail.com'
 
@@ -303,12 +303,10 @@ def create_traits(clinvar_traits, trait_2_efo_dict, report):
 
 
 def create_trait(trait_counter, name_list, trait_2_efo_dict):
-    trait = SimpleNamespace()
-    trait.trait_counter = trait_counter
-    trait.clinvar_trait_list, trait.efo_list = map_efo(trait_2_efo_dict, name_list)
+    trait = Trait(name_list, trait_counter, trait_2_efo_dict)
     # Only ClinVar records associated to a
     # trait with mapped EFO term will generate evidence_strings
-    if len(trait.efo_list) == 0:
+    if trait.ontology_name is None:
         return None
     return trait
 
@@ -323,29 +321,6 @@ def append_nsv(nsv_list, clinvar_record):
     if nsv is not None:
         nsv_list.append(nsv)
     return nsv_list
-
-
-def map_efo(trait_2_efo, name_list):
-    efo_list = []
-    trait_list_to_return = []
-    trait_string = name_list[0].lower()
-    if trait_string in trait_2_efo:
-        for efo_trait in trait_2_efo[trait_string]:
-            # First element in trait_list mus always be the "Preferred" trait name
-            if efo_trait not in efo_list:
-                trait_list_to_return.append(name_list[0])
-                efo_list.append(efo_trait)
-    else:
-        for trait in name_list[1:]:
-            trait_string = trait.lower()
-            if trait_string in trait_2_efo:
-                for efo_trait in trait_2_efo[trait_string]:
-                    # First element in trait_list mus always be the "Preferred" trait name
-                    if efo_trait not in efo_list:
-                        trait_list_to_return.append(trait)
-                        efo_list.append(efo_trait)
-
-    return trait_list_to_return, efo_list
 
 
 def load_efo_mapping(efo_mapping_file, ignore_terms_file=None, adapt_terms_file=None):

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -333,7 +333,7 @@ def load_efo_mapping(efo_mapping_file):
             clinvar_name = line_list[0].lower()
             if len(line_list) > 1:
                 ontology_id = line_list[1]
-                ontology_label = line_list[2]
+                ontology_label = line_list[2] if len(line_list) > 2 else None
                 trait_2_efo[clinvar_name] = (ontology_id, ontology_label)
             else:
                 unavailable_efo.add(clinvar_name)

--- a/eva_cttv_pipeline/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_strings.py
@@ -63,7 +63,6 @@ class CTTVEvidenceString(dict):
     def __init__(self, a_dictionary, clinvar_record=None, ontology_name=None, ref_list=None,
                  ensembl_gene_id=None, report=None, clinvar_name=None, ontology_label=None):
         super().__init__(a_dictionary)
-        # dict.__init__(a_dictionary)
 
         if ensembl_gene_id:
             self.add_unique_association_field('gene', ensembl_gene_id)

--- a/eva_cttv_pipeline/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_strings.py
@@ -87,10 +87,10 @@ class CTTVEvidenceString(dict):
         self.add_unique_association_field('phenotype', ontology_name)
 
         if clinvar_name:
-            self.disease_source_name = clinvar_name
+            self.disease_source_name = [clinvar_name]
 
         if ontology_label:
-            self.disease_name = ontology_label
+            self.disease_name = [ontology_label]
 
 
     def add_unique_association_field(self, key, value):

--- a/eva_cttv_pipeline/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_strings.py
@@ -60,8 +60,8 @@ class CTTVEvidenceString(dict):
     Subclass of dict to use indexing.
     """
 
-    def __init__(self, a_dictionary, clinvar_record=None, ontology_name=None, ref_list=None,
-                 ensembl_gene_id=None, report=None, clinvar_name=None, ontology_label=None):
+    def __init__(self, a_dictionary, clinvar_record=None, ref_list=None,
+                 ensembl_gene_id=None, report=None, trait=None):
         super().__init__(a_dictionary)
 
         if ensembl_gene_id:
@@ -82,14 +82,14 @@ class CTTVEvidenceString(dict):
         if ref_list and len(ref_list) > 0:
             self.top_level_literature = ref_list
 
-        self.disease_id = ontology_name
-        self.add_unique_association_field('phenotype', ontology_name)
+        self.disease_id = trait.ontology_name
+        self.add_unique_association_field('phenotype', trait.ontology_name)
 
-        if clinvar_name:
-            self.disease_source_name = clinvar_name
+        if trait.clinvar_name:
+            self.disease_source_name = trait.clinvar_name
 
-        if ontology_label:
-            self.disease_name = ontology_label
+        if trait.ontology_label:
+            self.disease_name = trait.ontology_label
 
 
     def add_unique_association_field(self, key, value):
@@ -167,8 +167,7 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
                             clinvar_record.observed_refs_list +
                             clinvar_record.measure_set_refs_list))
 
-        super().__init__(a_dictionary, clinvar_record, trait.ontology_id, ref_list,
-                         ensembl_gene_id, report, trait.clinvar_name, trait.ontology_label)
+        super().__init__(a_dictionary, clinvar_record, ref_list, ensembl_gene_id, report, trait)
 
         self.add_unique_association_field('alleleOrigin', 'germline')
         if clinvar_record.rs:
@@ -316,8 +315,7 @@ class CTTVSomaticEvidenceString(CTTVEvidenceString):
                             clinvar_record.observed_refs_list +
                             clinvar_record.measure_set_refs_list))
 
-        super().__init__(a_dictionary, clinvar_record, trait.ontology_id, ref_list,
-                         ensembl_gene_id, report, trait.clinvar_name, trait.ontology_label)
+        super().__init__(a_dictionary, clinvar_record, ref_list, ensembl_gene_id, report, trait)
 
         self.add_unique_association_field('alleleOrigin', 'somatic')
 

--- a/eva_cttv_pipeline/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_strings.py
@@ -87,10 +87,10 @@ class CTTVEvidenceString(dict):
         self.add_unique_association_field('phenotype', ontology_name)
 
         if clinvar_name:
-            self.disease_source_name = [clinvar_name]
+            self.disease_source_name = clinvar_name
 
         if ontology_label:
-            self.disease_name = [ontology_label]
+            self.disease_name = ontology_label
 
 
     def add_unique_association_field(self, key, value):

--- a/eva_cttv_pipeline/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_strings.py
@@ -156,7 +156,7 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
                             clinvar_record.observed_refs_list +
                             clinvar_record.measure_set_refs_list))
 
-        super().__init__(a_dictionary, clinvar_record, trait.ontology_name, ref_list,
+        super().__init__(a_dictionary, clinvar_record, trait.ontology_id, ref_list,
                          ensembl_gene_id, report, trait.clinvar_name)
 
         self.add_unique_association_field('alleleOrigin', 'germline')
@@ -305,7 +305,7 @@ class CTTVSomaticEvidenceString(CTTVEvidenceString):
                             clinvar_record.observed_refs_list +
                             clinvar_record.measure_set_refs_list))
 
-        super().__init__(a_dictionary, clinvar_record, trait.ontology_name, ref_list,
+        super().__init__(a_dictionary, clinvar_record, trait.ontology_id, ref_list,
                          ensembl_gene_id, report, trait.clinvar_name)
 
         self.add_unique_association_field('alleleOrigin', 'somatic')

--- a/eva_cttv_pipeline/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_strings.py
@@ -156,8 +156,8 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
                             clinvar_record.observed_refs_list +
                             clinvar_record.measure_set_refs_list))
 
-        super().__init__(a_dictionary, clinvar_record,
-                         trait.ontology_name, ref_list, ensembl_gene_id, report. trait.clinvar_name)
+        super().__init__(a_dictionary, clinvar_record, trait.ontology_name, ref_list,
+                         ensembl_gene_id, report, trait.clinvar_name)
 
         self.add_unique_association_field('alleleOrigin', 'germline')
         if clinvar_record.rs:

--- a/eva_cttv_pipeline/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_strings.py
@@ -61,7 +61,7 @@ class CTTVEvidenceString(dict):
     """
 
     def __init__(self, a_dictionary, clinvar_record=None, ontology_name=None, ref_list=None,
-                 ensembl_gene_id=None, report=None, clinvar_name=None):
+                 ensembl_gene_id=None, report=None, clinvar_name=None, ontology_label=None):
         super().__init__(a_dictionary)
         # dict.__init__(a_dictionary)
 
@@ -89,6 +89,10 @@ class CTTVEvidenceString(dict):
         if clinvar_name:
             self.disease_source_name = clinvar_name
 
+        if ontology_label:
+            self.disease_name = ontology_label
+
+
     def add_unique_association_field(self, key, value):
         self['unique_association_fields'][key] = value
 
@@ -98,6 +102,14 @@ class CTTVEvidenceString(dict):
     def set_target(self, target_id, activity):
         self['target']['id'].append(target_id)
         self['target']['activity'] = activity
+
+    @property
+    def disease_name(self):
+        return efo_term.EFOTerm(self['disease']['name'][0])
+
+    @disease_name.setter
+    def disease_name(self, value):
+        self['disease']['name'] = [value]
 
     @property
     def disease_source_name(self):
@@ -157,7 +169,7 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
                             clinvar_record.measure_set_refs_list))
 
         super().__init__(a_dictionary, clinvar_record, trait.ontology_id, ref_list,
-                         ensembl_gene_id, report, trait.clinvar_name)
+                         ensembl_gene_id, report, trait.clinvar_name, trait.ontology_label)
 
         self.add_unique_association_field('alleleOrigin', 'germline')
         if clinvar_record.rs:
@@ -306,7 +318,7 @@ class CTTVSomaticEvidenceString(CTTVEvidenceString):
                             clinvar_record.measure_set_refs_list))
 
         super().__init__(a_dictionary, clinvar_record, trait.ontology_id, ref_list,
-                         ensembl_gene_id, report, trait.clinvar_name)
+                         ensembl_gene_id, report, trait.clinvar_name, trait.ontology_label)
 
         self.add_unique_association_field('alleleOrigin', 'somatic')
 

--- a/eva_cttv_pipeline/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_strings.py
@@ -82,8 +82,8 @@ class CTTVEvidenceString(dict):
         if ref_list and len(ref_list) > 0:
             self.top_level_literature = ref_list
 
-        self.disease_id = trait.ontology_name
-        self.add_unique_association_field('phenotype', trait.ontology_name)
+        self.disease_id = trait.ontology_id
+        self.add_unique_association_field('phenotype', trait.ontology_id)
 
         if trait.clinvar_name:
             self.disease_source_name = trait.clinvar_name

--- a/eva_cttv_pipeline/trait.py
+++ b/eva_cttv_pipeline/trait.py
@@ -1,22 +1,22 @@
 def map_efo(trait_2_efo_dict, name_list):
     trait_string = name_list[0].lower()
     if trait_string in trait_2_efo_dict:
-        for efo_trait in trait_2_efo_dict[trait_string]:
-            # First element in trait_list mus always be the "Preferred" trait name
-            return trait_string, efo_trait
+        ontology_id = trait_2_efo_dict[trait_string][0]
+        ontology_label = trait_2_efo_dict[trait_string][1]
+        return trait_string, ontology_id, ontology_label
     else:
         for trait in name_list[1:]:
             trait_string = trait.lower()
             if trait_string in trait_2_efo_dict:
-                for efo_trait in trait_2_efo_dict[trait_string]:
-                    # First element in trait_list mus always be the "Preferred" trait name
-                    return trait_string, efo_trait
+                ontology_id = trait_2_efo_dict[trait_string][0]
+                ontology_label = trait_2_efo_dict[trait_string][1]
+                return trait_string, ontology_id, ontology_label
 
-    return None, None
+    return None, None, None
 
 
 class Trait:
     def __init__(self, clinvar_trait_name_list, trait_counter, trait_2_efo_dict):
         self.trait_counter = trait_counter  # number of trait for record
-        self.clinvar_name, self.ontology_id = map_efo(trait_2_efo_dict,
-                                                      clinvar_trait_name_list)
+        self.clinvar_name, self.ontology_id, self.ontology_label = map_efo(trait_2_efo_dict,
+                                                                           clinvar_trait_name_list)

--- a/eva_cttv_pipeline/trait.py
+++ b/eva_cttv_pipeline/trait.py
@@ -20,9 +20,11 @@ def map_efo(trait_2_efo_dict, name_list):
         ontology_label = trait_2_efo_dict[trait_string][1]
         return trait_string, ontology_id, ontology_label
     else:
-        for trait in name_list[1:]:  # Otherwise cycle through the list, the first name that is in
-            trait_string = trait.lower()  # the dict is returned along with the ontology id and
-            if trait_string in trait_2_efo_dict:  # label from the dict
+        # Otherwise cycle through the list, the first name that is in the dict
+        # is returned along with the ontology id and label from the dict
+        for trait in name_list[1:]:
+            trait_string = trait.lower()
+            if trait_string in trait_2_efo_dict:
                 ontology_id = trait_2_efo_dict[trait_string][0]
                 ontology_label = trait_2_efo_dict[trait_string][1]
                 return trait_string, ontology_id, ontology_label

--- a/eva_cttv_pipeline/trait.py
+++ b/eva_cttv_pipeline/trait.py
@@ -1,18 +1,33 @@
 def map_efo(trait_2_efo_dict, name_list):
-    trait_string = name_list[0].lower()
+    """
+    Function accepts a dict with mappings from clinvar trait names to tuples containing ontology
+    ids and labels, and a list with clinvar trait names for one trait. Returns the clinvar trait
+    name (in lowercase) that is earliest in the list and has a mapping in the dict, along with the
+    ontology id and label.
+
+    :param trait_2_efo_dict: dict with clinvar trait names as keys, and tuples as values. The first
+    element of each tuple is an ontology id (uri), the second element is the ontology label for
+    that id.
+    :param name_list: List of clinvar trait names for the trait, with the preferred trait name (if
+    one exists) in the first element.
+    :return: The clinvar name, ontology id, and ontology label, for the clinvar name in the
+    name_list with the lowest element that is in the trait_2_efo_dict. If none of the names in the
+    name_list are keys in the trait_2_efo_dict then None is returned in each position.
+    """
+    trait_string = name_list[0].lower()  # Try first element, which should be preferred name if it exists
     if trait_string in trait_2_efo_dict:
         ontology_id = trait_2_efo_dict[trait_string][0]
         ontology_label = trait_2_efo_dict[trait_string][1]
         return trait_string, ontology_id, ontology_label
     else:
-        for trait in name_list[1:]:
-            trait_string = trait.lower()
-            if trait_string in trait_2_efo_dict:
+        for trait in name_list[1:]:  # Otherwise cycle through the list, the first name that is in
+            trait_string = trait.lower()  # the dict is returned along with the ontology id and
+            if trait_string in trait_2_efo_dict:  # label from the dict
                 ontology_id = trait_2_efo_dict[trait_string][0]
                 ontology_label = trait_2_efo_dict[trait_string][1]
                 return trait_string, ontology_id, ontology_label
 
-    return None, None, None
+    return None, None, None  # If none of the names in the list are keys in the dict then None is returned
 
 
 class Trait:

--- a/eva_cttv_pipeline/trait.py
+++ b/eva_cttv_pipeline/trait.py
@@ -18,5 +18,5 @@ def map_efo(trait_2_efo_dict, name_list):
 class Trait:
     def __init__(self, clinvar_trait_name_list, trait_counter, trait_2_efo_dict):
         self.trait_counter = trait_counter  # number of trait for record
-        self.clinvar_name, self.ontology_name = map_efo(trait_2_efo_dict,
-                                                        clinvar_trait_name_list)
+        self.clinvar_name, self.ontology_id = map_efo(trait_2_efo_dict,
+                                                      clinvar_trait_name_list)

--- a/eva_cttv_pipeline/trait.py
+++ b/eva_cttv_pipeline/trait.py
@@ -1,0 +1,22 @@
+def map_efo(trait_2_efo_dict, name_list):
+    trait_string = name_list[0].lower()
+    if trait_string in trait_2_efo_dict:
+        for efo_trait in trait_2_efo_dict[trait_string]:
+            # First element in trait_list mus always be the "Preferred" trait name
+            return trait_string, efo_trait
+    else:
+        for trait in name_list[1:]:
+            trait_string = trait.lower()
+            if trait_string in trait_2_efo_dict:
+                for efo_trait in trait_2_efo_dict[trait_string]:
+                    # First element in trait_list mus always be the "Preferred" trait name
+                    return trait_string, efo_trait
+
+    return None, None
+
+
+class Trait:
+    def __init__(self, clinvar_trait_name_list, trait_counter, trait_2_efo_dict):
+        self.trait_counter = trait_counter  # number of trait for record
+        self.clinvar_name, self.ontology_name = map_efo(trait_2_efo_dict,
+                                                        clinvar_trait_name_list)

--- a/tests/resources/feb16_jul16_combined_trait_to_url.tsv
+++ b/tests/resources/feb16_jul16_combined_trait_to_url.tsv
@@ -1,34 +1,34 @@
 RENAL-HEPATIC-PANCREATIC DYSPLASIA 2	http://www.orpha.net/ORDO/Orphanet_294415
-MIYOSHI MUSCULAR DYSTROPHY 1	http://www.orpha.net/ORDO/Orphanet_45448	http://www.orpha.net/ORDO/Orphanet_263
+MIYOSHI MUSCULAR DYSTROPHY 1	http://www.orpha.net/ORDO/Orphanet_45448
 BRITTLE CORNEA SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_90354
-FRONTOTEMPORAL DEMENTIA	http://purl.obolibrary.org/obo/HP_0000733	http://purl.obolibrary.org/obo/HP_0002120	http://www.orpha.net/ORDO/Orphanet_282	http://purl.obolibrary.org/obo/HP_0002310	http://purl.obolibrary.org/obo/HP_0002529	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0000734	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0002371	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0000743	http://purl.obolibrary.org/obo/HP_0000711	http://purl.obolibrary.org/obo/HP_0000710	http://purl.obolibrary.org/obo/HP_0000020	http://purl.obolibrary.org/obo/HP_0000757	http://purl.obolibrary.org/obo/HP_0000751	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002442	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000741	http://purl.obolibrary.org/obo/HP_0002300	http://purl.obolibrary.org/obo/HP_0002145	http://purl.obolibrary.org/obo/HP_0001336	http://www.orpha.net/ORDO/Orphanet_683	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0002446	http://purl.obolibrary.org/obo/HP_0002354	http://purl.obolibrary.org/obo/HP_0000718
-MYCOBACTERIAL AND VIRAL INFECTIONS	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0011274	http://purl.obolibrary.org/obo/HP_0012302
+FRONTOTEMPORAL DEMENTIA	http://purl.obolibrary.org/obo/HP_0000733
+MYCOBACTERIAL AND VIRAL INFECTIONS	http://purl.obolibrary.org/obo/HP_0000007
 Craniosynostosis 3	http://www.orpha.net/ORDO/Orphanet_1531
 Progressive myoclonus epilepsy with ataxia	http://www.orpha.net/ORDO/Orphanet_98261
 ANDROGEN INSENSITIVITY	http://www.ebi.ac.uk/efo/EFO_0000305
 Achondrogenesis type 2	http://www.orpha.net/ORDO/Orphanet_93296
-GRISCELLI SYNDROME	http://purl.obolibrary.org/obo/HP_0002216	http://purl.obolibrary.org/obo/HP_0002227	http://purl.obolibrary.org/obo/HP_0004527	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0003119	http://purl.obolibrary.org/obo/HP_0001287	http://purl.obolibrary.org/obo/HP_0002718	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0001010	http://purl.obolibrary.org/obo/HP_0003819	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002218	http://purl.obolibrary.org/obo/HP_0002716	http://purl.obolibrary.org/obo/HP_0001107	http://purl.obolibrary.org/obo/HP_0001053	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001933	http://purl.obolibrary.org/obo/HP_0001874	http://purl.obolibrary.org/obo/HP_0002113	http://purl.obolibrary.org/obo/HP_0001008	http://purl.obolibrary.org/obo/HP_0002220	http://purl.obolibrary.org/obo/HP_0007513	http://purl.obolibrary.org/obo/HP_0005599	http://purl.obolibrary.org/obo/HP_0004370	http://purl.obolibrary.org/obo/HP_0002972	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002017	http://purl.obolibrary.org/obo/HP_0001317	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0002344	http://purl.obolibrary.org/obo/HP_0001425	http://purl.obolibrary.org/obo/HP_0005528
+GRISCELLI SYNDROME	http://purl.obolibrary.org/obo/HP_0002216
 Anhidrotic ectodermal dysplasia with immune deficiency	http://www.orpha.net/ORDO/Orphanet_238468
 Atypical hemolytic-uremic syndrome 5	http://www.orpha.net/ORDO/Orphanet_2134
 Spondyloenchondrodysplasia with immune dysregulation	http://www.orpha.net/ORDO/Orphanet_1855
 CHONDRODYSPLASIA	http://www.orpha.net/ORDO/Orphanet_50945
-GLYCOGEN STORAGE DISEASE II	http://www.orpha.net/ORDO/Orphanet_365	http://www.orpha.net/ORDO/Orphanet_79201
-BETHLEM MYOPATHY	http://www.orpha.net/ORDO/Orphanet_610	http://www.orpha.net/ORDO/Orphanet_97242
+GLYCOGEN STORAGE DISEASE II	http://www.orpha.net/ORDO/Orphanet_365
+BETHLEM MYOPATHY	http://www.orpha.net/ORDO/Orphanet_610
 AGAMMAGLOBULINEMIA 2	http://www.orpha.net/ORDO/Orphanet_33110
-6-Pyruvoyltetrahydropterin Synthase Deficiency	http://purl.obolibrary.org/obo/HP_0006887	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0001954	http://purl.obolibrary.org/obo/HP_0001266	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0000737	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001300	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001262	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002067	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002033	http://purl.obolibrary.org/obo/HP_0002344	http://purl.obolibrary.org/obo/HP_0004923
-INSULIN-LIKE GROWTH FACTOR I DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0009466	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000752	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0004325	http://purl.obolibrary.org/obo/HP_0000736	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0030084
+6-Pyruvoyltetrahydropterin Synthase Deficiency	http://purl.obolibrary.org/obo/HP_0006887
+INSULIN-LIKE GROWTH FACTOR I DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001270
 Selective tooth agenesis 1	http://www.orpha.net/ORDO/Orphanet_99798
 Peroxisome biogenesis disorder 5A	http://www.orpha.net/ORDO/Orphanet_79189
-Neurofibromatosis-Noonan syndrome	http://www.orpha.net/ORDO/Orphanet_638	http://www.orpha.net/ORDO/Orphanet_636
+Neurofibromatosis-Noonan syndrome	http://www.orpha.net/ORDO/Orphanet_638
 Congenital disorder of glycosylation type 2J	http://www.orpha.net/ORDO/Orphanet_137
 Interstitial lung disease	http://www.ebi.ac.uk/efo/EFO_0004244
-RETINITIS PIGMENTOSA 74	http://www.orpha.net/ORDO/Orphanet_110	http://www.orpha.net/ORDO/Orphanet_791
-CRANIOFACIAL ANOMALIES AND ANTERIOR SEGMENT DYSGENESIS SYNDROME	http://purl.obolibrary.org/obo/HP_0000512	http://purl.obolibrary.org/obo/HP_0007035	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0000356	http://purl.obolibrary.org/obo/HP_0007291	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0011488	http://purl.obolibrary.org/obo/HP_0000316
-PHENYLKETONURIA	http://www.orpha.net/ORDO/Orphanet_716	http://www.orpha.net/ORDO/Orphanet_2209
-Familial hypertrophic cardiomyopathy 24	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
-GLYCOGEN STORAGE DISEASE XI	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0003109	http://purl.obolibrary.org/obo/HP_0003542	http://purl.obolibrary.org/obo/HP_0012468	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0003155	http://purl.obolibrary.org/obo/HP_0002148	http://purl.obolibrary.org/obo/HP_0000124	http://purl.obolibrary.org/obo/HP_0002749	http://purl.obolibrary.org/obo/HP_0002900	http://purl.obolibrary.org/obo/HP_0004915	http://purl.obolibrary.org/obo/HP_0003552	http://purl.obolibrary.org/obo/HP_0003546	http://purl.obolibrary.org/obo/HP_0003537	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003270	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0002913	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0003201	http://purl.obolibrary.org/obo/HP_0002024	http://purl.obolibrary.org/obo/HP_0004396	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0003326	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001002	http://purl.obolibrary.org/obo/HP_0003394	http://purl.obolibrary.org/obo/HP_0002909	http://purl.obolibrary.org/obo/HP_0003076
-TYROSINEMIA	http://purl.obolibrary.org/obo/HP_0004348	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0006949	http://purl.obolibrary.org/obo/HP_0001402	http://purl.obolibrary.org/obo/HP_0004510	http://purl.obolibrary.org/obo/HP_0001994	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0001394	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0006254	http://purl.obolibrary.org/obo/HP_0002590	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0003235	http://purl.obolibrary.org/obo/HP_0006554	http://purl.obolibrary.org/obo/HP_0001743	http://purl.obolibrary.org/obo/HP_0001892	http://purl.obolibrary.org/obo/HP_0001541	http://purl.obolibrary.org/obo/HP_0003231	http://purl.obolibrary.org/obo/HP_0002239	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0001943	http://purl.obolibrary.org/obo/HP_0000121	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0003355	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0004298	http://purl.obolibrary.org/obo/HP_0000105	http://purl.obolibrary.org/obo/HP_0000096	http://purl.obolibrary.org/obo/HP_0003768	http://purl.obolibrary.org/obo/HP_0004912	http://purl.obolibrary.org/obo/HP_0003163
-Polyarteritis nodosa	http://purl.obolibrary.org/obo/HP_0001369	http://purl.obolibrary.org/obo/HP_0001974	http://purl.obolibrary.org/obo/HP_0001697	http://purl.obolibrary.org/obo/HP_0100762	http://purl.obolibrary.org/obo/HP_0003401	http://purl.obolibrary.org/obo/HP_0000708	http://purl.obolibrary.org/obo/HP_0002754	http://purl.obolibrary.org/obo/HP_0001677	http://purl.obolibrary.org/obo/HP_0001063	http://purl.obolibrary.org/obo/HP_0002383	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0100533	http://purl.obolibrary.org/obo/HP_0002027	http://purl.obolibrary.org/obo/HP_0008046	http://purl.obolibrary.org/obo/HP_0002099	http://purl.obolibrary.org/obo/HP_0003326	http://purl.obolibrary.org/obo/HP_0001933	http://purl.obolibrary.org/obo/HP_0200042	http://purl.obolibrary.org/obo/HP_0007256	http://purl.obolibrary.org/obo/HP_0000112	http://purl.obolibrary.org/obo/HP_0100796	http://purl.obolibrary.org/obo/HP_0001271	http://purl.obolibrary.org/obo/HP_0001824	http://purl.obolibrary.org/obo/HP_0001541	http://purl.obolibrary.org/obo/HP_0002239	http://purl.obolibrary.org/obo/HP_0100735	http://purl.obolibrary.org/obo/HP_0004370	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0004420	http://purl.obolibrary.org/obo/HP_0002960	http://purl.obolibrary.org/obo/HP_0000988	http://purl.obolibrary.org/obo/HP_0011675	http://purl.obolibrary.org/obo/HP_0100614	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001025	http://purl.obolibrary.org/obo/HP_0002633	http://purl.obolibrary.org/obo/HP_0004374	http://purl.obolibrary.org/obo/HP_0002829	http://purl.obolibrary.org/obo/HP_0001733	http://purl.obolibrary.org/obo/HP_0000541	http://purl.obolibrary.org/obo/HP_0002617	http://purl.obolibrary.org/obo/HP_0010741	http://purl.obolibrary.org/obo/HP_0005244	http://purl.obolibrary.org/obo/HP_0002071	http://purl.obolibrary.org/obo/HP_0002797	http://purl.obolibrary.org/obo/HP_0002024	http://purl.obolibrary.org/obo/HP_0000071	http://purl.obolibrary.org/obo/HP_0000965	http://purl.obolibrary.org/obo/HP_0100758
+RETINITIS PIGMENTOSA 74	http://www.orpha.net/ORDO/Orphanet_110
+CRANIOFACIAL ANOMALIES AND ANTERIOR SEGMENT DYSGENESIS SYNDROME	http://purl.obolibrary.org/obo/HP_0000512
+PHENYLKETONURIA	http://www.orpha.net/ORDO/Orphanet_716
+Familial hypertrophic cardiomyopathy 24	http://www.ebi.ac.uk/efo/EFO_0000318
+GLYCOGEN STORAGE DISEASE XI	http://purl.obolibrary.org/obo/HP_0002151
+TYROSINEMIA	http://purl.obolibrary.org/obo/HP_0004348
+Polyarteritis nodosa	http://purl.obolibrary.org/obo/HP_0001369
 Adenine phosphoribosyltransferase deficiency	http://www.orpha.net/ORDO/Orphanet_976
 Breast cancer	http://www.ebi.ac.uk/efo/EFO_0000305
 CHONDRODYSPLASIA PUNCTATA 2 X-LINKED DOMINANT	http://www.orpha.net/ORDO/Orphanet_93442
@@ -38,52 +38,52 @@ Oculocutaneous albinism type 4	http://www.orpha.net/ORDO/Orphanet_79435
 Hyperparathyroidism	http://purl.obolibrary.org/obo/HP_0000843
 Hemosiderosis	http://www.orpha.net/ORDO/Orphanet_48818
 Deficiency of beta-ureidopropionase	http://www.orpha.net/ORDO/Orphanet_65287
-Hypogonadotropic hypogonadism 14 with or without anosmia	http://www.orpha.net/ORDO/Orphanet_478	http://www.orpha.net/ORDO/Orphanet_432
+Hypogonadotropic hypogonadism 14 with or without anosmia	http://www.orpha.net/ORDO/Orphanet_478
 Granulosa cell tumor of the ovary	http://www.ebi.ac.uk/efo/EFO_0006461
-HYPOTHYROIDISM	http://purl.obolibrary.org/obo/HP_0006887	http://purl.obolibrary.org/obo/HP_0001903	http://www.orpha.net/ORDO/Orphanet_90673	http://purl.obolibrary.org/obo/HP_0000958	http://purl.obolibrary.org/obo/HP_0001539	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0000158	http://purl.obolibrary.org/obo/HP_0005990	http://purl.obolibrary.org/obo/HP_0004482	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0100028	http://purl.obolibrary.org/obo/HP_0002329	http://www.ebi.ac.uk/efo/EFO_0004705	http://purl.obolibrary.org/obo/HP_0000851	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0010864	http://purl.obolibrary.org/obo/HP_0012559	http://purl.obolibrary.org/obo/HP_0000684	http://purl.obolibrary.org/obo/HP_0002930	http://purl.obolibrary.org/obo/HP_0000821	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0001374
+HYPOTHYROIDISM	http://purl.obolibrary.org/obo/HP_0006887
 Herpes simplex encephalitis 2	http://www.orpha.net/ORDO/Orphanet_1930
 ATRIAL SEPTAL DEFECT 5	http://www.ebi.ac.uk/efo/EFO_1000825
-Leukodystrophy	http://purl.obolibrary.org/obo/HP_0007371	http://purl.obolibrary.org/obo/HP_0005876	http://purl.obolibrary.org/obo/HP_0002804	http://purl.obolibrary.org/obo/HP_0008936	http://www.orpha.net/ORDO/Orphanet_68356	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003269	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002415	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0007256	http://purl.obolibrary.org/obo/HP_0002283	http://purl.obolibrary.org/obo/HP_0006918	http://purl.obolibrary.org/obo/HP_0001622	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0002313	http://purl.obolibrary.org/obo/HP_0002751	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002587	http://purl.obolibrary.org/obo/HP_0001522	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0000280
+Leukodystrophy	http://purl.obolibrary.org/obo/HP_0007371
 Winchester syndrome	http://www.orpha.net/ORDO/Orphanet_3460
 Malignant melanoma	http://www.ebi.ac.uk/efo/EFO_0000756
 LONG QT SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_768
 Opsismodysplasia	http://www.orpha.net/ORDO/Orphanet_2746
 SMITH-MCCORT DYSPLASIA 2	http://www.orpha.net/ORDO/Orphanet_178355
 Carney triad	http://www.orpha.net/ORDO/Orphanet_139411
-Familial hypertrophic cardiomyopathy 15	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
-Cataract	http://purl.obolibrary.org/obo/HP_0010693	http://purl.obolibrary.org/obo/HP_0010920	http://purl.obolibrary.org/obo/HP_0003076	http://purl.obolibrary.org/obo/HP_0001134	http://purl.obolibrary.org/obo/HP_0000646	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0007834	http://purl.obolibrary.org/obo/HP_0000612	http://purl.obolibrary.org/obo/HP_0001167	http://purl.obolibrary.org/obo/HP_0007657	http://purl.obolibrary.org/obo/HP_0000501	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0007971	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0008031	http://www.ebi.ac.uk/efo/EFO_0001059	http://purl.obolibrary.org/obo/HP_0000519	http://purl.obolibrary.org/obo/HP_0000568	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0100018
-MITOCHONDRIAL COMPLEX I DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_123512	http://www.orpha.net/ORDO/Orphanet_289527	http://www.orpha.net/ORDO/Orphanet_255210	http://www.orpha.net/ORDO/Orphanet_254905
-PEROXISOME BIOGENESIS DISORDER 11B	http://purl.obolibrary.org/obo/HP_0000572	http://purl.obolibrary.org/obo/HP_0000364	http://purl.obolibrary.org/obo/HP_0011398	http://purl.obolibrary.org/obo/HP_0011947	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0011968
+Familial hypertrophic cardiomyopathy 15	http://www.ebi.ac.uk/efo/EFO_0000407
+Cataract	http://purl.obolibrary.org/obo/HP_0010693
+MITOCHONDRIAL COMPLEX I DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_123512
+PEROXISOME BIOGENESIS DISORDER 11B	http://purl.obolibrary.org/obo/HP_0000572
 FACTOR V HONG KONG	http://www.orpha.net/ORDO/Orphanet_410090
 Sinus node disease	http://www.orpha.net/ORDO/Orphanet_166282
-MUSCLE HYPERTROPHY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003712
+MUSCLE HYPERTROPHY	http://purl.obolibrary.org/obo/HP_0000007
 MENTAL RETARDATION AUTOSOMAL DOMINANT 1	http://www.ebi.ac.uk/efo/EFO_0003847
 Infertility associated with multi-tailed spermatozoa and excessive DNA	http://www.orpha.net/ORDO/Orphanet_137893
 Roberts-SC phocomelia syndrome	http://www.orpha.net/ORDO/Orphanet_3103
 Postaxial polydactyly type A6	http://purl.obolibrary.org/obo/HP_0100259
-Chronic kidney disease	http://www.ebi.ac.uk/efo/EFO_0004518	http://www.ebi.ac.uk/efo/EFO_0003884	http://www.ebi.ac.uk/efo/EFO_0004617
-Metaphyseal chondrodysplasia	http://www.orpha.net/ORDO/Orphanet_175	http://www.orpha.net/ORDO/Orphanet_33067	http://www.orpha.net/ORDO/Orphanet_2501
-NEUTRAL LIPID STORAGE DISEASE WITH MYOPATHY	http://purl.obolibrary.org/obo/HP_0000467	http://purl.obolibrary.org/obo/HP_0002355	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0009058	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0003546	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001638	http://purl.obolibrary.org/obo/HP_0002155	http://purl.obolibrary.org/obo/HP_0002380	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003326	http://purl.obolibrary.org/obo/HP_0003198	http://purl.obolibrary.org/obo/HP_0003388	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003701	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0000819	http://purl.obolibrary.org/obo/HP_0003391	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0009046	http://purl.obolibrary.org/obo/HP_0001397
+Chronic kidney disease	http://www.ebi.ac.uk/efo/EFO_0004518
+Metaphyseal chondrodysplasia	http://www.orpha.net/ORDO/Orphanet_175
+NEUTRAL LIPID STORAGE DISEASE WITH MYOPATHY	http://purl.obolibrary.org/obo/HP_0000467
 GALLBLADDER DISEASE 4	http://www.ebi.ac.uk/efo/EFO_0003832
-Short-rib thoracic dysplasia 3 with or without polydactyly	http://purl.obolibrary.org/obo/HP_0005054	http://purl.obolibrary.org/obo/HP_0000110	http://purl.obolibrary.org/obo/HP_0002980	http://purl.obolibrary.org/obo/HP_0003022	http://purl.obolibrary.org/obo/HP_0000204	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002023	http://purl.obolibrary.org/obo/HP_0010984	http://purl.obolibrary.org/obo/HP_0003038	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000895	http://purl.obolibrary.org/obo/HP_0100259	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0000773	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000062	http://purl.obolibrary.org/obo/HP_0003016	http://purl.obolibrary.org/obo/HP_0002350	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0010579	http://purl.obolibrary.org/obo/HP_0000113	http://purl.obolibrary.org/obo/HP_0002566	http://purl.obolibrary.org/obo/HP_0001274	http://purl.obolibrary.org/obo/HP_0005257	http://purl.obolibrary.org/obo/HP_0100258	http://purl.obolibrary.org/obo/HP_0000105	http://purl.obolibrary.org/obo/HP_0010297	http://purl.obolibrary.org/obo/HP_0000888	http://purl.obolibrary.org/obo/HP_0009556	http://purl.obolibrary.org/obo/HP_0010454
-Chromosome 2q32-q33 deletion syndrome	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000348	http://purl.obolibrary.org/obo/HP_0000276	http://purl.obolibrary.org/obo/HP_0001841	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0009804	http://purl.obolibrary.org/obo/HP_0000698	http://purl.obolibrary.org/obo/HP_0000678	http://purl.obolibrary.org/obo/HP_0006482	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0001382	http://purl.obolibrary.org/obo/HP_0001883	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0002136	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0000444	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0002648	http://purl.obolibrary.org/obo/HP_0000677	http://purl.obolibrary.org/obo/HP_0000752	http://purl.obolibrary.org/obo/HP_0000414	http://purl.obolibrary.org/obo/HP_0008070	http://purl.obolibrary.org/obo/HP_0000717	http://purl.obolibrary.org/obo/HP_0000718	http://purl.obolibrary.org/obo/HP_0009602	http://purl.obolibrary.org/obo/HP_0003189	http://purl.obolibrary.org/obo/HP_0040082	http://purl.obolibrary.org/obo/HP_0012385	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0002213	http://purl.obolibrary.org/obo/HP_0001166	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000035	http://purl.obolibrary.org/obo/HP_0007018	http://purl.obolibrary.org/obo/HP_0000963	http://purl.obolibrary.org/obo/HP_0001608	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0002164	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000233	http://purl.obolibrary.org/obo/HP_0100499	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0000319	http://purl.obolibrary.org/obo/HP_0000324	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0000426	http://purl.obolibrary.org/obo/HP_0011362	http://purl.obolibrary.org/obo/HP_0002360	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000023
+Short-rib thoracic dysplasia 3 with or without polydactyly	http://purl.obolibrary.org/obo/HP_0005054
+Chromosome 2q32-q33 deletion syndrome	http://purl.obolibrary.org/obo/HP_0000272
 MANTLE CELL LYMPHOMA	http://www.orpha.net/ORDO/Orphanet_52416
 ANGIOPATHY	http://www.ebi.ac.uk/efo/EFO_0003086
 ALKAPTONURIA	http://www.orpha.net/ORDO/Orphanet_56
-Atrial fibrillation	http://purl.obolibrary.org/obo/HP_0004757	http://www.ebi.ac.uk/efo/EFO_0004269	http://purl.obolibrary.org/obo/HP_0001650	http://purl.obolibrary.org/obo/HP_0004749	http://www.orpha.net/ORDO/Orphanet_334	http://www.ebi.ac.uk/efo/EFO_0000275	http://purl.obolibrary.org/obo/HP_0005110
+Atrial fibrillation	http://purl.obolibrary.org/obo/HP_0004757
 Severe combined immunodeficiency due to ADA deficiency	http://www.orpha.net/ORDO/Orphanet_183660
-HYPERTENSION	http://www.ebi.ac.uk/efo/EFO_0000537	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0005117
+HYPERTENSION	http://www.ebi.ac.uk/efo/EFO_0000537
 BARDET-BIEDL SYNDROME 9	http://www.orpha.net/ORDO/Orphanet_110
-ROBINOW-SORAUF SYNDROME	http://purl.obolibrary.org/obo/HP_0010055	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0010066	http://purl.obolibrary.org/obo/HP_0003189	http://purl.obolibrary.org/obo/HP_0000460	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000586	http://purl.obolibrary.org/obo/HP_0001357	http://purl.obolibrary.org/obo/HP_0000316
+ROBINOW-SORAUF SYNDROME	http://purl.obolibrary.org/obo/HP_0010055
 Malignant tumor of testis	http://www.ebi.ac.uk/efo/EFO_0000616
-Monocyte and dendritic cell deficiency	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000007
+Monocyte and dendritic cell deficiency	http://purl.obolibrary.org/obo/HP_0001508
 Bifunctional peroxisomal enzyme deficiency	http://www.orpha.net/ORDO/Orphanet_300
-Molybdenum cofactor deficiency	http://purl.obolibrary.org/obo/HP_0005268	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002421	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0000817	http://purl.obolibrary.org/obo/HP_0003570	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0002126	http://purl.obolibrary.org/obo/HP_0002069
+Molybdenum cofactor deficiency	http://purl.obolibrary.org/obo/HP_0005268
 SENIOR-LOKEN SYNDROME 7	http://www.orpha.net/ORDO/Orphanet_3156
 SIDERIUS X-LINKED MENTAL RETARDATION SYNDROME	http://www.ebi.ac.uk/efo/EFO_0003847
 Deficiency of 2-methylbutyryl-CoA dehydrogenase	http://www.orpha.net/ORDO/Orphanet_79157
 NEU-LAXOVA SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_2671
-SPLIT-HAND/FOOT MALFORMATION 4	http://purl.obolibrary.org/obo/HP_0009767	http://purl.obolibrary.org/obo/HP_0010173	http://purl.obolibrary.org/obo/HP_0001964	http://purl.obolibrary.org/obo/HP_0001171	http://purl.obolibrary.org/obo/HP_0001159	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0005914	http://purl.obolibrary.org/obo/HP_0100257	http://purl.obolibrary.org/obo/HP_0001199
+SPLIT-HAND/FOOT MALFORMATION 4	http://purl.obolibrary.org/obo/HP_0009767
 Hyperbilirubinemia	http://purl.obolibrary.org/obo/HP_0002904
 Primary ciliary dyskinesia 23	http://www.orpha.net/ORDO/Orphanet_244
 Congenital myasthenic syndrome 1B	http://www.orpha.net/ORDO/Orphanet_590
@@ -97,133 +97,133 @@ SCHIZOPHRENIA 4	http://www.ebi.ac.uk/efo/EFO_0000692
 SIALURIA	http://www.orpha.net/ORDO/Orphanet_3166
 Cerebral ischemia	http://www.ebi.ac.uk/efo/EFO_0003883
 LONG QT SYNDROME 12	http://www.orpha.net/ORDO/Orphanet_768
-HISTIOCYTOSIS-LYMPHADENOPATHY PLUS SYNDROME	http://www.orpha.net/ORDO/Orphanet_168569	http://www.orpha.net/ORDO/Orphanet_158014
-FOCAL SEGMENTAL GLOMERULOSCLEROSIS 4	http://purl.obolibrary.org/obo/HP_0000097	http://purl.obolibrary.org/obo/HP_0003774	http://purl.obolibrary.org/obo/HP_0010982
-MITOCHONDRIAL PHOSPHATE CARRIER DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0012087	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0000961	http://purl.obolibrary.org/obo/HP_0001942	http://purl.obolibrary.org/obo/HP_0002093
+HISTIOCYTOSIS-LYMPHADENOPATHY PLUS SYNDROME	http://www.orpha.net/ORDO/Orphanet_168569
+FOCAL SEGMENTAL GLOMERULOSCLEROSIS 4	http://purl.obolibrary.org/obo/HP_0000097
+MITOCHONDRIAL PHOSPHATE CARRIER DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
 Cataract 3	http://www.ebi.ac.uk/efo/EFO_0001059
 Sjogren-Larsson syndrome	http://www.orpha.net/ORDO/Orphanet_816
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 13	http://purl.obolibrary.org/obo/HP_0100660	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0006829	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0001266	http://purl.obolibrary.org/obo/HP_0001265
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 13	http://purl.obolibrary.org/obo/HP_0100660
 ADENOSINE TRIPHOSPHATE	http://www.ebi.ac.uk/efo/EFO_0005840
 KNOBLOCH SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_1571
-GLOMERULOCYSTIC KIDNEY DISEASE WITH HYPERURICEMIA AND ISOSTHENURIA	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0000091	http://purl.obolibrary.org/obo/HP_0002149	http://purl.obolibrary.org/obo/HP_0100611
+GLOMERULOCYSTIC KIDNEY DISEASE WITH HYPERURICEMIA AND ISOSTHENURIA	http://purl.obolibrary.org/obo/HP_0000006
 Nemaline myopathy	http://www.orpha.net/ORDO/Orphanet_607
-SPASTIC ATAXIA 5	http://purl.obolibrary.org/obo/HP_0007141	http://purl.obolibrary.org/obo/HP_0002123	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0002497	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000657	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0012240	http://purl.obolibrary.org/obo/HP_0002075	http://purl.obolibrary.org/obo/HP_0002313	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002069
-DIAMOND-BLACKFAN ANEMIA 4	http://purl.obolibrary.org/obo/HP_0012133	http://purl.obolibrary.org/obo/HP_0001896	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001972
+SPASTIC ATAXIA 5	http://purl.obolibrary.org/obo/HP_0007141
+DIAMOND-BLACKFAN ANEMIA 4	http://purl.obolibrary.org/obo/HP_0012133
 Congenital disorder of glycosylation type 1w	http://www.orpha.net/ORDO/Orphanet_137
 VENOUS THROMBOEMBOLISM	http://www.ebi.ac.uk/efo/EFO_0004286
-SPINOCEREBELLAR ATAXIA 35	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000315	http://purl.obolibrary.org/obo/HP_0000467	http://purl.obolibrary.org/obo/HP_0002355	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0000473	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0003487
+SPINOCEREBELLAR ATAXIA 35	http://purl.obolibrary.org/obo/HP_0001347
 CAPILLARY MALFORMATION WITHOUT ARTERIOVENOUS MALFORMATION	http://www.orpha.net/ORDO/Orphanet_211247
 MULTIPLE SULFATASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_585
-PLATELET GLYCOPROTEIN IV DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001892	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000818	http://purl.obolibrary.org/obo/HP_0001902	http://purl.obolibrary.org/obo/HP_0003010
-Deficiency of steroid 11-beta-monooxygenase	http://www.orpha.net/ORDO/Orphanet_90795	http://www.orpha.net/ORDO/Orphanet_418
-Spinal muscular atrophy	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0002355	http://purl.obolibrary.org/obo/HP_0002380	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001765	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0008981	http://purl.obolibrary.org/obo/HP_0007269
+PLATELET GLYCOPROTEIN IV DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
+Deficiency of steroid 11-beta-monooxygenase	http://www.orpha.net/ORDO/Orphanet_90795
+Spinal muscular atrophy	http://purl.obolibrary.org/obo/HP_0001284
 RETINITIS PIGMENTOSA 9	http://www.orpha.net/ORDO/Orphanet_791
 Osteogenesis imperfecta type 2	http://www.orpha.net/ORDO/Orphanet_216804
-HYPOTRICHOSIS 6	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003777	http://purl.obolibrary.org/obo/HP_0007502	http://purl.obolibrary.org/obo/HP_0002299	http://purl.obolibrary.org/obo/HP_0000653	http://purl.obolibrary.org/obo/HP_0001006	http://purl.obolibrary.org/obo/HP_0000535	http://purl.obolibrary.org/obo/HP_0000989	http://purl.obolibrary.org/obo/HP_0010783
+HYPOTRICHOSIS 6	http://purl.obolibrary.org/obo/HP_0000007
 Nemaline myopathy 6	http://www.orpha.net/ORDO/Orphanet_607
 Macular dystrophy	http://www.ebi.ac.uk/efo/EFO_0001365
 Myotonic dystrophy type 2	http://www.orpha.net/ORDO/Orphanet_606
 Syndactyly type 9	http://www.orpha.net/ORDO/Orphanet_157801
 Squamous cell carcinoma of the head and neck	http://www.ebi.ac.uk/efo/EFO_0000181
 Amelogenesis imperfecta - hypoplastic autosomal dominant - local	http://www.orpha.net/ORDO/Orphanet_88661
-Metabolic syndrome	http://www.ebi.ac.uk/efo/EFO_0001073	http://www.ebi.ac.uk/efo/EFO_0000195
+Metabolic syndrome	http://www.ebi.ac.uk/efo/EFO_0001073
 Severe congenital neutropenia X-linked	http://www.orpha.net/ORDO/Orphanet_42738
-Thrombocytopenia 5	http://purl.obolibrary.org/obo/HP_0000421	http://purl.obolibrary.org/obo/HP_0001875	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0000967
-Cap myopathy 1	http://www.orpha.net/ORDO/Orphanet_607	http://www.orpha.net/ORDO/Orphanet_171881	http://www.orpha.net/ORDO/Orphanet_2020
-AU-KLINE SYNDROME	http://purl.obolibrary.org/obo/HP_0008551	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0002714	http://purl.obolibrary.org/obo/HP_0000276	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0006610	http://purl.obolibrary.org/obo/HP_0100259	http://purl.obolibrary.org/obo/HP_0000430	http://purl.obolibrary.org/obo/HP_0001845	http://purl.obolibrary.org/obo/HP_0000268	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000637	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001385	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000474	http://purl.obolibrary.org/obo/HP_0005338	http://purl.obolibrary.org/obo/HP_0012811	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0000677	http://purl.obolibrary.org/obo/HP_0000194	http://purl.obolibrary.org/obo/HP_0000960	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0002465	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001363	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0003186
-Charcot-Marie-Tooth disease type 2P	http://www.orpha.net/ORDO/Orphanet_166	http://www.orpha.net/ORDO/Orphanet_300319
-EPISODIC ATAXIA	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0001269	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0002411	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002321	http://purl.obolibrary.org/obo/HP_0002131	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0000622	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0001155	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0003457	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0002301	http://purl.obolibrary.org/obo/HP_0002078	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002064	http://purl.obolibrary.org/obo/HP_0100022	http://purl.obolibrary.org/obo/HP_0000776	http://purl.obolibrary.org/obo/HP_0001350	http://purl.obolibrary.org/obo/HP_0002315
+Thrombocytopenia 5	http://purl.obolibrary.org/obo/HP_0000421
+Cap myopathy 1	http://www.orpha.net/ORDO/Orphanet_607
+AU-KLINE SYNDROME	http://purl.obolibrary.org/obo/HP_0008551
+Charcot-Marie-Tooth disease type 2P	http://www.orpha.net/ORDO/Orphanet_166
+EPISODIC ATAXIA	http://purl.obolibrary.org/obo/HP_0001337
 MCKUSICK-KAUFMAN SYNDROME	http://www.orpha.net/ORDO/Orphanet_2473
 MEGALENCEPHALIC LEUKOENCEPHALOPATHY WITH SUBCORTICAL CYSTS 2B	http://www.orpha.net/ORDO/Orphanet_2478
-Familial medullary thyroid carcinoma	http://www.orpha.net/ORDO/Orphanet_99361	http://www.orpha.net/ORDO/Orphanet_247698
+Familial medullary thyroid carcinoma	http://www.orpha.net/ORDO/Orphanet_99361
 COWDEN SYNDROME	http://www.orpha.net/ORDO/Orphanet_201
-ECTODERMAL DYSPLASIA/SKIN FRAGILITY SYNDROME	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0001597	http://purl.obolibrary.org/obo/HP_0000534	http://purl.obolibrary.org/obo/HP_0000958	http://purl.obolibrary.org/obo/HP_0000968	http://purl.obolibrary.org/obo/HP_0002024	http://purl.obolibrary.org/obo/HP_0001030	http://purl.obolibrary.org/obo/HP_0008066	http://purl.obolibrary.org/obo/HP_0000989	http://purl.obolibrary.org/obo/HP_0002224	http://purl.obolibrary.org/obo/HP_0000982	http://purl.obolibrary.org/obo/HP_0000498	http://purl.obolibrary.org/obo/HP_0200042	http://purl.obolibrary.org/obo/HP_0000221
-DEAFNESS	http://purl.obolibrary.org/obo/HP_0005406	http://purl.obolibrary.org/obo/HP_0000962	http://purl.obolibrary.org/obo/HP_0000653	http://purl.obolibrary.org/obo/HP_0008404	http://purl.obolibrary.org/obo/HP_0001423	http://purl.obolibrary.org/obo/HP_0009591	http://purl.obolibrary.org/obo/HP_0000559	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0007642	http://purl.obolibrary.org/obo/HP_0008529	http://purl.obolibrary.org/obo/HP_0002321	http://www.ebi.ac.uk/efo/EFO_0001063	http://purl.obolibrary.org/obo/HP_0007678	http://purl.obolibrary.org/obo/HP_0011463	http://purl.obolibrary.org/obo/HP_0008615	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0008596	http://purl.obolibrary.org/obo/HP_0006380	http://purl.obolibrary.org/obo/HP_0002164	http://purl.obolibrary.org/obo/HP_0000408	http://purl.obolibrary.org/obo/HP_0000384	http://purl.obolibrary.org/obo/HP_0008568	http://purl.obolibrary.org/obo/HP_0004463	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0010984	http://purl.obolibrary.org/obo/HP_0001128	http://purl.obolibrary.org/obo/HP_0011492	http://purl.obolibrary.org/obo/HP_0000613	http://purl.obolibrary.org/obo/HP_0004458	http://www.orpha.net/ORDO/Orphanet_90636	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0000221	http://purl.obolibrary.org/obo/HP_0000360	http://purl.obolibrary.org/obo/HP_0000966	http://purl.obolibrary.org/obo/HP_0001730	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0000495	http://purl.obolibrary.org/obo/HP_0012804	http://purl.obolibrary.org/obo/HP_0009796	http://purl.obolibrary.org/obo/HP_0005101	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0008625	http://purl.obolibrary.org/obo/HP_0004467	http://purl.obolibrary.org/obo/HP_0002710	http://www.ebi.ac.uk/efo/EFO_0004238	http://purl.obolibrary.org/obo/HP_0000381	http://purl.obolibrary.org/obo/HP_0001097	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0002860	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0011476	http://purl.obolibrary.org/obo/HP_0002745	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0000535	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0011462	http://purl.obolibrary.org/obo/HP_0001751	http://purl.obolibrary.org/obo/HP_0005102	http://purl.obolibrary.org/obo/HP_0002987	http://www.orpha.net/ORDO/Orphanet_90635	http://purl.obolibrary.org/obo/HP_0001756
-PARAGANGLIOMAS 1 WITH SENSORINEURAL HEARING LOSS	http://www.ebi.ac.uk/efo/EFO_0004238	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0000239
-N-terminal acetyltransferase deficiency	http://purl.obolibrary.org/obo/HP_0004755	http://purl.obolibrary.org/obo/HP_0004415	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000270	http://purl.obolibrary.org/obo/HP_0009762	http://purl.obolibrary.org/obo/HP_0000215	http://purl.obolibrary.org/obo/HP_0002213	http://purl.obolibrary.org/obo/HP_0010055	http://purl.obolibrary.org/obo/HP_0001664	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0001582	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0000430	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0002059	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0002000	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0006682	http://purl.obolibrary.org/obo/HP_0005288	http://purl.obolibrary.org/obo/HP_0000535	http://purl.obolibrary.org/obo/HP_0003717	http://purl.obolibrary.org/obo/HP_0004756	http://purl.obolibrary.org/obo/HP_0000308	http://purl.obolibrary.org/obo/HP_0000023	http://purl.obolibrary.org/obo/HP_0001629	http://purl.obolibrary.org/obo/HP_0000400
+ECTODERMAL DYSPLASIA/SKIN FRAGILITY SYNDROME	http://purl.obolibrary.org/obo/HP_0001596
+DEAFNESS	http://purl.obolibrary.org/obo/HP_0005406
+PARAGANGLIOMAS 1 WITH SENSORINEURAL HEARING LOSS	http://www.ebi.ac.uk/efo/EFO_0004238
+N-terminal acetyltransferase deficiency	http://purl.obolibrary.org/obo/HP_0004755
 NOONAN SYNDROME 9	http://www.orpha.net/ORDO/Orphanet_648
 ACTH resistance	http://www.orpha.net/ORDO/Orphanet_361
 NAIL-PATELLA SYNDROME	http://www.orpha.net/ORDO/Orphanet_2614
-Multiple endocrine neoplasia type 2A	http://www.orpha.net/ORDO/Orphanet_99361	http://www.orpha.net/ORDO/Orphanet_247698
+Multiple endocrine neoplasia type 2A	http://www.orpha.net/ORDO/Orphanet_99361
 Pineal hyperplasia AND diabetes mellitus syndrome	http://www.orpha.net/ORDO/Orphanet_769
-Adenocarcinoma	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0000228
-Fanconi anemia	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0009777	http://purl.obolibrary.org/obo/HP_0005528	http://purl.obolibrary.org/obo/HP_0003812	http://www.orpha.net/ORDO/Orphanet_84	http://purl.obolibrary.org/obo/HP_0002032	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0005912
+Adenocarcinoma	http://www.ebi.ac.uk/efo/EFO_0000311
+Fanconi anemia	http://purl.obolibrary.org/obo/HP_0000007
 Spondyloepimetaphyseal dysplasia with joint laxity	http://www.orpha.net/ORDO/Orphanet_93359
 ICHTHYOSIS PREMATURITY SYNDROME	http://www.orpha.net/ORDO/Orphanet_88621
 TRANSFERRIN VARIANT CHI	http://www.orpha.net/ORDO/Orphanet_657
-ICHTHYOSIS BULLOSA OF SIEMENS	http://www.orpha.net/ORDO/Orphanet_289586	http://www.orpha.net/ORDO/Orphanet_455
+ICHTHYOSIS BULLOSA OF SIEMENS	http://www.orpha.net/ORDO/Orphanet_289586
 HYPERPROLACTINEMIA	http://www.ebi.ac.uk/efo/EFO_0007319
-GLYCOGEN STORAGE DISEASE IXb	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0006568	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0009051
-LOEYS-DIETZ SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_144	http://www.orpha.net/ORDO/Orphanet_60030
+GLYCOGEN STORAGE DISEASE IXb	http://purl.obolibrary.org/obo/HP_0002240
+LOEYS-DIETZ SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_144
 CARPENTER SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_65759
 Common variable immunodeficiency 9	http://www.orpha.net/ORDO/Orphanet_1572
 LEFT VENTRICULAR NONCOMPACTION 7	http://www.orpha.net/ORDO/Orphanet_54260
 Chronic progressive multiple sclerosis	http://www.ebi.ac.uk/efo/EFO_0003840
 Primary ciliary dyskinesia	http://www.orpha.net/ORDO/Orphanet_244
 Severe combined immunodeficiency	http://www.orpha.net/ORDO/Orphanet_183660
-SPONDYLOEPIMETAPHYSEAL DYSPLASIA	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0010306	http://www.orpha.net/ORDO/Orphanet_171866	http://www.orpha.net/ORDO/Orphanet_93282	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0008873	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002979	http://purl.obolibrary.org/obo/HP_0005930	http://purl.obolibrary.org/obo/HP_0003026	http://purl.obolibrary.org/obo/HP_0002812	http://purl.obolibrary.org/obo/HP_0001883	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000907	http://purl.obolibrary.org/obo/HP_0002868	http://purl.obolibrary.org/obo/HP_0003300	http://purl.obolibrary.org/obo/HP_0000768	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003320	http://purl.obolibrary.org/obo/HP_0002652	http://www.orpha.net/ORDO/Orphanet_93356	http://purl.obolibrary.org/obo/HP_0003180	http://purl.obolibrary.org/obo/HP_0000926	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0003375	http://purl.obolibrary.org/obo/HP_0002758	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0002823	http://purl.obolibrary.org/obo/HP_0005257	http://purl.obolibrary.org/obo/HP_0002983	http://purl.obolibrary.org/obo/HP_0002651	http://purl.obolibrary.org/obo/HP_0010582	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0008794	http://purl.obolibrary.org/obo/HP_0005054	http://purl.obolibrary.org/obo/HP_0010585	http://purl.obolibrary.org/obo/HP_0000922	http://purl.obolibrary.org/obo/HP_0003272	http://purl.obolibrary.org/obo/HP_0002938	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0006406	http://purl.obolibrary.org/obo/HP_0003025	http://purl.obolibrary.org/obo/HP_0008788	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0001538	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0003016	http://purl.obolibrary.org/obo/HP_0003510	http://purl.obolibrary.org/obo/HP_0000541	http://purl.obolibrary.org/obo/HP_0011860	http://purl.obolibrary.org/obo/HP_0003311	http://purl.obolibrary.org/obo/HP_0002970	http://purl.obolibrary.org/obo/HP_0003173	http://purl.obolibrary.org/obo/HP_0001377	http://purl.obolibrary.org/obo/HP_0003307	http://purl.obolibrary.org/obo/HP_0002515	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0002857	http://purl.obolibrary.org/obo/HP_0000023
-LUNG CANCER	http://www.ebi.ac.uk/efo/EFO_0000707	http://www.ebi.ac.uk/efo/EFO_0000571	http://www.ebi.ac.uk/efo/EFO_0001071
-Colorectal cancer	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0007354	http://www.ebi.ac.uk/efo/EFO_0000232	http://www.ebi.ac.uk/efo/EFO_0005842
-FOLLICLE-STIMULATING HORMONE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000789	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003199	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0000786	http://purl.obolibrary.org/obo/HP_0008734	http://purl.obolibrary.org/obo/HP_0001939
+SPONDYLOEPIMETAPHYSEAL DYSPLASIA	http://purl.obolibrary.org/obo/HP_0000272
+LUNG CANCER	http://www.ebi.ac.uk/efo/EFO_0000707
+Colorectal cancer	http://www.ebi.ac.uk/efo/EFO_0000311
+FOLLICLE-STIMULATING HORMONE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000789
 Long QT syndrome 2/5	http://www.orpha.net/ORDO/Orphanet_768
-Parkinson disease	http://purl.obolibrary.org/obo/HP_0000716	http://purl.obolibrary.org/obo/HP_0002459	http://www.ebi.ac.uk/efo/EFO_0002508	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002172	http://purl.obolibrary.org/obo/HP_0100315	http://purl.obolibrary.org/obo/HP_0002322	http://purl.obolibrary.org/obo/HP_0000298	http://purl.obolibrary.org/obo/HP_0002529	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0001300	http://purl.obolibrary.org/obo/HP_0000738	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0011960	http://purl.obolibrary.org/obo/HP_0000012	http://purl.obolibrary.org/obo/HP_0000751	http://purl.obolibrary.org/obo/HP_0002067	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0003587	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0002360	http://purl.obolibrary.org/obo/HP_0000726	http://purl.obolibrary.org/obo/HP_0007311	http://purl.obolibrary.org/obo/HP_0001621
+Parkinson disease	http://purl.obolibrary.org/obo/HP_0000716
 Stickler syndrome	http://www.orpha.net/ORDO/Orphanet_828
-Hyperproinsulinemia	http://purl.obolibrary.org/obo/HP_0000842	http://purl.obolibrary.org/obo/HP_0003074
+Hyperproinsulinemia	http://purl.obolibrary.org/obo/HP_0000842
 RETINITIS PIGMENTOSA 44	http://www.orpha.net/ORDO/Orphanet_791
-Growth restriction	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000062	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000325	http://purl.obolibrary.org/obo/HP_0000995	http://purl.obolibrary.org/obo/HP_0004482	http://purl.obolibrary.org/obo/HP_0004325
+Growth restriction	http://purl.obolibrary.org/obo/HP_0000028
 Exercise intolerance	http://purl.obolibrary.org/obo/HP_0003546
 EPIDERMOLYSIS BULLOSA SIMPLEX WITH PYLORIC ATRESIA	http://www.orpha.net/ORDO/Orphanet_158684
-AXENFELD-RIEGER SYNDROME	http://www.orpha.net/ORDO/Orphanet_98978	http://www.orpha.net/ORDO/Orphanet_782
-Hutchinson-Gilford syndrome	http://www.orpha.net/ORDO/Orphanet_740	http://www.orpha.net/ORDO/Orphanet_2670
+AXENFELD-RIEGER SYNDROME	http://www.orpha.net/ORDO/Orphanet_98978
+Hutchinson-Gilford syndrome	http://www.orpha.net/ORDO/Orphanet_740
 Cleidocranial dysostosis	http://www.orpha.net/ORDO/Orphanet_1452
 RETINITIS PIGMENTOSA 71	http://www.orpha.net/ORDO/Orphanet_791
-Autoimmune disease	http://purl.obolibrary.org/obo/HP_0001369	http://purl.obolibrary.org/obo/HP_0000164	http://purl.obolibrary.org/obo/HP_0002608	http://purl.obolibrary.org/obo/HP_0000964	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000821	http://purl.obolibrary.org/obo/HP_0006515	http://purl.obolibrary.org/obo/HP_0000823	http://purl.obolibrary.org/obo/HP_0002719	http://purl.obolibrary.org/obo/HP_0002960
+Autoimmune disease	http://purl.obolibrary.org/obo/HP_0001369
 ESOPHAGEAL SQUAMOUS CELL CARCINOMA	http://www.ebi.ac.uk/efo/EFO_0005922
 Hereditary sideroblastic anemia	http://www.ebi.ac.uk/efo/EFO_0004272
-SURFACTANT METABOLISM DYSFUNCTION	http://purl.obolibrary.org/obo/HP_0002789	http://purl.obolibrary.org/obo/HP_0001417	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0005942	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003678	http://purl.obolibrary.org/obo/HP_0005576	http://purl.obolibrary.org/obo/HP_0001217	http://purl.obolibrary.org/obo/HP_0006515	http://purl.obolibrary.org/obo/HP_0002104	http://purl.obolibrary.org/obo/HP_0000961	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0002092	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0002098	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0002094	http://purl.obolibrary.org/obo/HP_0006517	http://purl.obolibrary.org/obo/HP_0006530	http://purl.obolibrary.org/obo/HP_0001425	http://purl.obolibrary.org/obo/HP_0002878	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002091
-SEBASTIAN SYNDROME	http://purl.obolibrary.org/obo/HP_0000421	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0008264	http://purl.obolibrary.org/obo/HP_0001902	http://purl.obolibrary.org/obo/HP_0003010
+SURFACTANT METABOLISM DYSFUNCTION	http://purl.obolibrary.org/obo/HP_0002789
+SEBASTIAN SYNDROME	http://purl.obolibrary.org/obo/HP_0000421
 SECKEL SYNDROME 7	http://www.orpha.net/ORDO/Orphanet_808
 Thyrotropin-releasing hormone resistance	http://www.orpha.net/ORDO/Orphanet_120259
-Sting-associated vasculopathy	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0001945	http://purl.obolibrary.org/obo/HP_0008404	http://purl.obolibrary.org/obo/HP_0001894	http://purl.obolibrary.org/obo/HP_0003565	http://purl.obolibrary.org/obo/HP_0002729	http://purl.obolibrary.org/obo/HP_0002829	http://purl.obolibrary.org/obo/HP_0001387	http://purl.obolibrary.org/obo/HP_0001009	http://purl.obolibrary.org/obo/HP_0010783	http://purl.obolibrary.org/obo/HP_0200039	http://purl.obolibrary.org/obo/HP_0001882	http://purl.obolibrary.org/obo/HP_0010702	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0100614	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0006530	http://purl.obolibrary.org/obo/HP_0000965	http://purl.obolibrary.org/obo/HP_0003326	http://purl.obolibrary.org/obo/HP_0001508
+Sting-associated vasculopathy	http://purl.obolibrary.org/obo/HP_0001903
 MARSHALL SYNDROME	http://www.orpha.net/ORDO/Orphanet_560
-RUIJS-AALFS SYNDROME	http://purl.obolibrary.org/obo/HP_0200021	http://purl.obolibrary.org/obo/HP_0001402	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000426	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0004325	http://purl.obolibrary.org/obo/HP_0000414	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0005659	http://purl.obolibrary.org/obo/HP_0009125	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0007787	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0000325	http://purl.obolibrary.org/obo/HP_0002987	http://purl.obolibrary.org/obo/HP_0002007
-Long QT syndrome	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0004756	http://purl.obolibrary.org/obo/HP_0001657	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002224	http://purl.obolibrary.org/obo/HP_0000982	http://purl.obolibrary.org/obo/HP_0007475	http://purl.obolibrary.org/obo/HP_0009804
+RUIJS-AALFS SYNDROME	http://purl.obolibrary.org/obo/HP_0200021
+Long QT syndrome	http://purl.obolibrary.org/obo/HP_0001635
 KALLMANN SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_478
 Meier-Gorlin syndrome 2	http://www.orpha.net/ORDO/Orphanet_2554
 URIC ACID NEPHROLITHIASIS	http://purl.obolibrary.org/obo/HP_0000791
-Gorlin syndrome	http://www.orpha.net/ORDO/Orphanet_377	http://www.orpha.net/ORDO/Orphanet_2162
-Pseudohyperkalemia Cardiff	http://purl.obolibrary.org/obo/HP_0001878	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0004446	http://purl.obolibrary.org/obo/HP_0001939
-Macrothrombocytopenia and progressive sensorineural deafness	http://purl.obolibrary.org/obo/HP_0000421	http://purl.obolibrary.org/obo/HP_0000132	http://purl.obolibrary.org/obo/HP_0000093	http://purl.obolibrary.org/obo/HP_0000478	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001892	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003774	http://purl.obolibrary.org/obo/HP_0000123	http://purl.obolibrary.org/obo/HP_0008264	http://purl.obolibrary.org/obo/HP_0000790	http://purl.obolibrary.org/obo/HP_0001757	http://purl.obolibrary.org/obo/HP_0000079	http://purl.obolibrary.org/obo/HP_0000408	http://purl.obolibrary.org/obo/HP_0001977	http://purl.obolibrary.org/obo/HP_0001658	http://purl.obolibrary.org/obo/HP_0000519	http://purl.obolibrary.org/obo/HP_0001902	http://purl.obolibrary.org/obo/HP_0003010
+Gorlin syndrome	http://www.orpha.net/ORDO/Orphanet_377
+Pseudohyperkalemia Cardiff	http://purl.obolibrary.org/obo/HP_0001878
+Macrothrombocytopenia and progressive sensorineural deafness	http://purl.obolibrary.org/obo/HP_0000421
 HOMOCYSTINURIA-MEGALOBLASTIC ANEMIA DUE TO DEFECT IN COBALAMIN METABOLISM	http://www.ebi.ac.uk/efo/EFO_0004272
-Andersen Tawil syndrome	http://www.orpha.net/ORDO/Orphanet_206976	http://www.orpha.net/ORDO/Orphanet_367	http://www.orpha.net/ORDO/Orphanet_251274	http://www.orpha.net/ORDO/Orphanet_768
-Asphyxiating thoracic dystrophy 5	http://purl.obolibrary.org/obo/HP_0000093	http://purl.obolibrary.org/obo/HP_0003259	http://purl.obolibrary.org/obo/HP_0003016	http://purl.obolibrary.org/obo/HP_0000293	http://purl.obolibrary.org/obo/HP_0000089	http://purl.obolibrary.org/obo/HP_0003774	http://purl.obolibrary.org/obo/HP_0008905	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0004743	http://purl.obolibrary.org/obo/HP_0100866	http://purl.obolibrary.org/obo/HP_0000774	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0001773	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0006644	http://purl.obolibrary.org/obo/HP_0000023
+Andersen Tawil syndrome	http://www.orpha.net/ORDO/Orphanet_206976
+Asphyxiating thoracic dystrophy 5	http://purl.obolibrary.org/obo/HP_0000093
 GRANULOMATOUS DISEASE CHRONIC AUTOSOMAL RECESSIVE CYTOCHROME b-NEGATIVE	http://www.orpha.net/ORDO/Orphanet_123524
-LIPASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001939
+LIPASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
 Werdnig-Hoffmann disease	http://www.orpha.net/ORDO/Orphanet_83330
 Metabolic disease	http://www.ebi.ac.uk/efo/EFO_0000589
-Noonan-like syndrome with loose anagen hair	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002209	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0001611	http://purl.obolibrary.org/obo/HP_0000752	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0000465	http://purl.obolibrary.org/obo/HP_0000964	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001642	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0001629
-Roussy-Levy syndrome	http://www.orpha.net/ORDO/Orphanet_3115	http://www.orpha.net/ORDO/Orphanet_101082
+Noonan-like syndrome with loose anagen hair	http://purl.obolibrary.org/obo/HP_0001631
+Roussy-Levy syndrome	http://www.orpha.net/ORDO/Orphanet_3115
 SENIOR-LOKEN SYNDROME 8	http://www.orpha.net/ORDO/Orphanet_3156
 Charcot-Marie-Tooth disease type 2F	http://www.orpha.net/ORDO/Orphanet_166
-Childhood hypophosphatasia	http://www.orpha.net/ORDO/Orphanet_247651	http://www.orpha.net/ORDO/Orphanet_247676	http://www.orpha.net/ORDO/Orphanet_247667	http://www.orpha.net/ORDO/Orphanet_247685
+Childhood hypophosphatasia	http://www.orpha.net/ORDO/Orphanet_247651
 PERIPHERAL DEMYELINATING NEUROPATHY	http://www.ebi.ac.uk/efo/EFO_0004149
-Malaria	http://www.ebi.ac.uk/efo/EFO_0001068	http://www.ebi.ac.uk/efo/EFO_0003033
+Malaria	http://www.ebi.ac.uk/efo/EFO_0001068
 C SYNDROME	http://www.orpha.net/ORDO/Orphanet_1308
 Hirschsprung disease 2	http://www.orpha.net/ORDO/Orphanet_388
-Neonatal diabetes mellitus	http://www.orpha.net/ORDO/Orphanet_224	http://www.orpha.net/ORDO/Orphanet_99885
-INCLUSION BODY MYOPATHY WITH EARLY-ONSET PAGET DISEASE AND FRONTOTEMPORAL DEMENTIA	http://www.ebi.ac.uk/efo/EFO_0003862	http://www.ebi.ac.uk/efo/EFO_0000253
-Spondyloepiphyseal dysplasia	http://purl.obolibrary.org/obo/HP_0002751	http://www.orpha.net/ORDO/Orphanet_263482	http://purl.obolibrary.org/obo/HP_0002673	http://purl.obolibrary.org/obo/HP_0002829	http://purl.obolibrary.org/obo/HP_0001387	http://www.orpha.net/ORDO/Orphanet_93283	http://purl.obolibrary.org/obo/HP_0000946	http://purl.obolibrary.org/obo/HP_0000926	http://purl.obolibrary.org/obo/HP_0004568
+Neonatal diabetes mellitus	http://www.orpha.net/ORDO/Orphanet_224
+INCLUSION BODY MYOPATHY WITH EARLY-ONSET PAGET DISEASE AND FRONTOTEMPORAL DEMENTIA	http://www.ebi.ac.uk/efo/EFO_0003862
+Spondyloepiphyseal dysplasia	http://purl.obolibrary.org/obo/HP_0002751
 Goiter	http://www.ebi.ac.uk/efo/EFO_0000616
-DIAMOND-BLACKFAN ANEMIA 3	http://purl.obolibrary.org/obo/HP_0005518	http://purl.obolibrary.org/obo/HP_0001896	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0011904	http://purl.obolibrary.org/obo/HP_0001972
+DIAMOND-BLACKFAN ANEMIA 3	http://purl.obolibrary.org/obo/HP_0005518
 Hereditary motor and sensory neuropathy with optic atrophy	http://www.ebi.ac.uk/efo/EFO_0004149
 Spastic paraplegia	http://purl.obolibrary.org/obo/HP_0001258
 Abnormal glycosylation (CDG IIa)	http://purl.obolibrary.org/obo/HP_0001263
 Anonychia	http://www.orpha.net/ORDO/Orphanet_79143
 CULLER-JONES SYNDROME	http://www.orpha.net/ORDO/Orphanet_2027
-Danon disease	http://www.orpha.net/ORDO/Orphanet_34587	http://www.orpha.net/ORDO/Orphanet_99739
-Familial hypertrophic cardiomyopathy 8	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
-Ventriculomegaly with cystic kidney disease	http://purl.obolibrary.org/obo/HP_0000108	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001622	http://purl.obolibrary.org/obo/HP_0001561	http://purl.obolibrary.org/obo/HP_0001629
-Congenital absence of salivary gland	http://www.orpha.net/ORDO/Orphanet_86815	http://www.orpha.net/ORDO/Orphanet_2363
+Danon disease	http://www.orpha.net/ORDO/Orphanet_34587
+Familial hypertrophic cardiomyopathy 8	http://www.ebi.ac.uk/efo/EFO_0000318
+Ventriculomegaly with cystic kidney disease	http://purl.obolibrary.org/obo/HP_0000108
+Congenital absence of salivary gland	http://www.orpha.net/ORDO/Orphanet_86815
 SERKAL SYNDROME	http://www.orpha.net/ORDO/Orphanet_139466
 X-linked mental retardation with marfanoid habitus syndrome	http://www.orpha.net/ORDO/Orphanet_776
 Tay-sachs disease	http://www.orpha.net/ORDO/Orphanet_845
@@ -232,25 +232,25 @@ Nestor-Guillermo progeria syndrome	http://www.orpha.net/ORDO/Orphanet_280576
 FOCAL SEGMENTAL GLOMERULOSCLEROSIS 5	http://www.ebi.ac.uk/efo/EFO_0004236
 Cutaneous malignant melanoma 3	http://www.ebi.ac.uk/efo/EFO_0000389
 HOMOCYSTINURIA DUE TO MTHFR DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_395
-Spastic paraplegia 57	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000572	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0000648
+Spastic paraplegia 57	http://purl.obolibrary.org/obo/HP_0001258
 EXUDATIVE VITREORETINOPATHY 4	http://www.orpha.net/ORDO/Orphanet_98668
-Stomatocytosis I	http://purl.obolibrary.org/obo/HP_0012115	http://purl.obolibrary.org/obo/HP_0001081	http://purl.obolibrary.org/obo/HP_0000980	http://purl.obolibrary.org/obo/HP_0008269	http://purl.obolibrary.org/obo/HP_0003281	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0001923	http://purl.obolibrary.org/obo/HP_0000952	http://purl.obolibrary.org/obo/HP_0003641	http://purl.obolibrary.org/obo/HP_0003575	http://purl.obolibrary.org/obo/HP_0005535	http://purl.obolibrary.org/obo/HP_0001878	http://purl.obolibrary.org/obo/HP_0005502	http://purl.obolibrary.org/obo/HP_0004446
-Alstrom Syndrome	http://purl.obolibrary.org/obo/HP_0000826	http://purl.obolibrary.org/obo/HP_0009124	http://purl.obolibrary.org/obo/HP_0001970	http://purl.obolibrary.org/obo/HP_0100820	http://purl.obolibrary.org/obo/HP_0000144	http://purl.obolibrary.org/obo/HP_0003119	http://purl.obolibrary.org/obo/HP_0000076	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000842	http://purl.obolibrary.org/obo/HP_0002155	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0002206	http://purl.obolibrary.org/obo/HP_0100817	http://purl.obolibrary.org/obo/HP_0000956	http://purl.obolibrary.org/obo/HP_0000055	http://purl.obolibrary.org/obo/HP_0002099	http://purl.obolibrary.org/obo/HP_0000548	http://purl.obolibrary.org/obo/HP_0000821	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0000091	http://purl.obolibrary.org/obo/HP_0005616	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0005987	http://purl.obolibrary.org/obo/HP_0001956	http://purl.obolibrary.org/obo/HP_0000998	http://purl.obolibrary.org/obo/HP_0000873	http://purl.obolibrary.org/obo/HP_0000123	http://purl.obolibrary.org/obo/HP_0000311	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0000121	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0200120	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0000717	http://purl.obolibrary.org/obo/HP_0002621	http://purl.obolibrary.org/obo/HP_0000855	http://purl.obolibrary.org/obo/HP_0000388	http://purl.obolibrary.org/obo/HP_0000771	http://purl.obolibrary.org/obo/HP_0007360	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0000035	http://purl.obolibrary.org/obo/HP_0001394	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0000164	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0006532	http://purl.obolibrary.org/obo/HP_0000408	http://purl.obolibrary.org/obo/HP_0000831	http://purl.obolibrary.org/obo/HP_0000815	http://purl.obolibrary.org/obo/HP_0000230	http://purl.obolibrary.org/obo/HP_0001409	http://purl.obolibrary.org/obo/HP_0003233	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0000490	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0000613	http://purl.obolibrary.org/obo/HP_0000147	http://purl.obolibrary.org/obo/HP_0000532	http://purl.obolibrary.org/obo/HP_0004438	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0100626	http://purl.obolibrary.org/obo/HP_0001155	http://purl.obolibrary.org/obo/HP_0000523	http://purl.obolibrary.org/obo/HP_0000858	http://purl.obolibrary.org/obo/HP_0005978	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0000580	http://purl.obolibrary.org/obo/HP_0002092	http://purl.obolibrary.org/obo/HP_0000795	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0000722	http://purl.obolibrary.org/obo/HP_0002149	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001397	http://purl.obolibrary.org/obo/HP_0000824
-ULNA AND FIBULA	http://purl.obolibrary.org/obo/HP_0002980	http://purl.obolibrary.org/obo/HP_0000008	http://purl.obolibrary.org/obo/HP_0002992	http://purl.obolibrary.org/obo/HP_0000276	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0001231	http://purl.obolibrary.org/obo/HP_0001839	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001964	http://purl.obolibrary.org/obo/HP_0001180	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0005914	http://purl.obolibrary.org/obo/HP_0003041	http://purl.obolibrary.org/obo/HP_0006487	http://purl.obolibrary.org/obo/HP_0001883	http://purl.obolibrary.org/obo/HP_0000046	http://purl.obolibrary.org/obo/HP_0002991	http://purl.obolibrary.org/obo/HP_0001789	http://purl.obolibrary.org/obo/HP_0400004	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0003070	http://purl.obolibrary.org/obo/HP_0000768	http://purl.obolibrary.org/obo/HP_0000189	http://purl.obolibrary.org/obo/HP_0000884	http://purl.obolibrary.org/obo/HP_0000916	http://purl.obolibrary.org/obo/HP_0010769	http://purl.obolibrary.org/obo/HP_0009104	http://purl.obolibrary.org/obo/HP_0006585	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0002937	http://purl.obolibrary.org/obo/HP_0003982	http://purl.obolibrary.org/obo/HP_0002983	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0006502	http://purl.obolibrary.org/obo/HP_0009829	http://purl.obolibrary.org/obo/HP_0003498	http://purl.obolibrary.org/obo/HP_0000885	http://purl.obolibrary.org/obo/HP_0000377	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0005613	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0002997	http://purl.obolibrary.org/obo/HP_0002557	http://purl.obolibrary.org/obo/HP_0008736	http://purl.obolibrary.org/obo/HP_0000475	http://purl.obolibrary.org/obo/HP_0002436	http://purl.obolibrary.org/obo/HP_0010173	http://purl.obolibrary.org/obo/HP_0009767	http://purl.obolibrary.org/obo/HP_0003252	http://purl.obolibrary.org/obo/HP_0002986	http://purl.obolibrary.org/obo/HP_0002644	http://purl.obolibrary.org/obo/HP_0001773	http://purl.obolibrary.org/obo/HP_0001798	http://purl.obolibrary.org/obo/HP_0005474	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000151	http://purl.obolibrary.org/obo/HP_0008817	http://purl.obolibrary.org/obo/HP_0100589	http://purl.obolibrary.org/obo/HP_0008363	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0006501	http://purl.obolibrary.org/obo/HP_0001362	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0003063	http://purl.obolibrary.org/obo/HP_0002984	http://purl.obolibrary.org/obo/HP_0001849	http://purl.obolibrary.org/obo/HP_0002575	http://purl.obolibrary.org/obo/HP_0004231	http://purl.obolibrary.org/obo/HP_0001171	http://purl.obolibrary.org/obo/HP_0001552	http://purl.obolibrary.org/obo/HP_0002435	http://purl.obolibrary.org/obo/HP_0002990	http://purl.obolibrary.org/obo/HP_0002987	http://purl.obolibrary.org/obo/HP_0002827
+Stomatocytosis I	http://purl.obolibrary.org/obo/HP_0012115
+Alstrom Syndrome	http://purl.obolibrary.org/obo/HP_0000826
+ULNA AND FIBULA	http://purl.obolibrary.org/obo/HP_0002980
 Primary autosomal recessive microcephaly 11	http://www.orpha.net/ORDO/Orphanet_2512
 Androgen resistance syndrome	http://www.orpha.net/ORDO/Orphanet_754
 Mild obesity	http://purl.obolibrary.org/obo/HP_0001249
 OTOFACIOCERVICAL SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_2792
 CATARACT 9	http://www.ebi.ac.uk/efo/EFO_0001059
-MITOCHONDRIAL DNA DEPLETION SYNDROME 7 (HEPATOCEREBRAL TYPE)	http://purl.obolibrary.org/obo/HP_0003390	http://purl.obolibrary.org/obo/HP_0002312	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0002305	http://purl.obolibrary.org/obo/HP_0000817	http://purl.obolibrary.org/obo/HP_0006957	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0000815	http://purl.obolibrary.org/obo/HP_0200134	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001262	http://purl.obolibrary.org/obo/HP_0000597	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0001328	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000709	http://purl.obolibrary.org/obo/HP_0100022	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0000602	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0001315	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0012847
-Dilated cardiomyopathy 1C	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
-Thanatophoric dysplasia type 1	http://www.orpha.net/ORDO/Orphanet_429	http://www.orpha.net/ORDO/Orphanet_1860
+MITOCHONDRIAL DNA DEPLETION SYNDROME 7 (HEPATOCEREBRAL TYPE)	http://purl.obolibrary.org/obo/HP_0003390
+Dilated cardiomyopathy 1C	http://www.ebi.ac.uk/efo/EFO_0000407
+Thanatophoric dysplasia type 1	http://www.orpha.net/ORDO/Orphanet_429
 EEM syndrome	http://www.orpha.net/ORDO/Orphanet_1897
 SYNPOLYDACTYLY 1	http://www.orpha.net/ORDO/Orphanet_295195
 Cone monochromatism	http://www.orpha.net/ORDO/Orphanet_16
 FACTOR VII DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_327
-Wieacker syndrome	http://purl.obolibrary.org/obo/HP_0000582	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0005745	http://purl.obolibrary.org/obo/HP_0010806	http://purl.obolibrary.org/obo/HP_0000774	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0003693	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0100022	http://purl.obolibrary.org/obo/HP_0002827	http://purl.obolibrary.org/obo/HP_0009623	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0000278	http://purl.obolibrary.org/obo/HP_0012385	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0002804	http://purl.obolibrary.org/obo/HP_0002643	http://purl.obolibrary.org/obo/HP_0000657	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0009890	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0002307	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000597	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000319	http://purl.obolibrary.org/obo/HP_0001558	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0002104	http://purl.obolibrary.org/obo/HP_0000187	http://purl.obolibrary.org/obo/HP_0002186	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0003307	http://purl.obolibrary.org/obo/HP_0012448	http://purl.obolibrary.org/obo/HP_0010628	http://purl.obolibrary.org/obo/HP_0001376	http://purl.obolibrary.org/obo/HP_0002059
-AUTOIMMUNE DISEASE	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0002028	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000269	http://purl.obolibrary.org/obo/HP_0000331	http://purl.obolibrary.org/obo/HP_0004482	http://purl.obolibrary.org/obo/HP_0000268
+Wieacker syndrome	http://purl.obolibrary.org/obo/HP_0000582
+AUTOIMMUNE DISEASE	http://purl.obolibrary.org/obo/HP_0002240
 ANTERIOR SEGMENT ANOMALIES	http://www.ebi.ac.uk/efo/EFO_0001059
 Corpus callosum agenesis	http://purl.obolibrary.org/obo/HP_0001274
 Lumbosacral myelomeningocele	http://purl.obolibrary.org/obo/HP_0001360
@@ -258,179 +258,179 @@ Retinitis pigmentosa 67	http://www.orpha.net/ORDO/Orphanet_791
 MOWAT-WILSON SYNDROME	http://www.orpha.net/ORDO/Orphanet_2152
 Ataxia and retinitis pigmentosa with isolated vitamin e deficiency	http://www.orpha.net/ORDO/Orphanet_96
 Severe congenital neutropenia	http://www.orpha.net/ORDO/Orphanet_42738
-Ectodermal dysplasia/short stature syndrome	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0000962	http://purl.obolibrary.org/obo/HP_0008404	http://purl.obolibrary.org/obo/HP_0006297	http://purl.obolibrary.org/obo/HP_0001798	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0002099	http://purl.obolibrary.org/obo/HP_0000668
-CARNEY COMPLEX VARIANT	http://www.orpha.net/ORDO/Orphanet_319340	http://www.orpha.net/ORDO/Orphanet_3377
-EPILEPSY	http://purl.obolibrary.org/obo/HP_0003700	http://purl.obolibrary.org/obo/HP_0002355	http://purl.obolibrary.org/obo/HP_0001337	http://www.orpha.net/ORDO/Orphanet_98261	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0012075	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0003429	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000708	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000486	http://www.ebi.ac.uk/efo/EFO_0000773	http://purl.obolibrary.org/obo/HP_0002509	http://purl.obolibrary.org/obo/HP_0002133	http://purl.obolibrary.org/obo/HP_0002349	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0007334	http://purl.obolibrary.org/obo/HP_0011158	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002069	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0010819	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000709	http://purl.obolibrary.org/obo/HP_0002121	http://purl.obolibrary.org/obo/HP_0002384	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0007359	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0003829	http://www.ebi.ac.uk/efo/EFO_0000474	http://purl.obolibrary.org/obo/HP_0100704	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000407	http://www.orpha.net/ORDO/Orphanet_501	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0000718
-DIARRHEA 4	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001944	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0004918	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0003623	http://purl.obolibrary.org/obo/HP_0001508
-3-@METHYLGLUTACONIC ACIDURIA	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0002470	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0001645	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0004856	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0003150	http://purl.obolibrary.org/obo/HP_0003344	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0012817	http://purl.obolibrary.org/obo/HP_0001657	http://purl.obolibrary.org/obo/HP_0001414	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0008734
-ASPHYXIATING THORACIC DYSTROPHY 2	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003027	http://purl.obolibrary.org/obo/HP_0000774	http://purl.obolibrary.org/obo/HP_0001162	http://purl.obolibrary.org/obo/HP_0001773	http://purl.obolibrary.org/obo/HP_0010049	http://purl.obolibrary.org/obo/HP_0008905	http://purl.obolibrary.org/obo/HP_0001169
-LACTASE PERSISTENCE	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0004789	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0001939
+Ectodermal dysplasia/short stature syndrome	http://purl.obolibrary.org/obo/HP_0002015
+CARNEY COMPLEX VARIANT	http://www.orpha.net/ORDO/Orphanet_319340
+EPILEPSY	http://purl.obolibrary.org/obo/HP_0003700
+DIARRHEA 4	http://purl.obolibrary.org/obo/HP_0000007
+3-@METHYLGLUTACONIC ACIDURIA	http://purl.obolibrary.org/obo/HP_0001324
+ASPHYXIATING THORACIC DYSTROPHY 2	http://purl.obolibrary.org/obo/HP_0001156
+LACTASE PERSISTENCE	http://purl.obolibrary.org/obo/HP_0000007
 Orofacial cleft 15	http://www.orpha.net/ORDO/Orphanet_139039
 Autosomal recessive cutis laxa type 2B	http://www.orpha.net/ORDO/Orphanet_357064
 Spermatogenic failure 8	http://www.orpha.net/ORDO/Orphanet_399805
-BIPOLAR AFFECTIVE DISORDER	http://www.ebi.ac.uk/efo/EFO_0000289	http://www.ebi.ac.uk/efo/EFO_0005204	http://www.ebi.ac.uk/efo/EFO_0001072	http://www.ebi.ac.uk/efo/EFO_0004215	http://www.ebi.ac.uk/efo/EFO_0002508
+BIPOLAR AFFECTIVE DISORDER	http://www.ebi.ac.uk/efo/EFO_0000289
 BUTYRYLCHOLINESTERASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_132
 BRUCK SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_2771
 PELIZAEUS-MERZBACHER DISEASE	http://www.orpha.net/ORDO/Orphanet_702
 ADAMS-OLIVER SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_974
-Martin-Probst deafness-mental retardation syndrome	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000093	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0001876	http://purl.obolibrary.org/obo/HP_0002557	http://purl.obolibrary.org/obo/HP_0001009	http://purl.obolibrary.org/obo/HP_0008736	http://purl.obolibrary.org/obo/HP_0000003	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000089	http://purl.obolibrary.org/obo/HP_0000048	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0000164	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0006610	http://purl.obolibrary.org/obo/HP_0000689	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0006709	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0000821	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0000232	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0010669	http://purl.obolibrary.org/obo/HP_0000581	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0000506	http://purl.obolibrary.org/obo/HP_0000179	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0100585	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0007477	http://purl.obolibrary.org/obo/HP_0008678	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0005528
+Martin-Probst deafness-mental retardation syndrome	http://purl.obolibrary.org/obo/HP_0000272
 Nephronophthisis	http://www.orpha.net/ORDO/Orphanet_655
 Arterial dissection	http://purl.obolibrary.org/obo/HP_0005294
-SPERMATOGENIC FAILURE	http://purl.obolibrary.org/obo/HP_0003251	http://purl.obolibrary.org/obo/HP_0000027	http://purl.obolibrary.org/obo/HP_0001939
-CENTRAL CORE DISEASE	http://www.orpha.net/ORDO/Orphanet_597	http://www.ebi.ac.uk/efo/EFO_1000855
+SPERMATOGENIC FAILURE	http://purl.obolibrary.org/obo/HP_0003251
+CENTRAL CORE DISEASE	http://www.orpha.net/ORDO/Orphanet_597
 Marfanoid habitus	http://purl.obolibrary.org/obo/HP_0001519
 HYPERTRIGLYCERIDEMIA	http://www.ebi.ac.uk/efo/EFO_0004211
-B-CELL EXPANSION WITH NFKB AND T-CELL ANERGY	http://purl.obolibrary.org/obo/HP_0002850	http://purl.obolibrary.org/obo/HP_0002719	http://purl.obolibrary.org/obo/HP_0001744
+B-CELL EXPANSION WITH NFKB AND T-CELL ANERGY	http://purl.obolibrary.org/obo/HP_0002850
 Schwannomatosis	http://www.orpha.net/ORDO/Orphanet_93921
 Early infantile epileptic encephalopathy 11	http://www.orpha.net/ORDO/Orphanet_1934
-GARDNER SYNDROME	http://www.orpha.net/ORDO/Orphanet_733	http://www.orpha.net/ORDO/Orphanet_79665
-PSEUDOPSEUDOHYPOPARATHYROIDISM	http://www.orpha.net/ORDO/Orphanet_79445	http://www.orpha.net/ORDO/Orphanet_79443
+GARDNER SYNDROME	http://www.orpha.net/ORDO/Orphanet_733
+PSEUDOPSEUDOHYPOPARATHYROIDISM	http://www.orpha.net/ORDO/Orphanet_79445
 Unverricht-Lundborg syndrome	http://www.orpha.net/ORDO/Orphanet_308
-Glycogen Storage Disease Type III	http://www.orpha.net/ORDO/Orphanet_366	http://www.orpha.net/ORDO/Orphanet_79201
+Glycogen Storage Disease Type III	http://www.orpha.net/ORDO/Orphanet_366
 Pseudohypoaldosteronism type 1 autosomal recessive	http://www.orpha.net/ORDO/Orphanet_756
-Gamstorp-Wohlfart syndrome	http://purl.obolibrary.org/obo/HP_0003390	http://purl.obolibrary.org/obo/HP_0009027	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0002411	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0001760	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0003552	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002380	http://purl.obolibrary.org/obo/HP_0000975	http://purl.obolibrary.org/obo/HP_0002486	http://purl.obolibrary.org/obo/HP_0003394
+Gamstorp-Wohlfart syndrome	http://purl.obolibrary.org/obo/HP_0003390
 Early infantile epileptic encephalopathy 8	http://www.orpha.net/ORDO/Orphanet_1934
-Dystonia 10	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0002310	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0002197	http://purl.obolibrary.org/obo/HP_0040168	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002268	http://purl.obolibrary.org/obo/HP_0007098	http://purl.obolibrary.org/obo/HP_0000271
+Dystonia 10	http://purl.obolibrary.org/obo/HP_0003829
 CHOROIDEREMIA	http://www.orpha.net/ORDO/Orphanet_180
-Oculocutaneous albinism type 1B	http://www.orpha.net/ORDO/Orphanet_79431	http://www.orpha.net/ORDO/Orphanet_79434
-EPSTEIN SYNDROME	http://purl.obolibrary.org/obo/HP_0000421	http://purl.obolibrary.org/obo/HP_0002907	http://purl.obolibrary.org/obo/HP_0001757	http://purl.obolibrary.org/obo/HP_0000093	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0008619	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003774	http://purl.obolibrary.org/obo/HP_0000123	http://purl.obolibrary.org/obo/HP_0002239	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0001902
-HYPOSPADIAS 2	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0000808
+Oculocutaneous albinism type 1B	http://www.orpha.net/ORDO/Orphanet_79431
+EPSTEIN SYNDROME	http://purl.obolibrary.org/obo/HP_0000421
+HYPOSPADIAS 2	http://purl.obolibrary.org/obo/HP_0001419
 DOPAMINE BETA-HYDROXYLASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_230
 RETT SYNDROME CONGENITAL VARIANT	http://www.orpha.net/ORDO/Orphanet_778
 Joubert syndrome 22	http://www.orpha.net/ORDO/Orphanet_475
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 2	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0002375	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0000969	http://purl.obolibrary.org/obo/HP_0005989	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0001274	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0001254
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 2	http://purl.obolibrary.org/obo/HP_0002151
 CORNELIA DE LANGE SYNDROME 5	http://www.orpha.net/ORDO/Orphanet_199
 CHONDRODYSPLASIA PUNCTATA 1 X-LINKED RECESSIVE	http://www.orpha.net/ORDO/Orphanet_79345
 ECTRODACTYLY	http://www.ebi.ac.uk/efo/EFO_0003959
-ALPHA-METHYLACYL-CoA RACEMASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0007141	http://purl.obolibrary.org/obo/HP_0003256	http://purl.obolibrary.org/obo/HP_0006579	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000580	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0001399	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0001406	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0002133	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0200084	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0002630	http://purl.obolibrary.org/obo/HP_0002904	http://purl.obolibrary.org/obo/HP_0003623	http://purl.obolibrary.org/obo/HP_0001508
-PARAMYOTONIA CONGENITA OF VON EULENBURG	http://www.orpha.net/ORDO/Orphanet_682	http://www.orpha.net/ORDO/Orphanet_684
+ALPHA-METHYLACYL-CoA RACEMASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0007141
+PARAMYOTONIA CONGENITA OF VON EULENBURG	http://www.orpha.net/ORDO/Orphanet_682
 RETINITIS PUNCTATA ALBESCENS	http://www.orpha.net/ORDO/Orphanet_52427
 SWEAT CHLORIDE ELEVATION WITHOUT CYSTIC FIBROSIS	http://www.orpha.net/ORDO/Orphanet_586
-VENTRICULAR TACHYCARDIA	http://purl.obolibrary.org/obo/HP_0000007	http://www.ebi.ac.uk/efo/EFO_0000318	http://purl.obolibrary.org/obo/HP_0001699	http://www.ebi.ac.uk/efo/EFO_0005306	http://purl.obolibrary.org/obo/HP_0001279	http://purl.obolibrary.org/obo/HP_0004756	http://purl.obolibrary.org/obo/HP_0001250
-Essential tremor	http://www.ebi.ac.uk/efo/EFO_0003108	http://www.ebi.ac.uk/efo/EFO_0002508
+VENTRICULAR TACHYCARDIA	http://purl.obolibrary.org/obo/HP_0000007
+Essential tremor	http://www.ebi.ac.uk/efo/EFO_0003108
 Oculomelic amyoplasia	http://www.orpha.net/ORDO/Orphanet_1154
-Juvenile myelomonocytic leukemia	http://www.ebi.ac.uk/efo/EFO_0000707	http://www.ebi.ac.uk/efo/EFO_0001071	http://www.ebi.ac.uk/efo/EFO_0000206	http://www.ebi.ac.uk/efo/EFO_0002618	http://www.ebi.ac.uk/efo/EFO_1000309	http://www.ebi.ac.uk/efo/EFO_0000571	http://www.ebi.ac.uk/efo/EFO_0000708	http://www.ebi.ac.uk/efo/EFO_0000205	http://www.ebi.ac.uk/efo/EFO_0003060	http://www.ebi.ac.uk/efo/EFO_0000616
+Juvenile myelomonocytic leukemia	http://www.ebi.ac.uk/efo/EFO_0000707
 Bardet-Biedl syndrome 19	http://www.orpha.net/ORDO/Orphanet_110
-T-cell prolymphocytic leukemia	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0000305	http://www.ebi.ac.uk/efo/EFO_1000560
+T-cell prolymphocytic leukemia	http://www.ebi.ac.uk/efo/EFO_0000311
 Pseudohypoparathyroidism type 1C	http://www.orpha.net/ORDO/Orphanet_79444
-Familial multiple trichoepitheliomata	http://www.orpha.net/ORDO/Orphanet_867	http://www.orpha.net/ORDO/Orphanet_79493
+Familial multiple trichoepitheliomata	http://www.orpha.net/ORDO/Orphanet_867
 BARDET-BIEDL SYNDROME 2/4	http://www.orpha.net/ORDO/Orphanet_110
-HEMOPHAGOCYTIC LYMPHOHISTIOCYTOSIS	http://purl.obolibrary.org/obo/HP_0001875	http://purl.obolibrary.org/obo/HP_0007430	http://purl.obolibrary.org/obo/HP_0003073	http://purl.obolibrary.org/obo/HP_0003281	http://purl.obolibrary.org/obo/HP_0002445	http://purl.obolibrary.org/obo/HP_0001954	http://purl.obolibrary.org/obo/HP_0001287	http://purl.obolibrary.org/obo/HP_0003573	http://purl.obolibrary.org/obo/HP_0001882	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0002383	http://purl.obolibrary.org/obo/HP_0000737	http://purl.obolibrary.org/obo/HP_0002902	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002155	http://purl.obolibrary.org/obo/HP_0002716	http://purl.obolibrary.org/obo/HP_0008151	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0011900	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001433	http://purl.obolibrary.org/obo/HP_0002516	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001945	http://purl.obolibrary.org/obo/HP_0002301	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0012156	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0012178	http://purl.obolibrary.org/obo/HP_0000952	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0012229	http://purl.obolibrary.org/obo/HP_0012177	http://purl.obolibrary.org/obo/HP_0002922	http://purl.obolibrary.org/obo/HP_0001259	http://purl.obolibrary.org/obo/HP_0001913	http://purl.obolibrary.org/obo/HP_0003075
-Poretti-boltshauser syndrome	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002350	http://purl.obolibrary.org/obo/HP_0000646	http://purl.obolibrary.org/obo/HP_0007033	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0002518	http://purl.obolibrary.org/obo/HP_0000657	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000556	http://purl.obolibrary.org/obo/HP_0002198	http://purl.obolibrary.org/obo/HP_0030329	http://purl.obolibrary.org/obo/HP_0001105	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001320
+HEMOPHAGOCYTIC LYMPHOHISTIOCYTOSIS	http://purl.obolibrary.org/obo/HP_0001875
+Poretti-boltshauser syndrome	http://purl.obolibrary.org/obo/HP_0001270
 Monoclonal B-Cell Lymphocytosis	http://www.ebi.ac.uk/efo/EFO_0006889
 Primary hyperparathyroidism	http://purl.obolibrary.org/obo/HP_0008200
 BARDET-BIEDL SYNDROME 1/2	http://www.orpha.net/ORDO/Orphanet_110
 Juvenile neuronal ceroid lipofuscinosis	http://www.orpha.net/ORDO/Orphanet_79264
-HYPOPARATHYROIDISM	http://www.orpha.net/ORDO/Orphanet_2238	http://www.orpha.net/ORDO/Orphanet_189466
+HYPOPARATHYROIDISM	http://www.orpha.net/ORDO/Orphanet_2238
 DESBUQUOIS DYSPLASIA 2	http://www.orpha.net/ORDO/Orphanet_1425
 Yunis Varon syndrome	http://www.orpha.net/ORDO/Orphanet_3472
-ALPHA-THALASSEMIA	http://www.orpha.net/ORDO/Orphanet_93616	http://www.orpha.net/ORDO/Orphanet_846
-MEACHAM SYNDROME	http://www.orpha.net/ORDO/Orphanet_3097	http://www.orpha.net/ORDO/Orphanet_220
-HEPATIC VENOOCCLUSIVE DISEASE WITH IMMUNODEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0006685	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0004315	http://purl.obolibrary.org/obo/HP_0002849	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0001392
-EXUDATIVE VITREORETINOPATHY 5	http://purl.obolibrary.org/obo/HP_0007917	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001146	http://purl.obolibrary.org/obo/HP_0000594	http://purl.obolibrary.org/obo/HP_0030490	http://purl.obolibrary.org/obo/HP_0000006
+ALPHA-THALASSEMIA	http://www.orpha.net/ORDO/Orphanet_93616
+MEACHAM SYNDROME	http://www.orpha.net/ORDO/Orphanet_3097
+HEPATIC VENOOCCLUSIVE DISEASE WITH IMMUNODEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
+EXUDATIVE VITREORETINOPATHY 5	http://purl.obolibrary.org/obo/HP_0007917
 Amyotrophic lateral sclerosis type 2	http://www.ebi.ac.uk/efo/EFO_0000253
-Myotonia congenita	http://www.orpha.net/ORDO/Orphanet_206973	http://www.orpha.net/ORDO/Orphanet_614
+Myotonia congenita	http://www.orpha.net/ORDO/Orphanet_206973
 Congenital generalized lipodystrophy type 2	http://www.ebi.ac.uk/efo/EFO_1000681
 RETICULAR DYSGENESIS	http://www.orpha.net/ORDO/Orphanet_33355
 OTOFACIOCERVICAL SYNDROME	http://www.orpha.net/ORDO/Orphanet_2792
-Oocyte maturation defect	http://purl.obolibrary.org/obo/HP_0000789	http://purl.obolibrary.org/obo/HP_0000007
-GENERALIZED EPILEPSY AND PAROXYSMAL DYSKINESIA	http://purl.obolibrary.org/obo/HP_0002069	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002121	http://purl.obolibrary.org/obo/HP_0007166	http://purl.obolibrary.org/obo/HP_0010849
+Oocyte maturation defect	http://purl.obolibrary.org/obo/HP_0000789
+GENERALIZED EPILEPSY AND PAROXYSMAL DYSKINESIA	http://purl.obolibrary.org/obo/HP_0002069
 RING DERMOID OF CORNEA	http://www.orpha.net/ORDO/Orphanet_91481
-ENDOCRINE-CEREBROOSTEODYSPLASIA	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000046	http://purl.obolibrary.org/obo/HP_0001852	http://purl.obolibrary.org/obo/HP_0000437	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000377	http://purl.obolibrary.org/obo/HP_0001193	http://purl.obolibrary.org/obo/HP_0000062	http://purl.obolibrary.org/obo/HP_0001360	http://purl.obolibrary.org/obo/HP_0000835	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0001159	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000204	http://purl.obolibrary.org/obo/HP_0000914	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0007370	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0002983	http://purl.obolibrary.org/obo/HP_0006610	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0030260	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0001552	http://purl.obolibrary.org/obo/HP_0100259	http://purl.obolibrary.org/obo/HP_0000054
+ENDOCRINE-CEREBROOSTEODYSPLASIA	http://purl.obolibrary.org/obo/HP_0000272
 Congenital disorder of glycosylation type 1K	http://www.orpha.net/ORDO/Orphanet_79327
 Barakat syndrome	http://www.orpha.net/ORDO/Orphanet_2237
 Wolcott-Rallison dysplasia	http://www.orpha.net/ORDO/Orphanet_1667
-X-linked hereditary motor and sensory neuropathy	http://www.orpha.net/ORDO/Orphanet_64747	http://www.orpha.net/ORDO/Orphanet_64748
+X-linked hereditary motor and sensory neuropathy	http://www.orpha.net/ORDO/Orphanet_64747
 Autosomal recessive woolly hair 3	http://www.orpha.net/ORDO/Orphanet_170
-DYSTONIA	http://www.orpha.net/ORDO/Orphanet_254851	http://www.orpha.net/ORDO/Orphanet_98808	http://www.orpha.net/ORDO/Orphanet_238583
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 1	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0002375	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000817	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0001396	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0002283	http://purl.obolibrary.org/obo/HP_0004448	http://purl.obolibrary.org/obo/HP_0001942	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0012448	http://purl.obolibrary.org/obo/HP_0006799	http://purl.obolibrary.org/obo/HP_0002490
-Familial cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0002945
+DYSTONIA	http://www.orpha.net/ORDO/Orphanet_254851
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 1	http://purl.obolibrary.org/obo/HP_0003577
+Familial cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000318
 NICOLAIDES-BARAITSER SYNDROME	http://www.orpha.net/ORDO/Orphanet_3051
 NEPHROPATHY	http://www.ebi.ac.uk/efo/EFO_0003086
-THYROID HORMONE METABOLISM	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002925	http://purl.obolibrary.org/obo/HP_0002750
-PROTOPORPHYRIA	http://purl.obolibrary.org/obo/HP_0001891	http://purl.obolibrary.org/obo/HP_0012187	http://purl.obolibrary.org/obo/HP_0001081	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0001423	http://purl.obolibrary.org/obo/HP_0000992	http://purl.obolibrary.org/obo/HP_0011463
-COMBINED D-2- AND L-2-HYDROXYGLUTARIC ACIDURIA	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0010307	http://purl.obolibrary.org/obo/HP_0006829	http://purl.obolibrary.org/obo/HP_0000817	http://purl.obolibrary.org/obo/HP_0001298	http://purl.obolibrary.org/obo/HP_0000737	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0002094	http://purl.obolibrary.org/obo/HP_0100704	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0040144	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0012448	http://purl.obolibrary.org/obo/HP_0000256
-MATURITY-ONSET DIABETES OF THE YOUNG	http://www.ebi.ac.uk/efo/EFO_0000400	http://www.ebi.ac.uk/efo/EFO_0000349	http://www.orpha.net/ORDO/Orphanet_99885	http://www.orpha.net/ORDO/Orphanet_99886	http://www.orpha.net/ORDO/Orphanet_224	http://www.orpha.net/ORDO/Orphanet_552	http://www.ebi.ac.uk/efo/EFO_0000335
+THYROID HORMONE METABOLISM	http://purl.obolibrary.org/obo/HP_0000007
+PROTOPORPHYRIA	http://purl.obolibrary.org/obo/HP_0001891
+COMBINED D-2- AND L-2-HYDROXYGLUTARIC ACIDURIA	http://purl.obolibrary.org/obo/HP_0001321
+MATURITY-ONSET DIABETES OF THE YOUNG	http://www.ebi.ac.uk/efo/EFO_0000400
 Susceptibility to malaria	http://www.ebi.ac.uk/efo/EFO_0001068
-Retinal dystrophy	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000582	http://purl.obolibrary.org/obo/HP_0000556	http://www.orpha.net/ORDO/Orphanet_71862	http://purl.obolibrary.org/obo/HP_0000687	http://www.orpha.net/ORDO/Orphanet_791	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000689	http://purl.obolibrary.org/obo/HP_0004322	http://www.orpha.net/ORDO/Orphanet_827	http://www.orpha.net/ORDO/Orphanet_352718	http://www.orpha.net/ORDO/Orphanet_110
+Retinal dystrophy	http://purl.obolibrary.org/obo/HP_0000272
 DYSTONIA 16	http://www.orpha.net/ORDO/Orphanet_210571
 Mesothelioma	http://www.ebi.ac.uk/efo/EFO_0000588
 BRUGADA SYNDROME 9	http://www.orpha.net/ORDO/Orphanet_130
-ABDOMINAL OBESITY-METABOLIC SYNDROME 3	http://purl.obolibrary.org/obo/HP_0001956	http://purl.obolibrary.org/obo/HP_0001297	http://purl.obolibrary.org/obo/HP_0012743	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0003124
+ABDOMINAL OBESITY-METABOLIC SYNDROME 3	http://purl.obolibrary.org/obo/HP_0001956
 Parkinson disease 15	http://www.orpha.net/ORDO/Orphanet_171695
 JOUBERT SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_475
 Meckel syndrome	http://www.orpha.net/ORDO/Orphanet_564
 C3HEX	http://purl.obolibrary.org/obo/HP_0000006
 Severe combined immunodeficiency disease	http://www.orpha.net/ORDO/Orphanet_183660
-Peeling skin syndrome 3	http://www.orpha.net/ORDO/Orphanet_263543	http://www.orpha.net/ORDO/Orphanet_263548
+Peeling skin syndrome 3	http://www.orpha.net/ORDO/Orphanet_263543
 Severe brain malformation	http://purl.obolibrary.org/obo/HP_0002539
 Hyperimmunoglobulin E recurrent infection syndrome	http://www.ebi.ac.uk/efo/EFO_0003775
 FACTOR VIII (OKAYAMA)	http://www.orpha.net/ORDO/Orphanet_35909
-Ehlers-Danlos syndrome	http://purl.obolibrary.org/obo/HP_0001181	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0000506	http://www.orpha.net/ORDO/Orphanet_98249	http://www.orpha.net/ORDO/Orphanet_75496	http://www.orpha.net/ORDO/Orphanet_99876	http://purl.obolibrary.org/obo/HP_0001166	http://purl.obolibrary.org/obo/HP_0003324	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000592	http://purl.obolibrary.org/obo/HP_0001655	http://purl.obolibrary.org/obo/HP_0000678	http://purl.obolibrary.org/obo/HP_0000411	http://purl.obolibrary.org/obo/HP_0002194	http://www.orpha.net/ORDO/Orphanet_287	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0000023	http://purl.obolibrary.org/obo/HP_0002007
-Arthrogryposis multiplex congenita	http://purl.obolibrary.org/obo/HP_0001181	http://purl.obolibrary.org/obo/HP_0010767	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0001231	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0002747	http://purl.obolibrary.org/obo/HP_0000774	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0002828	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0007269	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0100490	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0009623	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0000400	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0008736	http://purl.obolibrary.org/obo/HP_0002804	http://purl.obolibrary.org/obo/HP_0002058	http://purl.obolibrary.org/obo/HP_0002398	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0004404	http://purl.obolibrary.org/obo/HP_0001308	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003198	http://purl.obolibrary.org/obo/HP_0000268	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000474	http://purl.obolibrary.org/obo/HP_0001558	http://purl.obolibrary.org/obo/HP_0006829	http://purl.obolibrary.org/obo/HP_0000194	http://www.orpha.net/ORDO/Orphanet_1037	http://purl.obolibrary.org/obo/HP_0000954	http://purl.obolibrary.org/obo/HP_0000028	http://www.orpha.net/ORDO/Orphanet_294965	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0010628	http://purl.obolibrary.org/obo/HP_0001376	http://purl.obolibrary.org/obo/HP_0000023
-Glycogen storage disease type 1A	http://www.orpha.net/ORDO/Orphanet_79258	http://www.orpha.net/ORDO/Orphanet_79259
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 23	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0001638	http://purl.obolibrary.org/obo/HP_0011675	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250
+Ehlers-Danlos syndrome	http://purl.obolibrary.org/obo/HP_0001181
+Arthrogryposis multiplex congenita	http://purl.obolibrary.org/obo/HP_0001181
+Glycogen storage disease type 1A	http://www.orpha.net/ORDO/Orphanet_79258
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 23	http://purl.obolibrary.org/obo/HP_0002151
 PYRUVATE KINASE DEFICIENCY OF RED CELLS	http://www.orpha.net/ORDO/Orphanet_766
 Opitz G/BBB syndrome	http://www.orpha.net/ORDO/Orphanet_2745
 CARDIOENCEPHALOMYOPATHY	http://www.orpha.net/ORDO/Orphanet_1561
-Multicystic renal dysplasia	http://purl.obolibrary.org/obo/HP_0000110	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000089	http://purl.obolibrary.org/obo/HP_0000003	http://purl.obolibrary.org/obo/HP_0000074	http://purl.obolibrary.org/obo/HP_0030157	http://purl.obolibrary.org/obo/HP_0000100	http://purl.obolibrary.org/obo/HP_0001562	http://purl.obolibrary.org/obo/HP_0000126	http://purl.obolibrary.org/obo/HP_0001561	http://purl.obolibrary.org/obo/HP_0000069	http://purl.obolibrary.org/obo/HP_0000072	http://purl.obolibrary.org/obo/HP_0001626	http://purl.obolibrary.org/obo/HP_0000800	http://purl.obolibrary.org/obo/HP_0008676	http://purl.obolibrary.org/obo/HP_0008663
-Mitral valve prolapse	http://purl.obolibrary.org/obo/HP_0001653	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003831	http://purl.obolibrary.org/obo/HP_0001634
+Multicystic renal dysplasia	http://purl.obolibrary.org/obo/HP_0000110
+Mitral valve prolapse	http://purl.obolibrary.org/obo/HP_0001653
 DOWLING-DEGOS DISEASE 4	http://www.orpha.net/ORDO/Orphanet_79145
-Brachydactyly with hypertension	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0001163	http://purl.obolibrary.org/obo/HP_0009803	http://purl.obolibrary.org/obo/HP_0010579	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0010049	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0001167
-DYSTONIA 26	http://purl.obolibrary.org/obo/HP_0000473	http://purl.obolibrary.org/obo/HP_0000643	http://purl.obolibrary.org/obo/HP_0000739	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0012049
+Brachydactyly with hypertension	http://purl.obolibrary.org/obo/HP_0001156
+DYSTONIA 26	http://purl.obolibrary.org/obo/HP_0000473
 NEPHRONOPHTHISIS 13	http://www.orpha.net/ORDO/Orphanet_655
 Neurodegeneration with brain iron accumulation	http://www.orpha.net/ORDO/Orphanet_385
-HYPERURICEMIC NEPHROPATHY	http://purl.obolibrary.org/obo/HP_0004719	http://purl.obolibrary.org/obo/HP_0000097	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0002149	http://purl.obolibrary.org/obo/HP_0000092	http://purl.obolibrary.org/obo/HP_0012622	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000089	http://purl.obolibrary.org/obo/HP_0005576
-Dilated cardiomyopathy 1W	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318
-CORONARY ARTERY DISEASE	http://purl.obolibrary.org/obo/HP_0001997	http://purl.obolibrary.org/obo/HP_0002155	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0000819	http://purl.obolibrary.org/obo/HP_0001645	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000833	http://purl.obolibrary.org/obo/HP_0001658	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0003124
+HYPERURICEMIC NEPHROPATHY	http://purl.obolibrary.org/obo/HP_0004719
+Dilated cardiomyopathy 1W	http://www.ebi.ac.uk/efo/EFO_0000407
+CORONARY ARTERY DISEASE	http://purl.obolibrary.org/obo/HP_0001997
 Optic atrophy 10	http://purl.obolibrary.org/obo/HP_0000648
 PREECLAMPSIA/ECLAMPSIA 4	http://www.orpha.net/ORDO/Orphanet_275555
-CARD11 IMMUNODEFICIENCY	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0002090	http://purl.obolibrary.org/obo/HP_0004313
+CARD11 IMMUNODEFICIENCY	http://purl.obolibrary.org/obo/HP_0003593
 Mitochondrial DNA depletion syndrome 2	http://www.orpha.net/ORDO/Orphanet_35698
 Osteogenesis imperfecta with normal sclerae	http://www.orpha.net/ORDO/Orphanet_216820
-HYDROLETHALUS SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_36	http://www.orpha.net/ORDO/Orphanet_2189
-EXUDATIVE VITREORETINOPATHY 1	http://purl.obolibrary.org/obo/HP_0001147	http://purl.obolibrary.org/obo/HP_0000523	http://purl.obolibrary.org/obo/HP_0007685	http://purl.obolibrary.org/obo/HP_0001146	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000541	http://purl.obolibrary.org/obo/HP_0007902	http://purl.obolibrary.org/obo/HP_0001489	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0001493	http://purl.obolibrary.org/obo/HP_0030490	http://purl.obolibrary.org/obo/HP_0002757	http://purl.obolibrary.org/obo/HP_0000618
+HYDROLETHALUS SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_36
+EXUDATIVE VITREORETINOPATHY 1	http://purl.obolibrary.org/obo/HP_0001147
 BALLER-GEROLD SYNDROME	http://www.orpha.net/ORDO/Orphanet_1225
-Pancreatic agenesis and congenital heart disease	http://www.ebi.ac.uk/efo/EFO_0003777	http://www.ebi.ac.uk/efo/EFO_0007216
+Pancreatic agenesis and congenital heart disease	http://www.ebi.ac.uk/efo/EFO_0003777
 MULTIPLE SYNOSTOSES SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_3237
 Cerebral dysgenesis	http://www.orpha.net/ORDO/Orphanet_66631
-Hypophosphatasia	http://www.orpha.net/ORDO/Orphanet_247651	http://www.orpha.net/ORDO/Orphanet_247676	http://www.orpha.net/ORDO/Orphanet_247667	http://www.orpha.net/ORDO/Orphanet_436
+Hypophosphatasia	http://www.orpha.net/ORDO/Orphanet_247651
 Hypochromic microcytic anemia with iron overload 2	http://www.ebi.ac.uk/efo/EFO_0004272
-PEROXISOME BIOGENESIS DISORDER 14B	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0001730	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0000519	http://purl.obolibrary.org/obo/HP_0001271
-HYPERLIPOPROTEINEMIA	http://purl.obolibrary.org/obo/HP_0000660	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002583	http://purl.obolibrary.org/obo/HP_0010980
+PEROXISOME BIOGENESIS DISORDER 14B	http://purl.obolibrary.org/obo/HP_0000007
+HYPERLIPOPROTEINEMIA	http://purl.obolibrary.org/obo/HP_0000660
 Meckel syndrome 12	http://www.orpha.net/ORDO/Orphanet_564
-Hypokalemic periodic paralysis 1	http://www.orpha.net/ORDO/Orphanet_98913	http://www.orpha.net/ORDO/Orphanet_682	http://www.orpha.net/ORDO/Orphanet_681
+Hypokalemic periodic paralysis 1	http://www.orpha.net/ORDO/Orphanet_98913
 Parkinson disease 7	http://www.orpha.net/ORDO/Orphanet_2828
 Abnormal hemoglobin	http://purl.obolibrary.org/obo/HP_0011902
 LOEYS-DIETZ SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_60030
-Cerebellar ataxia and hypogonadotropic hypogonadism	http://purl.obolibrary.org/obo/HP_0000789	http://purl.obolibrary.org/obo/HP_0000044	http://purl.obolibrary.org/obo/HP_0000876	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000924	http://purl.obolibrary.org/obo/HP_0000726	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001135	http://purl.obolibrary.org/obo/HP_0002059
+Cerebellar ataxia and hypogonadotropic hypogonadism	http://purl.obolibrary.org/obo/HP_0000789
 Congenital disorder of glycosylation type 1O	http://www.orpha.net/ORDO/Orphanet_137
-Familial hypertrophic cardiomyopathy 1	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+Familial hypertrophic cardiomyopathy 1	http://www.ebi.ac.uk/efo/EFO_0000407
 LISSENCEPHALY 5	http://www.orpha.net/ORDO/Orphanet_48471
 Early infantile epileptic encephalopathy 4	http://www.orpha.net/ORDO/Orphanet_1934
 BARDET-BIEDL SYNDROME	http://www.orpha.net/ORDO/Orphanet_110
-MITOCHONDRIAL COMPLEX V (ATP SYNTHASE) DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002089	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0002104	http://purl.obolibrary.org/obo/HP_0001298	http://purl.obolibrary.org/obo/HP_0000737	http://purl.obolibrary.org/obo/HP_0000639
+MITOCHONDRIAL COMPLEX V (ATP SYNTHASE) DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
 SANDHOFF DISEASE	http://www.orpha.net/ORDO/Orphanet_796
 Barber-Say syndrome	http://www.orpha.net/ORDO/Orphanet_1231
 Hereditary neuralgic amyotrophy	http://www.orpha.net/ORDO/Orphanet_2901
 Cataract 6	http://www.ebi.ac.uk/efo/EFO_0001059
-Thrombophilia	http://purl.obolibrary.org/obo/HP_0100724	http://www.orpha.net/ORDO/Orphanet_217454
+Thrombophilia	http://purl.obolibrary.org/obo/HP_0100724
 HYPOTRICHOSIS-LYMPHEDEMA-TELANGIECTASIA SYNDROME	http://www.orpha.net/ORDO/Orphanet_69735
-Diaphyseal dysplasia	http://www.orpha.net/ORDO/Orphanet_1328	http://www.orpha.net/ORDO/Orphanet_586
+Diaphyseal dysplasia	http://www.orpha.net/ORDO/Orphanet_1328
 Mental retardation X-linked with cerebellar hypoplasia and distinctive facial appearance	http://www.ebi.ac.uk/efo/EFO_0003847
 NOONAN SYNDROME	http://www.orpha.net/ORDO/Orphanet_648
 Dilated cardiomyopathy 1I	http://www.ebi.ac.uk/efo/EFO_0000407
-SCAPULOPERONEAL MYOPATHY	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0003376	http://purl.obolibrary.org/obo/HP_0011675	http://purl.obolibrary.org/obo/HP_0003691	http://purl.obolibrary.org/obo/HP_0009027	http://purl.obolibrary.org/obo/HP_0001423	http://purl.obolibrary.org/obo/HP_0003236	http://www.orpha.net/ORDO/Orphanet_437572	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0002515	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0003715	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0007340	http://purl.obolibrary.org/obo/HP_0009054
-Diastrophic dysplasia	http://www.orpha.net/ORDO/Orphanet_628	http://www.orpha.net/ORDO/Orphanet_93307	http://www.orpha.net/ORDO/Orphanet_56304
+SCAPULOPERONEAL MYOPATHY	http://purl.obolibrary.org/obo/HP_0001371
+Diastrophic dysplasia	http://www.orpha.net/ORDO/Orphanet_628
 Glycogen storage disease IXd	http://www.orpha.net/ORDO/Orphanet_79201
 MYOKYMIA 1	http://purl.obolibrary.org/obo/HP_0002411
-PATTERNED DYSTROPHY OF RETINAL PIGMENT EPITHELIUM	http://purl.obolibrary.org/obo/HP_0007754	http://purl.obolibrary.org/obo/HP_0000662	http://purl.obolibrary.org/obo/HP_0007913	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000613	http://purl.obolibrary.org/obo/HP_0012508
+PATTERNED DYSTROPHY OF RETINAL PIGMENT EPITHELIUM	http://purl.obolibrary.org/obo/HP_0007754
 Congenital disorder of glycosylation type 1I	http://www.orpha.net/ORDO/Orphanet_79326
-Cognitive impairment with or without cerebellar ataxia	http://purl.obolibrary.org/obo/HP_0000712	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0000640	http://purl.obolibrary.org/obo/HP_0000646	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000609	http://purl.obolibrary.org/obo/HP_0001249
+Cognitive impairment with or without cerebellar ataxia	http://purl.obolibrary.org/obo/HP_0000712
 LI-FRAUMENI SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_524
-SPASTIC ATAXIA	http://purl.obolibrary.org/obo/HP_0007654	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0003438	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002493	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000762	http://purl.obolibrary.org/obo/HP_0002527	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002168	http://purl.obolibrary.org/obo/HP_0006150	http://purl.obolibrary.org/obo/HP_0001765	http://purl.obolibrary.org/obo/HP_0000012	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0003448	http://purl.obolibrary.org/obo/HP_0007240	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002497	http://purl.obolibrary.org/obo/HP_0003693	http://purl.obolibrary.org/obo/HP_0007772	http://purl.obolibrary.org/obo/HP_0007221	http://purl.obolibrary.org/obo/HP_0006855	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0007001	http://purl.obolibrary.org/obo/HP_0007922	http://purl.obolibrary.org/obo/HP_0002166	http://purl.obolibrary.org/obo/HP_0003387	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0002460	http://purl.obolibrary.org/obo/HP_0002936
+SPASTIC ATAXIA	http://purl.obolibrary.org/obo/HP_0007654
 Pseudoxanthoma elasticum-like disorder with multiple coagulation factor deficiency	http://www.orpha.net/ORDO/Orphanet_758
-AICARDI-GOUTIERES SYNDROME 3	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002514	http://purl.obolibrary.org/obo/HP_0011344	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0200149	http://purl.obolibrary.org/obo/HP_0001298	http://purl.obolibrary.org/obo/HP_0003819	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0012448	http://purl.obolibrary.org/obo/HP_0000253	http://purl.obolibrary.org/obo/HP_0001433	http://purl.obolibrary.org/obo/HP_0000639
+AICARDI-GOUTIERES SYNDROME 3	http://purl.obolibrary.org/obo/HP_0001347
 ASTHMA	http://purl.obolibrary.org/obo/HP_0002099
 Neurodegeneration with brain iron accumulation 5	http://www.orpha.net/ORDO/Orphanet_385
 Wilms tumor 6	http://www.ebi.ac.uk/efo/EFO_1000056
@@ -438,62 +438,62 @@ Leber congenital amaurosis 2	http://www.orpha.net/ORDO/Orphanet_65
 VESICOURETERAL REFLUX 2	http://www.ebi.ac.uk/efo/EFO_0007536
 MALATTIA LEVENTINESE	http://www.orpha.net/ORDO/Orphanet_75376
 HYPEREKPLEXIA 3	http://www.orpha.net/ORDO/Orphanet_3197
-Non-small cell lung cancer	http://www.ebi.ac.uk/efo/EFO_1000309	http://www.ebi.ac.uk/efo/EFO_0000304	http://www.ebi.ac.uk/efo/EFO_0000181	http://www.ebi.ac.uk/efo/EFO_0000756	http://www.ebi.ac.uk/efo/EFO_0000272	http://www.ebi.ac.uk/efo/EFO_0000641	http://www.ebi.ac.uk/efo/EFO_0003060	http://www.ebi.ac.uk/efo/EFO_0000365
+Non-small cell lung cancer	http://www.ebi.ac.uk/efo/EFO_1000309
 PERIODONTITIS	http://www.ebi.ac.uk/efo/EFO_0006342
-TRICHOTHIODYSTROPHY	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0000144	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0009886	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0006829	http://purl.obolibrary.org/obo/HP_0002299	http://purl.obolibrary.org/obo/HP_0001338	http://purl.obolibrary.org/obo/HP_0001598	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0001792	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0008070	http://purl.obolibrary.org/obo/HP_0000685	http://purl.obolibrary.org/obo/HP_0001629	http://purl.obolibrary.org/obo/HP_0000400
-Paroxysmal familial ventricular fibrillation	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0005306	http://www.ebi.ac.uk/efo/EFO_0004287	http://www.ebi.ac.uk/efo/EFO_0004269	http://www.ebi.ac.uk/efo/EFO_0000538
+TRICHOTHIODYSTROPHY	http://purl.obolibrary.org/obo/HP_0002120
+Paroxysmal familial ventricular fibrillation	http://www.ebi.ac.uk/efo/EFO_0000318
 Congenital myasthenic syndrome 13	http://www.orpha.net/ORDO/Orphanet_590
 RETINITIS PIGMENTOSA 43	http://www.orpha.net/ORDO/Orphanet_791
 Dentinogenesis imperfecta - Shields type II	http://www.orpha.net/ORDO/Orphanet_166260
 Leprosy 3	http://www.ebi.ac.uk/efo/EFO_0001054
 Brain atrophy	http://purl.obolibrary.org/obo/HP_0012444
-RENAL ADYSPLASIA	http://purl.obolibrary.org/obo/HP_0000110	http://purl.obolibrary.org/obo/HP_0002089	http://purl.obolibrary.org/obo/HP_0000093	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0000278	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0000104	http://purl.obolibrary.org/obo/HP_0000786	http://purl.obolibrary.org/obo/HP_0002009	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000813	http://purl.obolibrary.org/obo/HP_0001760	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0001562	http://purl.obolibrary.org/obo/HP_0000148	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000316
+RENAL ADYSPLASIA	http://purl.obolibrary.org/obo/HP_0000110
 Juvenile primary lateral sclerosis	http://www.orpha.net/ORDO/Orphanet_247604
-WILMS TUMOR 1	http://www.orpha.net/ORDO/Orphanet_347	http://www.orpha.net/ORDO/Orphanet_654
+WILMS TUMOR 1	http://www.orpha.net/ORDO/Orphanet_347
 Autosomal dominant inheritance	http://purl.obolibrary.org/obo/HP_0000006
 Oculocutaneous Albinism Type 1	http://www.orpha.net/ORDO/Orphanet_352731
-CARDIOMYOPATHY	http://purl.obolibrary.org/obo/HP_0005110	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0001820	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000982	http://purl.obolibrary.org/obo/HP_0007475	http://purl.obolibrary.org/obo/HP_0009804	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0001279	http://purl.obolibrary.org/obo/HP_0004756	http://www.ebi.ac.uk/efo/EFO_0000407	http://purl.obolibrary.org/obo/HP_0002224	http://purl.obolibrary.org/obo/HP_0001808	http://www.ebi.ac.uk/efo/EFO_0000538
+CARDIOMYOPATHY	http://purl.obolibrary.org/obo/HP_0005110
 TUBEROUS SCLEROSIS 1	http://www.orpha.net/ORDO/Orphanet_805
 BIOTINIDASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_79241
 Ataxia with vitamin E deficiency	http://www.orpha.net/ORDO/Orphanet_96
 RETINITIS PIGMENTOSA 27	http://www.orpha.net/ORDO/Orphanet_791
 Aminoadipic aciduria	http://www.orpha.net/ORDO/Orphanet_79154
 Cholestasis of pregnancy	http://www.orpha.net/ORDO/Orphanet_69665
-Multiple endocrine neoplasia	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.orpha.net/ORDO/Orphanet_276161	http://www.ebi.ac.uk/efo/EFO_0000616
+Multiple endocrine neoplasia	http://www.ebi.ac.uk/efo/EFO_0000311
 FEINGOLD SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_1305
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 11	http://purl.obolibrary.org/obo/HP_0000110	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0009830	http://purl.obolibrary.org/obo/HP_0003429	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0001302	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001638	http://purl.obolibrary.org/obo/HP_0001410	http://purl.obolibrary.org/obo/HP_0001308	http://purl.obolibrary.org/obo/HP_0001254	http://purl.obolibrary.org/obo/HP_0003198	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0006829	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0001947	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0001522	http://purl.obolibrary.org/obo/HP_0002490
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 11	http://purl.obolibrary.org/obo/HP_0000110
 COPROPORPHYRIA	http://www.orpha.net/ORDO/Orphanet_79273
 CONE DYSTROPHY 3	http://www.orpha.net/ORDO/Orphanet_1872
 PTEN HAMARTOMA TUMOR SYNDROME	http://www.orpha.net/ORDO/Orphanet_306498
 Grebe syndrome	http://www.orpha.net/ORDO/Orphanet_2098
-SPEECH-LANGUAGE DISORDER 1	http://purl.obolibrary.org/obo/HP_0007301	http://purl.obolibrary.org/obo/HP_0002134	http://purl.obolibrary.org/obo/HP_0002546	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000271
-RETINAL CONE DYSTROPHY 3B	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000666	http://purl.obolibrary.org/obo/HP_0000662	http://purl.obolibrary.org/obo/HP_0000575	http://purl.obolibrary.org/obo/HP_0000613	http://purl.obolibrary.org/obo/HP_0000483	http://purl.obolibrary.org/obo/HP_0000545
-DIAMOND-BLACKFAN ANEMIA 11	http://purl.obolibrary.org/obo/HP_0001875	http://purl.obolibrary.org/obo/HP_0000492	http://purl.obolibrary.org/obo/HP_0001647	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0002984	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0009777	http://purl.obolibrary.org/obo/HP_0006368	http://purl.obolibrary.org/obo/HP_0000104	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003022	http://purl.obolibrary.org/obo/HP_0000402	http://purl.obolibrary.org/obo/HP_0000413
-OROTIC ACIDURIA	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0005435	http://purl.obolibrary.org/obo/HP_0003272	http://purl.obolibrary.org/obo/HP_0003526	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0000790	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0004826	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0004447	http://purl.obolibrary.org/obo/HP_0011273	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0003267	http://purl.obolibrary.org/obo/HP_0010935	http://purl.obolibrary.org/obo/HP_0003355	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0003339	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0008388	http://purl.obolibrary.org/obo/HP_0003218	http://purl.obolibrary.org/obo/HP_0001629
+SPEECH-LANGUAGE DISORDER 1	http://purl.obolibrary.org/obo/HP_0007301
+RETINAL CONE DYSTROPHY 3B	http://purl.obolibrary.org/obo/HP_0000007
+DIAMOND-BLACKFAN ANEMIA 11	http://purl.obolibrary.org/obo/HP_0001875
+OROTIC ACIDURIA	http://purl.obolibrary.org/obo/HP_0000494
 Congenital disorder of glycosylation type 1y	http://www.orpha.net/ORDO/Orphanet_137
 MEIER-GORLIN SYNDROME 6	http://www.orpha.net/ORDO/Orphanet_2554
-PEELING SKIN SYNDROME	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0008066	http://www.orpha.net/ORDO/Orphanet_817	http://purl.obolibrary.org/obo/HP_0010783
-RETINITIS PIGMENTOSA 12	http://www.orpha.net/ORDO/Orphanet_65	http://www.orpha.net/ORDO/Orphanet_791
-Epilepsy	http://purl.obolibrary.org/obo/HP_0001268	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0000729	http://www.ebi.ac.uk/efo/EFO_0000474	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0001336	http://www.orpha.net/ORDO/Orphanet_307	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001251	http://www.orpha.net/ORDO/Orphanet_64280	http://purl.obolibrary.org/obo/HP_0001249
+PEELING SKIN SYNDROME	http://purl.obolibrary.org/obo/HP_0000007
+RETINITIS PIGMENTOSA 12	http://www.orpha.net/ORDO/Orphanet_65
+Epilepsy	http://purl.obolibrary.org/obo/HP_0001268
 PLATYSPONDYLIC LETHAL SKELETAL DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_85166
 LACTATE DEHYDROGENASE B DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_284435
 Infantile epilepsy	http://www.ebi.ac.uk/efo/EFO_0000474
 RETINITIS PIGMENTOSA 61	http://www.orpha.net/ORDO/Orphanet_791
-CARDIAC CONDUCTION DEFECT	http://www.orpha.net/ORDO/Orphanet_768	http://www.orpha.net/ORDO/Orphanet_130
+CARDIAC CONDUCTION DEFECT	http://www.orpha.net/ORDO/Orphanet_768
 Sebaceous tumors	http://www.ebi.ac.uk/efo/EFO_0000616
 EPIDERMOLYSIS BULLOSA SIMPLEX WITH MOTTLED PIGMENTATION	http://www.orpha.net/ORDO/Orphanet_79397
-DYSTONIA 24	http://purl.obolibrary.org/obo/HP_0012048	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0000643	http://purl.obolibrary.org/obo/HP_0000473	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002346
+DYSTONIA 24	http://purl.obolibrary.org/obo/HP_0012048
 CONE DYSTROPHY 4	http://www.orpha.net/ORDO/Orphanet_1871
 Hyperinsulinemia	http://purl.obolibrary.org/obo/HP_0000842
-Combined oxidative phosphorylation deficiency 20	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000590
+Combined oxidative phosphorylation deficiency 20	http://purl.obolibrary.org/obo/HP_0000508
 PAROXYSMAL NOCTURNAL HEMOGLOBINURIA 2	http://www.orpha.net/ORDO/Orphanet_447
 Infantile cortical hyperostosis	http://www.orpha.net/ORDO/Orphanet_1310
 Peroxisome biogenesis disorder 8A	http://www.orpha.net/ORDO/Orphanet_79189
-CONGENITAL HEART DISEASE	http://purl.obolibrary.org/obo/HP_0001682	http://purl.obolibrary.org/obo/HP_0001647	http://purl.obolibrary.org/obo/HP_0001724
+CONGENITAL HEART DISEASE	http://purl.obolibrary.org/obo/HP_0001682
 CORONARY ARTERY DISEASE/MYOCARDIAL INFARCTION	http://www.ebi.ac.uk/efo/EFO_0000378
 Autosomal recessive cutis laxa type 3B	http://www.orpha.net/ORDO/Orphanet_209
-DIABETES INSIPIDUS	http://www.ebi.ac.uk/efo/EFO_0000400	http://www.orpha.net/ORDO/Orphanet_223
-Hypotrichosis 12	http://purl.obolibrary.org/obo/HP_0100840	http://purl.obolibrary.org/obo/HP_0001006	http://purl.obolibrary.org/obo/HP_0200102
+DIABETES INSIPIDUS	http://www.ebi.ac.uk/efo/EFO_0000400
+Hypotrichosis 12	http://purl.obolibrary.org/obo/HP_0100840
 short QT syndrome	http://www.orpha.net/ORDO/Orphanet_51083
 Early infantile epileptic encephalopathy 9	http://www.orpha.net/ORDO/Orphanet_1934
 PROLIDASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_742
@@ -501,26 +501,26 @@ Adams Oliver syndrome	http://www.orpha.net/ORDO/Orphanet_974
 Primary autosomal recessive microcephaly 1	http://www.orpha.net/ORDO/Orphanet_2512
 Kugelberg-Welander disease	http://www.orpha.net/ORDO/Orphanet_83419
 HYPERCHOLESTEROLEMIA AND HYPERTRIGLYCERIDEMIA	http://www.ebi.ac.uk/efo/EFO_0004211
-HYPERTHYROIDISM	http://purl.obolibrary.org/obo/HP_0005616	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000752	http://purl.obolibrary.org/obo/HP_0001622	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000853	http://purl.obolibrary.org/obo/HP_0008249	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0003745	http://purl.obolibrary.org/obo/HP_0001649	http://purl.obolibrary.org/obo/HP_0000836	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0012188
+HYPERTHYROIDISM	http://purl.obolibrary.org/obo/HP_0005616
 Camptomelic dysplasia	http://www.orpha.net/ORDO/Orphanet_140
-ALOPECIA	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0011734	http://purl.obolibrary.org/obo/HP_0000771	http://purl.obolibrary.org/obo/HP_0001193	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0002333	http://purl.obolibrary.org/obo/HP_0000135	http://purl.obolibrary.org/obo/HP_0002493	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000953	http://purl.obolibrary.org/obo/HP_0002751	http://purl.obolibrary.org/obo/HP_0000670	http://purl.obolibrary.org/obo/HP_0001002	http://purl.obolibrary.org/obo/HP_0000823	http://purl.obolibrary.org/obo/HP_0000995	http://purl.obolibrary.org/obo/HP_0000668
+ALOPECIA	http://purl.obolibrary.org/obo/HP_0001371
 ALPHA-FETOPROTEIN DEFICIENCY	http://purl.obolibrary.org/obo/HP_0045057
-Benign recurrent intrahepatic cholestasis 2	http://www.orpha.net/ORDO/Orphanet_172	http://www.orpha.net/ORDO/Orphanet_65682
-COLORECTAL CANCER	http://www.ebi.ac.uk/efo/EFO_0000311	http://purl.obolibrary.org/obo/HP_0200063	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003581	http://www.ebi.ac.uk/efo/EFO_0007354	http://www.ebi.ac.uk/efo/EFO_0005842	http://www.ebi.ac.uk/efo/EFO_0004269	http://www.ebi.ac.uk/efo/EFO_0000365
-THROMBOPHILIA DUE TO PROTEIN S DEFICIENCY	http://purl.obolibrary.org/obo/HP_0005305	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0005521	http://purl.obolibrary.org/obo/HP_0100724	http://purl.obolibrary.org/obo/HP_0002204	http://purl.obolibrary.org/obo/HP_0002638	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0004420
+Benign recurrent intrahepatic cholestasis 2	http://www.orpha.net/ORDO/Orphanet_172
+COLORECTAL CANCER	http://www.ebi.ac.uk/efo/EFO_0000311
+THROMBOPHILIA DUE TO PROTEIN S DEFICIENCY	http://purl.obolibrary.org/obo/HP_0005305
 Nemaline myopathy 10	http://www.orpha.net/ORDO/Orphanet_607
-USHER SYNDROME TYPE 1D	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0008513	http://purl.obolibrary.org/obo/HP_0008619	http://purl.obolibrary.org/obo/HP_0001751
+USHER SYNDROME TYPE 1D	http://purl.obolibrary.org/obo/HP_0000007
 MYOPATHY WITH LACTIC ACIDOSIS	http://www.ebi.ac.uk/efo/EFO_0004145
-PITUITARY HORMONE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000871	http://purl.obolibrary.org/obo/HP_0000270	http://purl.obolibrary.org/obo/HP_0000158	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0008850	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0008202	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0000490	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000821	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0002173	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000846	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0005280	http://www.orpha.net/ORDO/Orphanet_95494	http://purl.obolibrary.org/obo/HP_0000135	http://purl.obolibrary.org/obo/HP_0001998	http://www.orpha.net/ORDO/Orphanet_467	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0006579
+PITUITARY HORMONE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000272
 GRACILE SYNDROME	http://www.orpha.net/ORDO/Orphanet_53693
 Shwachman syndrome	http://www.orpha.net/ORDO/Orphanet_811
 Collapse (finding)	http://purl.obolibrary.org/obo/HP_0006682
 Deficiency of glycerate kinase	http://www.orpha.net/ORDO/Orphanet_260595
 RETINOBLASTOMA	http://www.orpha.net/ORDO/Orphanet_790
 Glycogen storage disease IIIa	http://www.orpha.net/ORDO/Orphanet_79201
-MYASTHENIA	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0003693	http://purl.obolibrary.org/obo/HP_0001558	http://purl.obolibrary.org/obo/HP_0002715	http://purl.obolibrary.org/obo/HP_0001283	http://purl.obolibrary.org/obo/HP_0003473	http://purl.obolibrary.org/obo/HP_0008180	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002747	http://purl.obolibrary.org/obo/HP_0003391	http://purl.obolibrary.org/obo/HP_0002515	http://purl.obolibrary.org/obo/HP_0007126	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0010628	http://purl.obolibrary.org/obo/HP_0003388	http://purl.obolibrary.org/obo/HP_0003394	http://purl.obolibrary.org/obo/HP_0000597
-Analbuminemia	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0012378	http://purl.obolibrary.org/obo/HP_0003073	http://purl.obolibrary.org/obo/HP_0009125	http://purl.obolibrary.org/obo/HP_0003077	http://purl.obolibrary.org/obo/HP_0002615
-CARDIOFACIOCUTANEOUS SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_648	http://www.orpha.net/ORDO/Orphanet_1340
+MYASTHENIA	http://purl.obolibrary.org/obo/HP_0000508
+Analbuminemia	http://purl.obolibrary.org/obo/HP_0000007
+CARDIOFACIOCUTANEOUS SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_648
 RETINITIS PIGMENTOSA 56	http://www.orpha.net/ORDO/Orphanet_791
 Early infantile epileptic encephalopathy 17	http://www.orpha.net/ORDO/Orphanet_1934
 Leprechaunism syndrome	http://www.orpha.net/ORDO/Orphanet_508
@@ -528,81 +528,81 @@ Revesz syndrome	http://www.orpha.net/ORDO/Orphanet_3088
 JOUBERT SYNDROME 13	http://www.orpha.net/ORDO/Orphanet_475
 Ocular albinism	http://www.orpha.net/ORDO/Orphanet_54
 Waardenburg syndrome type 2E	http://www.orpha.net/ORDO/Orphanet_3440
-KAUFMAN OCULOCEREBROFACIAL SYNDROME	http://purl.obolibrary.org/obo/HP_0000582	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0000543	http://purl.obolibrary.org/obo/HP_0000276	http://purl.obolibrary.org/obo/HP_0010511	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000384	http://purl.obolibrary.org/obo/HP_0000670	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0001591	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0004283	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0001840	http://purl.obolibrary.org/obo/HP_0003300	http://purl.obolibrary.org/obo/HP_0000581	http://purl.obolibrary.org/obo/HP_0002648	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0100840	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0000275	http://purl.obolibrary.org/obo/HP_0011302	http://purl.obolibrary.org/obo/HP_0000057	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0002643	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0001166	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0010458	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000699	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000322	http://purl.obolibrary.org/obo/HP_0000233	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0006511	http://purl.obolibrary.org/obo/HP_0000319	http://purl.obolibrary.org/obo/HP_0000506	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0000954	http://purl.obolibrary.org/obo/HP_0000691	http://purl.obolibrary.org/obo/HP_0000174	http://purl.obolibrary.org/obo/HP_0000535	http://purl.obolibrary.org/obo/HP_0001139
-Combined oxidative phosphorylation deficiency 7	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0001349	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000602	http://purl.obolibrary.org/obo/HP_0002590	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002490	http://purl.obolibrary.org/obo/HP_0002936	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0000639
+KAUFMAN OCULOCEREBROFACIAL SYNDROME	http://purl.obolibrary.org/obo/HP_0000582
+Combined oxidative phosphorylation deficiency 7	http://purl.obolibrary.org/obo/HP_0002151
 LETHAL CONGENITAL CONTRACTURE SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_294965
 Sarcotubular myopathy	http://www.orpha.net/ORDO/Orphanet_1878
 X-linked periventricular heterotopia	http://www.orpha.net/ORDO/Orphanet_98892
 Familial colorectal cancer	http://www.ebi.ac.uk/efo/EFO_0000311
 Congenital contractural arachnodactyly	http://www.orpha.net/ORDO/Orphanet_115
-Interleukin 2 receptor	http://purl.obolibrary.org/obo/HP_0005403	http://purl.obolibrary.org/obo/HP_0002028	http://purl.obolibrary.org/obo/HP_0002720	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0002841	http://purl.obolibrary.org/obo/HP_0002718	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0001890	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0002716	http://purl.obolibrary.org/obo/HP_0000819	http://purl.obolibrary.org/obo/HP_0004429	http://purl.obolibrary.org/obo/HP_0000964	http://purl.obolibrary.org/obo/HP_0000821	http://purl.obolibrary.org/obo/HP_0011473	http://purl.obolibrary.org/obo/HP_0001433
-AICAR TRANSFORMYLASE/IMP CYCLOHYDROLASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0000057	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0007875	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000426	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002187	http://purl.obolibrary.org/obo/HP_0000951	http://purl.obolibrary.org/obo/HP_0000063	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0002007
+Interleukin 2 receptor	http://purl.obolibrary.org/obo/HP_0005403
+AICAR TRANSFORMYLASE/IMP CYCLOHYDROLASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001631
 Bilateral squint	http://purl.obolibrary.org/obo/HP_0001272
-Spondylometaphyseal Dysplasia with Cone-Rod Dystrophy	http://purl.obolibrary.org/obo/HP_0002980	http://purl.obolibrary.org/obo/HP_0009381	http://purl.obolibrary.org/obo/HP_0004565	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003025	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0000529	http://purl.obolibrary.org/obo/HP_0000689	http://purl.obolibrary.org/obo/HP_0000548	http://purl.obolibrary.org/obo/HP_0000613	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0002812	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000540	http://purl.obolibrary.org/obo/HP_0003016	http://purl.obolibrary.org/obo/HP_0003300	http://purl.obolibrary.org/obo/HP_0001387	http://purl.obolibrary.org/obo/HP_0000887	http://purl.obolibrary.org/obo/HP_0010049	http://purl.obolibrary.org/obo/HP_0008905	http://purl.obolibrary.org/obo/HP_0000403	http://purl.obolibrary.org/obo/HP_0008821	http://purl.obolibrary.org/obo/HP_0002982	http://purl.obolibrary.org/obo/HP_0002657	http://purl.obolibrary.org/obo/HP_0000483	http://purl.obolibrary.org/obo/HP_0000551	http://purl.obolibrary.org/obo/HP_0003375	http://purl.obolibrary.org/obo/HP_0008002	http://purl.obolibrary.org/obo/HP_0003021	http://purl.obolibrary.org/obo/HP_0003421	http://purl.obolibrary.org/obo/HP_0003307	http://purl.obolibrary.org/obo/HP_0001376	http://purl.obolibrary.org/obo/HP_0007703
-SPINOCEREBELLAR ATAXIA 27	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0003390	http://purl.obolibrary.org/obo/HP_0002078	http://purl.obolibrary.org/obo/HP_0000716	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0007772	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002346	http://purl.obolibrary.org/obo/HP_0002174	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0002310	http://purl.obolibrary.org/obo/HP_0000641	http://purl.obolibrary.org/obo/HP_0000640	http://purl.obolibrary.org/obo/HP_0002354	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002495	http://purl.obolibrary.org/obo/HP_0002066
+Spondylometaphyseal Dysplasia with Cone-Rod Dystrophy	http://purl.obolibrary.org/obo/HP_0002980
+SPINOCEREBELLAR ATAXIA 27	http://purl.obolibrary.org/obo/HP_0002070
 COLE-CARPENTER SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_2050
-Junctional epidermolysis bullosa gravis of Herlitz	http://www.orpha.net/ORDO/Orphanet_79404	http://www.orpha.net/ORDO/Orphanet_305
-Meconium Ileus	http://purl.obolibrary.org/obo/HP_0004401	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0004388
+Junctional epidermolysis bullosa gravis of Herlitz	http://www.orpha.net/ORDO/Orphanet_79404
+Meconium Ileus	http://purl.obolibrary.org/obo/HP_0004401
 Hypochromic microcytic anemia with iron overload	http://www.ebi.ac.uk/efo/EFO_0004272
-NYSTAGMUS 6	http://purl.obolibrary.org/obo/HP_0001417	http://purl.obolibrary.org/obo/HP_0000484	http://purl.obolibrary.org/obo/HP_0000646	http://purl.obolibrary.org/obo/HP_0000666
-SCHIZOPHRENIA	http://www.ebi.ac.uk/efo/EFO_0003108	http://www.ebi.ac.uk/efo/EFO_0000692
-Exudative vitreoretinopathy 6	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0000529	http://purl.obolibrary.org/obo/HP_0000533	http://purl.obolibrary.org/obo/HP_0030490	http://purl.obolibrary.org/obo/HP_0001489	http://purl.obolibrary.org/obo/HP_0000545
+NYSTAGMUS 6	http://purl.obolibrary.org/obo/HP_0001417
+SCHIZOPHRENIA	http://www.ebi.ac.uk/efo/EFO_0003108
+Exudative vitreoretinopathy 6	http://purl.obolibrary.org/obo/HP_0000518
 CONE-ROD DYSTROPHY 5	http://www.orpha.net/ORDO/Orphanet_1872
 AMYOTROPHIC LATERAL SCLEROSIS 6	http://www.ebi.ac.uk/efo/EFO_0000253
-PALMOPLANTAR KERATODERMA	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0000972	http://purl.obolibrary.org/obo/HP_0008404	http://www.orpha.net/ORDO/Orphanet_140966	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000989	http://purl.obolibrary.org/obo/HP_0000982	http://purl.obolibrary.org/obo/HP_0002164	http://purl.obolibrary.org/obo/HP_0000975	http://purl.obolibrary.org/obo/HP_0007759	http://purl.obolibrary.org/obo/HP_0007404	http://purl.obolibrary.org/obo/HP_0008070	http://purl.obolibrary.org/obo/HP_0007957	http://purl.obolibrary.org/obo/HP_0008392	http://purl.obolibrary.org/obo/HP_0002289	http://purl.obolibrary.org/obo/HP_0001036
-XERODERMA PIGMENTOSUM	http://purl.obolibrary.org/obo/HP_0000992	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000762	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002135	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000518	http://www.orpha.net/ORDO/Orphanet_276264	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0011400	http://purl.obolibrary.org/obo/HP_0002671	http://purl.obolibrary.org/obo/HP_0006739	http://purl.obolibrary.org/obo/HP_0001347	http://www.orpha.net/ORDO/Orphanet_910	http://purl.obolibrary.org/obo/HP_0003224	http://purl.obolibrary.org/obo/HP_0001480	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000580	http://purl.obolibrary.org/obo/HP_0000135	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0005328	http://purl.obolibrary.org/obo/HP_0012056	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0004334	http://purl.obolibrary.org/obo/HP_0000568
+PALMOPLANTAR KERATODERMA	http://purl.obolibrary.org/obo/HP_0001371
+XERODERMA PIGMENTOSUM	http://purl.obolibrary.org/obo/HP_0000992
 Rolandic epilepsy with mental retardation and speech dyspraxia	http://www.orpha.net/ORDO/Orphanet_1945
 Iron deficiency anemia	http://purl.obolibrary.org/obo/HP_0001891
-Van der Woude syndrome	http://www.orpha.net/ORDO/Orphanet_294963	http://www.orpha.net/ORDO/Orphanet_888
+Van der Woude syndrome	http://www.orpha.net/ORDO/Orphanet_294963
 Hereditary nonpolyposis colorectal cancer type 7	http://www.orpha.net/ORDO/Orphanet_144
 Deficiency of xanthine oxidase	http://www.orpha.net/ORDO/Orphanet_93601
-T-cell acute lymphoblastic leukemia	http://www.ebi.ac.uk/efo/EFO_0000209	http://www.ebi.ac.uk/efo/EFO_0000365
-Primary dilated cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0004269	http://www.ebi.ac.uk/efo/EFO_0000538
+T-cell acute lymphoblastic leukemia	http://www.ebi.ac.uk/efo/EFO_0000209
+Primary dilated cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000407
 PHOSPHOGLYCERATE DEHYDROGENASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_79351
-HYPOPROTEINEMIA	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002986	http://purl.obolibrary.org/obo/HP_0004315	http://purl.obolibrary.org/obo/HP_0003073	http://purl.obolibrary.org/obo/HP_0003022	http://purl.obolibrary.org/obo/HP_0003075
-KERATITIS-ICHTHYOSIS-DEAFNESS SYNDROME	http://purl.obolibrary.org/obo/HP_0005406	http://purl.obolibrary.org/obo/HP_0000966	http://purl.obolibrary.org/obo/HP_0000962	http://purl.obolibrary.org/obo/HP_0000653	http://purl.obolibrary.org/obo/HP_0008404	http://purl.obolibrary.org/obo/HP_0000495	http://purl.obolibrary.org/obo/HP_0000559	http://purl.obolibrary.org/obo/HP_0012804	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001097	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0002860	http://purl.obolibrary.org/obo/HP_0006380	http://purl.obolibrary.org/obo/HP_0002745	http://purl.obolibrary.org/obo/HP_0002164	http://purl.obolibrary.org/obo/HP_0002987	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0000535	http://purl.obolibrary.org/obo/HP_0001128	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0011492	http://purl.obolibrary.org/obo/HP_0000613	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0000221
+HYPOPROTEINEMIA	http://purl.obolibrary.org/obo/HP_0000007
+KERATITIS-ICHTHYOSIS-DEAFNESS SYNDROME	http://purl.obolibrary.org/obo/HP_0005406
 Autosomal recessive congenital ichthyosis 5	http://www.orpha.net/ORDO/Orphanet_281097
 SYSTEMIC LUPUS ERYTHMATOSUS	http://www.ebi.ac.uk/efo/EFO_0002690
 Atelosteogenesis type 3	http://www.orpha.net/ORDO/Orphanet_56305
 LUPUS NEPHRITIS	http://www.ebi.ac.uk/efo/EFO_0005761
 GREIG CEPHALOPOLYSYNDACTYLY SYNDROME	http://www.orpha.net/ORDO/Orphanet_380
-JOUBERT SYNDROME 5	http://www.orpha.net/ORDO/Orphanet_110	http://www.orpha.net/ORDO/Orphanet_65	http://www.orpha.net/ORDO/Orphanet_475	http://www.orpha.net/ORDO/Orphanet_564
+JOUBERT SYNDROME 5	http://www.orpha.net/ORDO/Orphanet_110
 Left ventricular noncompaction cardiomyopathy	http://purl.obolibrary.org/obo/HP_0011664
 BARAITSER-WINTER SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_2995
-BILIRUBIN	http://purl.obolibrary.org/obo/HP_0002904	http://purl.obolibrary.org/obo/HP_0001626
+BILIRUBIN	http://purl.obolibrary.org/obo/HP_0002904
 TRITANOPIA	http://www.orpha.net/ORDO/Orphanet_88629
-EMERY-DREIFUSS MUSCULAR DYSTROPHY 7	http://purl.obolibrary.org/obo/HP_0000467	http://purl.obolibrary.org/obo/HP_0005110	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003701	http://purl.obolibrary.org/obo/HP_0007126	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0001662	http://purl.obolibrary.org/obo/HP_0003560
+EMERY-DREIFUSS MUSCULAR DYSTROPHY 7	http://purl.obolibrary.org/obo/HP_0000467
 BLAU SYNDROME	http://www.orpha.net/ORDO/Orphanet_90340
-BODY MASS INDEX QUANTITATIVE TRAIT LOCUS 18	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001513
+BODY MASS INDEX QUANTITATIVE TRAIT LOCUS 18	http://purl.obolibrary.org/obo/HP_0000006
 RETINITIS PIGMENTOSA 45	http://www.orpha.net/ORDO/Orphanet_791
-METHYLCOBALAMIN DEFICIENCY	http://purl.obolibrary.org/obo/HP_0002370	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0002156	http://purl.obolibrary.org/obo/HP_0003658	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002160	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003524	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002059	http://purl.obolibrary.org/obo/HP_0003223	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0001889	http://purl.obolibrary.org/obo/HP_0000639
+METHYLCOBALAMIN DEFICIENCY	http://purl.obolibrary.org/obo/HP_0002370
 Anauxetic dysplasia	http://www.orpha.net/ORDO/Orphanet_93347
 Maple syrup urine disease type 1B	http://www.orpha.net/ORDO/Orphanet_511
-CEREBELLAR ATAXIA	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0000307	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000276	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000179	http://purl.obolibrary.org/obo/HP_0002317	http://purl.obolibrary.org/obo/HP_0000414	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0100540	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001350	http://purl.obolibrary.org/obo/HP_0400005	http://www.orpha.net/ORDO/Orphanet_1766	http://purl.obolibrary.org/obo/HP_0002003
+CEREBELLAR ATAXIA	http://purl.obolibrary.org/obo/HP_0001321
 ACROMICRIC DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_969
 Sensorineural deafness and migraine	http://www.ebi.ac.uk/efo/EFO_0001063
 Dilated cardiomyopathy 1II	http://www.ebi.ac.uk/efo/EFO_0000407
-CORTICAL DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_268950	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0002510	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001302	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0002804	http://purl.obolibrary.org/obo/HP_0001339	http://purl.obolibrary.org/obo/HP_0002539	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001989	http://purl.obolibrary.org/obo/HP_0002126	http://purl.obolibrary.org/obo/HP_0000639
+CORTICAL DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_268950
 TRICHOTHIODYSTROPHY 2	http://www.orpha.net/ORDO/Orphanet_33364
-JOUBERT SYNDROME 17	http://www.orpha.net/ORDO/Orphanet_140997	http://www.orpha.net/ORDO/Orphanet_475
-Porphobilinogen synthase deficiency	http://purl.obolibrary.org/obo/HP_0000998	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0008069	http://purl.obolibrary.org/obo/HP_0004374	http://purl.obolibrary.org/obo/HP_0000992	http://purl.obolibrary.org/obo/HP_0008066	http://purl.obolibrary.org/obo/HP_0000708	http://purl.obolibrary.org/obo/HP_0003401	http://purl.obolibrary.org/obo/HP_0011848	http://purl.obolibrary.org/obo/HP_0002203	http://purl.obolibrary.org/obo/HP_0000963	http://purl.obolibrary.org/obo/HP_0000988	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001053	http://purl.obolibrary.org/obo/HP_0001878	http://purl.obolibrary.org/obo/HP_0100021	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0007400	http://purl.obolibrary.org/obo/HP_0003163
+JOUBERT SYNDROME 17	http://www.orpha.net/ORDO/Orphanet_140997
+Porphobilinogen synthase deficiency	http://purl.obolibrary.org/obo/HP_0000998
 AUDITORY NEUROPATHY	http://www.ebi.ac.uk/efo/EFO_0004149
-AMYLOIDOSIS	http://www.orpha.net/ORDO/Orphanet_85451	http://www.orpha.net/ORDO/Orphanet_69
+AMYLOIDOSIS	http://www.orpha.net/ORDO/Orphanet_85451
 MARTSOLF SYNDROME	http://www.orpha.net/ORDO/Orphanet_1387
 HEREDITARY LEIOMYOMATOSIS AND RENAL CELL CANCER	http://www.orpha.net/ORDO/Orphanet_523
 Temtamy preaxial brachydactyly syndrome	http://www.orpha.net/ORDO/Orphanet_363417
 PITUITARY ADENOMA	http://www.orpha.net/ORDO/Orphanet_963
-VITAMIN K-DEPENDENT CLOTTING FACTORS	http://purl.obolibrary.org/obo/HP_0000421	http://purl.obolibrary.org/obo/HP_0005261	http://purl.obolibrary.org/obo/HP_0001892	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0008321	http://purl.obolibrary.org/obo/HP_0008169	http://purl.obolibrary.org/obo/HP_0011858	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0010655	http://purl.obolibrary.org/obo/HP_0009882	http://purl.obolibrary.org/obo/HP_0003645	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0012201
-SPINOCEREBELLAR ATAXIA	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0003680	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0002607	http://purl.obolibrary.org/obo/HP_0004325	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://www.ebi.ac.uk/efo/EFO_0004149	http://purl.obolibrary.org/obo/HP_0000951	http://purl.obolibrary.org/obo/HP_0000678	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0010864	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0000020	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0000998	http://purl.obolibrary.org/obo/HP_0012810	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0011448	http://purl.obolibrary.org/obo/HP_0002198	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0000280	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0006887	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0000729	http://purl.obolibrary.org/obo/HP_0007338	http://purl.obolibrary.org/obo/HP_0012385	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000565	http://purl.obolibrary.org/obo/HP_0000158	http://purl.obolibrary.org/obo/HP_0000657	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0002380	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002169	http://purl.obolibrary.org/obo/HP_0000684	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0030084	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0002078	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0012745	http://purl.obolibrary.org/obo/HP_0004482	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0000289	http://purl.obolibrary.org/obo/HP_0002540	http://purl.obolibrary.org/obo/HP_0002186	http://purl.obolibrary.org/obo/HP_0012471	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0000514	http://purl.obolibrary.org/obo/HP_0000283
-Multiple mitochondrial dysfunctions syndrome 2	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0200134	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001522	http://purl.obolibrary.org/obo/HP_0002878	http://purl.obolibrary.org/obo/HP_0001254	http://purl.obolibrary.org/obo/HP_0008972	http://purl.obolibrary.org/obo/HP_0002093
+VITAMIN K-DEPENDENT CLOTTING FACTORS	http://purl.obolibrary.org/obo/HP_0000421
+SPINOCEREBELLAR ATAXIA	http://purl.obolibrary.org/obo/HP_0001371
+Multiple mitochondrial dysfunctions syndrome 2	http://purl.obolibrary.org/obo/HP_0000007
 Iridogoniodysgenesis	http://www.orpha.net/ORDO/Orphanet_98634
 SCHWARTZ-JAMPEL SYNDROME	http://www.orpha.net/ORDO/Orphanet_800
-Spinocerebellar ataxia 38	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0003477	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000514	http://purl.obolibrary.org/obo/HP_0000639
+Spinocerebellar ataxia 38	http://purl.obolibrary.org/obo/HP_0002070
 BETHLEM MYOPATHY 1	http://www.orpha.net/ORDO/Orphanet_610
-Noonan syndrome and Noonan-related syndrome	http://www.orpha.net/ORDO/Orphanet_98733	http://www.orpha.net/ORDO/Orphanet_1340
+Noonan syndrome and Noonan-related syndrome	http://www.orpha.net/ORDO/Orphanet_98733
 HYPOGONADOTROPIC HYPOGONADISM 8 WITHOUT ANOSMIA	http://www.orpha.net/ORDO/Orphanet_174590
 BANNAYAN-RILEY-RUVALCABA SYNDROME	http://www.orpha.net/ORDO/Orphanet_109
-STARGARDT DISEASE 1	http://www.orpha.net/ORDO/Orphanet_1872	http://www.orpha.net/ORDO/Orphanet_827
+STARGARDT DISEASE 1	http://www.orpha.net/ORDO/Orphanet_1872
 SPONDYLOEPIMETAPHYSEAL DYSPLASIA WITH JOINT LAXITY	http://www.orpha.net/ORDO/Orphanet_93359
 Amyotrophic lateral sclerosis type 8	http://www.ebi.ac.uk/efo/EFO_0000253
 Abnormality of cardiovascular system morphology	http://purl.obolibrary.org/obo/HP_0030680
@@ -614,72 +614,72 @@ CATARACT 2	http://www.ebi.ac.uk/efo/EFO_0001059
 Laron-type isolated somatotropin defect	http://www.orpha.net/ORDO/Orphanet_633
 Cap myopathy 2	http://www.orpha.net/ORDO/Orphanet_171881
 GLUTARIC ACIDEMIA IIC	http://www.orpha.net/ORDO/Orphanet_26791
-Hypogonadotropic hypogonadism 17 with or without anosmia	http://www.orpha.net/ORDO/Orphanet_478	http://www.orpha.net/ORDO/Orphanet_432
-Stapes ankylosis with broad thumb and toes	http://purl.obolibrary.org/obo/HP_0010055	http://purl.obolibrary.org/obo/HP_0009882	http://purl.obolibrary.org/obo/HP_0003189	http://purl.obolibrary.org/obo/HP_0000466	http://purl.obolibrary.org/obo/HP_0000540	http://purl.obolibrary.org/obo/HP_0009765	http://purl.obolibrary.org/obo/HP_0011304	http://purl.obolibrary.org/obo/HP_0001770	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0007943	http://purl.obolibrary.org/obo/HP_0002949	http://purl.obolibrary.org/obo/HP_0009177	http://purl.obolibrary.org/obo/HP_0000430	http://purl.obolibrary.org/obo/HP_0000381	http://purl.obolibrary.org/obo/HP_0000405
+Hypogonadotropic hypogonadism 17 with or without anosmia	http://www.orpha.net/ORDO/Orphanet_478
+Stapes ankylosis with broad thumb and toes	http://purl.obolibrary.org/obo/HP_0010055
 CYANOSIS	http://www.orpha.net/ORDO/Orphanet_280615
 Cerebral autosomal dominant arteriopathy with subcortical infarcts and leukoencephalopathy	http://www.orpha.net/ORDO/Orphanet_136
 Hypohidrotic ectodermal dysplasia with immune deficiency	http://www.orpha.net/ORDO/Orphanet_238468
 SUDDEN DEATH	http://purl.obolibrary.org/obo/HP_0001699
 ACTH deficiency	http://purl.obolibrary.org/obo/HP_0011748
 Congenital disorder of glycosylation type 1M	http://www.orpha.net/ORDO/Orphanet_91131
-Neurofibromatosis	http://www.orpha.net/ORDO/Orphanet_637	http://www.orpha.net/ORDO/Orphanet_636
-HOMOCYSTINURIA	http://www.orpha.net/ORDO/Orphanet_394	http://www.orpha.net/ORDO/Orphanet_171059
-HYPOGONADOTROPIC HYPOGONADISM 11 WITH OR WITHOUT ANOSMIA	http://www.orpha.net/ORDO/Orphanet_478	http://www.orpha.net/ORDO/Orphanet_432
+Neurofibromatosis	http://www.orpha.net/ORDO/Orphanet_637
+HOMOCYSTINURIA	http://www.orpha.net/ORDO/Orphanet_394
+HYPOGONADOTROPIC HYPOGONADISM 11 WITH OR WITHOUT ANOSMIA	http://www.orpha.net/ORDO/Orphanet_478
 REtinitis pigmentosa 62	http://www.orpha.net/ORDO/Orphanet_791
-Lacrimal duct defect	http://purl.obolibrary.org/obo/HP_0000509	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000246	http://purl.obolibrary.org/obo/HP_0009926	http://purl.obolibrary.org/obo/HP_0000564
+Lacrimal duct defect	http://purl.obolibrary.org/obo/HP_0000509
 Dystonia	http://purl.obolibrary.org/obo/HP_0001332
 Neonatal insulin-dependent diabetes mellitus	http://purl.obolibrary.org/obo/HP_0000857
 PLASMINOGEN DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_722
 RETINITIS PIGMENTOSA 33	http://www.orpha.net/ORDO/Orphanet_791
-APHAKIA	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000647	http://purl.obolibrary.org/obo/HP_0007707	http://purl.obolibrary.org/obo/HP_0007779	http://purl.obolibrary.org/obo/HP_0000568	http://purl.obolibrary.org/obo/HP_0000526
-Charcot-Marie-Tooth disease type 2B1	http://www.orpha.net/ORDO/Orphanet_166	http://www.orpha.net/ORDO/Orphanet_98856
-VERTICAL TALUS	http://purl.obolibrary.org/obo/HP_0001369	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001838	http://purl.obolibrary.org/obo/HP_0001848	http://purl.obolibrary.org/obo/HP_0008138	http://purl.obolibrary.org/obo/HP_0003028
+APHAKIA	http://purl.obolibrary.org/obo/HP_0000007
+Charcot-Marie-Tooth disease type 2B1	http://www.orpha.net/ORDO/Orphanet_166
+VERTICAL TALUS	http://purl.obolibrary.org/obo/HP_0001369
 Deficiency of guanidinoacetate methyltransferase	http://www.orpha.net/ORDO/Orphanet_382
 Infantile myofibromatosis 2	http://www.orpha.net/ORDO/Orphanet_2591
-Immunodeficiency 38	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0011274
-HYPOMAGNESEMIA 4	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002917	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002342
-Malformation of the heart	http://www.orpha.net/ORDO/Orphanet_392	http://www.orpha.net/ORDO/Orphanet_88991
+Immunodeficiency 38	http://purl.obolibrary.org/obo/HP_0000007
+HYPOMAGNESEMIA 4	http://purl.obolibrary.org/obo/HP_0001263
+Malformation of the heart	http://www.orpha.net/ORDO/Orphanet_392
 Butyrylcholinesterase deficiency	http://www.orpha.net/ORDO/Orphanet_132
-AICARDI-GOUTIERES SYNDROME 5	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0002135	http://purl.obolibrary.org/obo/HP_0002415	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0009710
-Ichthyosis	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0002123	http://purl.obolibrary.org/obo/HP_0000962	http://purl.obolibrary.org/obo/HP_0002510	http://purl.obolibrary.org/obo/HP_0000958	http://purl.obolibrary.org/obo/HP_0000649	http://purl.obolibrary.org/obo/HP_0010783	http://purl.obolibrary.org/obo/HP_0011003	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002187	http://www.orpha.net/ORDO/Orphanet_79354	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0040189	http://purl.obolibrary.org/obo/HP_0012448	http://purl.obolibrary.org/obo/HP_0002099	http://purl.obolibrary.org/obo/HP_0012444	http://purl.obolibrary.org/obo/HP_0000023
+AICARDI-GOUTIERES SYNDROME 5	http://purl.obolibrary.org/obo/HP_0000007
+Ichthyosis	http://purl.obolibrary.org/obo/HP_0001371
 Pyridoxal 5-phosphate-dependent epilepsy	http://www.ebi.ac.uk/efo/EFO_0000474
-EPILEPTIC ENCEPHALOPATHY	http://purl.obolibrary.org/obo/HP_0002355	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0000546	http://purl.obolibrary.org/obo/HP_0002375	http://purl.obolibrary.org/obo/HP_0000377	http://purl.obolibrary.org/obo/HP_0009830	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0003429	http://purl.obolibrary.org/obo/HP_0002072	http://purl.obolibrary.org/obo/HP_0000341	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000708	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001298	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0002317	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0200134	http://purl.obolibrary.org/obo/HP_0002133	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0002521	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000643	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000322	http://purl.obolibrary.org/obo/HP_0000455	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002069	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0002059	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0002123	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002373	http://purl.obolibrary.org/obo/HP_0000294	http://purl.obolibrary.org/obo/HP_0000574	http://purl.obolibrary.org/obo/HP_0000506	http://purl.obolibrary.org/obo/HP_0100716	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000629	http://purl.obolibrary.org/obo/HP_0000512	http://purl.obolibrary.org/obo/HP_0002540	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0100704	http://purl.obolibrary.org/obo/HP_0012471	http://www.ebi.ac.uk/efo/EFO_0000474	http://purl.obolibrary.org/obo/HP_0002880	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0012448	http://purl.obolibrary.org/obo/HP_0000718	http://purl.obolibrary.org/obo/HP_0012110	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0002827
+EPILEPTIC ENCEPHALOPATHY	http://purl.obolibrary.org/obo/HP_0002355
 Gm2-gangliosidosis	http://www.orpha.net/ORDO/Orphanet_309144
 Idiopathic basal ganglia calcification 1	http://www.orpha.net/ORDO/Orphanet_1980
 PEHO syndrome	http://www.orpha.net/ORDO/Orphanet_2836
-TOOTH AGENESIS	http://www.ebi.ac.uk/efo/EFO_0005410	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000677	http://purl.obolibrary.org/obo/HP_0001423	http://purl.obolibrary.org/obo/HP_0006342	http://purl.obolibrary.org/obo/HP_0000691	http://purl.obolibrary.org/obo/HP_0000668
+TOOTH AGENESIS	http://www.ebi.ac.uk/efo/EFO_0005410
 BARDET-BIEDL SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_110
-XFE PROGEROID SYNDROME	http://purl.obolibrary.org/obo/HP_0002370	http://purl.obolibrary.org/obo/HP_0000958	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0006297	http://purl.obolibrary.org/obo/HP_0001541	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0003510	http://purl.obolibrary.org/obo/HP_0007519	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0004326	http://purl.obolibrary.org/obo/HP_0000490	http://purl.obolibrary.org/obo/HP_0007495	http://purl.obolibrary.org/obo/HP_0001620
+XFE PROGEROID SYNDROME	http://purl.obolibrary.org/obo/HP_0002370
 Cyclical neutropenia	http://www.orpha.net/ORDO/Orphanet_2686
 Acute megakaryoblastic leukemia	http://www.ebi.ac.uk/efo/EFO_0003025
 LEBER CONGENITAL AMAUROSIS 4	http://www.orpha.net/ORDO/Orphanet_65
 SENSORY ATAXIC NEUROPATHY	http://www.orpha.net/ORDO/Orphanet_70595
 HYDROLETHALUS SYNDROME	http://www.ebi.ac.uk/efo/EFO_1000033
 COSTELLO SYNDROME	http://www.orpha.net/ORDO/Orphanet_3071
-EPIDERMOLYSIS BULLOSA	http://purl.obolibrary.org/obo/HP_0100792	http://purl.obolibrary.org/obo/HP_0006288	http://purl.obolibrary.org/obo/HP_0001852	http://purl.obolibrary.org/obo/HP_0003811	http://purl.obolibrary.org/obo/HP_0004295	http://purl.obolibrary.org/obo/HP_0008066	http://purl.obolibrary.org/obo/HP_0009884	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0001741	http://purl.obolibrary.org/obo/HP_0004057	http://purl.obolibrary.org/obo/HP_0000695	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0008094	http://www.orpha.net/ORDO/Orphanet_89843	http://purl.obolibrary.org/obo/HP_0001798	http://purl.obolibrary.org/obo/HP_0200041	http://purl.obolibrary.org/obo/HP_0200042
-Hyperuricemia	http://purl.obolibrary.org/obo/HP_0004719	http://purl.obolibrary.org/obo/HP_0000093	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0012622	http://purl.obolibrary.org/obo/HP_0000127	http://purl.obolibrary.org/obo/HP_0001882	http://purl.obolibrary.org/obo/HP_0001622	http://purl.obolibrary.org/obo/HP_0002902	http://purl.obolibrary.org/obo/HP_0002092	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0005977	http://purl.obolibrary.org/obo/HP_0000103	http://purl.obolibrary.org/obo/HP_0000819	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0002149	http://purl.obolibrary.org/obo/HP_0003554	http://purl.obolibrary.org/obo/HP_0002878	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002917
-Atelosteogenesis type 1	http://www.orpha.net/ORDO/Orphanet_56305	http://www.orpha.net/ORDO/Orphanet_1190
-Menkes kinky-hair syndrome	http://www.orpha.net/ORDO/Orphanet_565	http://www.orpha.net/ORDO/Orphanet_198
-LONG QT SYNDROME 10	http://purl.obolibrary.org/obo/HP_0001657	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001678	http://purl.obolibrary.org/obo/HP_0012266	http://purl.obolibrary.org/obo/HP_0001645	http://purl.obolibrary.org/obo/HP_0005110
-Eiken skeletal dysplasia	http://purl.obolibrary.org/obo/HP_0002663	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002652
-Hb SS disease	http://www.orpha.net/ORDO/Orphanet_163596	http://www.orpha.net/ORDO/Orphanet_848
-Congenital muscular dystrophy-dystroglycanopathy without mental retardation	http://www.ebi.ac.uk/efo/EFO_0003847	http://www.orpha.net/ORDO/Orphanet_97242
-CONGENITAL LIPOMATOUS OVERGROWTH	http://purl.obolibrary.org/obo/HP_0004099	http://purl.obolibrary.org/obo/HP_0004437	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0100559	http://purl.obolibrary.org/obo/HP_0001528	http://purl.obolibrary.org/obo/HP_0010301	http://purl.obolibrary.org/obo/HP_0001852	http://purl.obolibrary.org/obo/HP_0002144	http://purl.obolibrary.org/obo/HP_0000324	http://purl.obolibrary.org/obo/HP_0012032	http://purl.obolibrary.org/obo/HP_0008678	http://purl.obolibrary.org/obo/HP_0001548	http://purl.obolibrary.org/obo/HP_0030680	http://purl.obolibrary.org/obo/HP_0001744
+EPIDERMOLYSIS BULLOSA	http://purl.obolibrary.org/obo/HP_0100792
+Hyperuricemia	http://purl.obolibrary.org/obo/HP_0004719
+Atelosteogenesis type 1	http://www.orpha.net/ORDO/Orphanet_56305
+Menkes kinky-hair syndrome	http://www.orpha.net/ORDO/Orphanet_565
+LONG QT SYNDROME 10	http://purl.obolibrary.org/obo/HP_0001657
+Eiken skeletal dysplasia	http://purl.obolibrary.org/obo/HP_0002663
+Hb SS disease	http://www.orpha.net/ORDO/Orphanet_163596
+Congenital muscular dystrophy-dystroglycanopathy without mental retardation	http://www.ebi.ac.uk/efo/EFO_0003847
+CONGENITAL LIPOMATOUS OVERGROWTH	http://purl.obolibrary.org/obo/HP_0004099
 Neu-laxova syndrome 2	http://www.orpha.net/ORDO/Orphanet_2671
-BECKER MUSCULAR DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_98896	http://www.orpha.net/ORDO/Orphanet_98895
-CLEFT LIP/PALATE-ECTODERMAL DYSPLASIA SYNDROME	http://www.orpha.net/ORDO/Orphanet_139039	http://www.orpha.net/ORDO/Orphanet_3253
-Pseudohypoparathyroidism type 1A	http://www.orpha.net/ORDO/Orphanet_79444	http://www.orpha.net/ORDO/Orphanet_2762	http://www.orpha.net/ORDO/Orphanet_79445	http://www.orpha.net/ORDO/Orphanet_79443
+BECKER MUSCULAR DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_98896
+CLEFT LIP/PALATE-ECTODERMAL DYSPLASIA SYNDROME	http://www.orpha.net/ORDO/Orphanet_139039
+Pseudohypoparathyroidism type 1A	http://www.orpha.net/ORDO/Orphanet_79444
 Neuroferritinopathy	http://www.orpha.net/ORDO/Orphanet_157846
 Neuropathy ataxia retinitis pigmentosa syndrome	http://www.ebi.ac.uk/efo/EFO_0004149
 Glycogen storage disease type 13	http://www.orpha.net/ORDO/Orphanet_79201
 Triglyceride storage disease with ichthyosis	http://www.orpha.net/ORDO/Orphanet_165
-Carcinoma of colon	http://www.ebi.ac.uk/efo/EFO_0000304	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0002939	http://www.ebi.ac.uk/efo/EFO_0000206	http://www.ebi.ac.uk/efo/EFO_0000205	http://www.ebi.ac.uk/efo/EFO_0003060	http://www.ebi.ac.uk/efo/EFO_0000365
+Carcinoma of colon	http://www.ebi.ac.uk/efo/EFO_0000304
 Hurthle cell carcinoma of thyroid	http://www.ebi.ac.uk/efo/EFO_0000313
 Noonan syndrome 8	http://www.orpha.net/ORDO/Orphanet_648
-SEVERE COMBINED IMMUNODEFICIENCY WITH SENSITIVITY TO IONIZING RADIATION	http://purl.obolibrary.org/obo/HP_0000388	http://purl.obolibrary.org/obo/HP_0005359	http://purl.obolibrary.org/obo/HP_0002732	http://purl.obolibrary.org/obo/HP_0002090	http://purl.obolibrary.org/obo/HP_0000155	http://purl.obolibrary.org/obo/HP_0003249	http://purl.obolibrary.org/obo/HP_0002788	http://purl.obolibrary.org/obo/HP_0004430	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0003139	http://purl.obolibrary.org/obo/HP_0001508
+SEVERE COMBINED IMMUNODEFICIENCY WITH SENSITIVITY TO IONIZING RADIATION	http://purl.obolibrary.org/obo/HP_0000388
 PYRUVATE DEHYDROGENASE E1-ALPHA DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_79243
 Central precocious puberty	http://www.orpha.net/ORDO/Orphanet_759
-Epileptic encephalopathy	http://purl.obolibrary.org/obo/HP_0000729	http://purl.obolibrary.org/obo/HP_0002123	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002373	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0000992	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002121	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0006813	http://purl.obolibrary.org/obo/HP_0200134	http://purl.obolibrary.org/obo/HP_0002133	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002521	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0010819
+Epileptic encephalopathy	http://purl.obolibrary.org/obo/HP_0000729
 Hereditary lymphedema type I	http://www.orpha.net/ORDO/Orphanet_79452
 Early infantile epileptic encephalopathy 21	http://www.orpha.net/ORDO/Orphanet_1934
 MAJEED SYNDROME	http://www.orpha.net/ORDO/Orphanet_77297
@@ -689,236 +689,236 @@ Autosomal recessive cutis laxa type 1B	http://www.orpha.net/ORDO/Orphanet_209
 High density lipoprotein deficiency	http://www.orpha.net/ORDO/Orphanet_31153
 Familial partial lipodystrophy 3	http://www.orpha.net/ORDO/Orphanet_98306
 FANCONI-BICKEL SYNDROME	http://www.orpha.net/ORDO/Orphanet_2088
-Early infantile epileptic encephalopathy	http://www.orpha.net/ORDO/Orphanet_33069	http://www.orpha.net/ORDO/Orphanet_1949	http://www.orpha.net/ORDO/Orphanet_1934
+Early infantile epileptic encephalopathy	http://www.orpha.net/ORDO/Orphanet_33069
 COLD-INDUCED SWEATING SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_157820
-CHARCOT-MARIE-TOOTH DISEASE	http://purl.obolibrary.org/obo/HP_0003484	http://purl.obolibrary.org/obo/HP_0007182	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0003438	http://purl.obolibrary.org/obo/HP_0003445	http://purl.obolibrary.org/obo/HP_0000764	http://purl.obolibrary.org/obo/HP_0006916	http://purl.obolibrary.org/obo/HP_0011463	http://purl.obolibrary.org/obo/HP_0000762	http://purl.obolibrary.org/obo/HP_0006958	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007695	http://purl.obolibrary.org/obo/HP_0002359	http://www.orpha.net/ORDO/Orphanet_99955	http://purl.obolibrary.org/obo/HP_0010871	http://purl.obolibrary.org/obo/HP_0011096	http://purl.obolibrary.org/obo/HP_0001765	http://purl.obolibrary.org/obo/HP_0003477	http://purl.obolibrary.org/obo/HP_0007107	http://purl.obolibrary.org/obo/HP_0008180	http://purl.obolibrary.org/obo/HP_0002136	http://purl.obolibrary.org/obo/HP_0000020	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000097	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0006915	http://purl.obolibrary.org/obo/HP_0003693	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0040078	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0008944	http://purl.obolibrary.org/obo/HP_0003676	http://www.ebi.ac.uk/efo/EFO_0000516	http://purl.obolibrary.org/obo/HP_0001290	http://purl.obolibrary.org/obo/HP_0003450	http://purl.obolibrary.org/obo/HP_0000602	http://purl.obolibrary.org/obo/HP_0004466	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0001178	http://www.orpha.net/ORDO/Orphanet_139515	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0001425	http://purl.obolibrary.org/obo/HP_0003382	http://purl.obolibrary.org/obo/HP_0003400	http://purl.obolibrary.org/obo/HP_0003376	http://purl.obolibrary.org/obo/HP_0003481	http://purl.obolibrary.org/obo/HP_0009053	http://purl.obolibrary.org/obo/HP_0000093	http://purl.obolibrary.org/obo/HP_0002355	http://www.orpha.net/ORDO/Orphanet_166	http://purl.obolibrary.org/obo/HP_0009830	http://purl.obolibrary.org/obo/HP_0003429	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0003774	http://purl.obolibrary.org/obo/HP_0003678	http://purl.obolibrary.org/obo/HP_0003447	http://www.orpha.net/ORDO/Orphanet_101082	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0009588	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0003383	http://purl.obolibrary.org/obo/HP_0009046	http://purl.obolibrary.org/obo/HP_0001308	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0003690	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001155	http://purl.obolibrary.org/obo/HP_0003431	http://purl.obolibrary.org/obo/HP_0009027	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0001159	http://purl.obolibrary.org/obo/HP_0000649	http://purl.obolibrary.org/obo/HP_0001760	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0001761	http://www.orpha.net/ORDO/Orphanet_101083	http://purl.obolibrary.org/obo/HP_0003199	http://purl.obolibrary.org/obo/HP_0007149	http://purl.obolibrary.org/obo/HP_0003387	http://www.orpha.net/ORDO/Orphanet_391351	http://purl.obolibrary.org/obo/HP_0003380	http://purl.obolibrary.org/obo/HP_0002751	http://purl.obolibrary.org/obo/HP_0001171	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0004696	http://purl.obolibrary.org/obo/HP_0002460	http://purl.obolibrary.org/obo/HP_0010628	http://purl.obolibrary.org/obo/HP_0012473	http://purl.obolibrary.org/obo/HP_0002515	http://purl.obolibrary.org/obo/HP_0012444	http://purl.obolibrary.org/obo/HP_0002936
+CHARCOT-MARIE-TOOTH DISEASE	http://purl.obolibrary.org/obo/HP_0003484
 FACIOSCAPULOHUMERAL MUSCULAR DYSTROPHY 2	http://www.orpha.net/ORDO/Orphanet_269
 Mitochondrial DNA depletion syndrome 8B (MNGIE type)	http://www.orpha.net/ORDO/Orphanet_35698
 Autosomal dominant nocturnal frontal lobe epilepsy	http://www.orpha.net/ORDO/Orphanet_98784
 Familial renal glucosuria	http://www.orpha.net/ORDO/Orphanet_69076
-Autoimmune polyglandular syndrome type 1	http://www.orpha.net/ORDO/Orphanet_282196	http://www.orpha.net/ORDO/Orphanet_3453
+Autoimmune polyglandular syndrome type 1	http://www.orpha.net/ORDO/Orphanet_282196
 RIDDLE syndrome	http://www.orpha.net/ORDO/Orphanet_420741
-SPINOCEREBELLAR ATAXIA 1	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0001151	http://purl.obolibrary.org/obo/HP_0002072	http://purl.obolibrary.org/obo/HP_0000543	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0001283	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0007006	http://purl.obolibrary.org/obo/HP_0002168	http://purl.obolibrary.org/obo/HP_0000640	http://purl.obolibrary.org/obo/HP_0002542	http://purl.obolibrary.org/obo/HP_0002839	http://purl.obolibrary.org/obo/HP_0007078	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0003448	http://purl.obolibrary.org/obo/HP_0002495	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0003431	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0000623	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003744	http://purl.obolibrary.org/obo/HP_0002078	http://purl.obolibrary.org/obo/HP_0003693	http://purl.obolibrary.org/obo/HP_0002503	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002075	http://purl.obolibrary.org/obo/HP_0002198	http://purl.obolibrary.org/obo/HP_0000641	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0002071	http://purl.obolibrary.org/obo/HP_0007263	http://purl.obolibrary.org/obo/HP_0002073	http://purl.obolibrary.org/obo/HP_0000514
-OSTEOGENESIS IMPERFECTA	http://purl.obolibrary.org/obo/HP_0008921	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0005897	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000260	http://purl.obolibrary.org/obo/HP_0004586	http://purl.obolibrary.org/obo/HP_0002645	http://purl.obolibrary.org/obo/HP_0005474	http://purl.obolibrary.org/obo/HP_0003100	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000707	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0002691	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002982	http://purl.obolibrary.org/obo/HP_0005758	http://purl.obolibrary.org/obo/HP_0003179	http://purl.obolibrary.org/obo/HP_0002092	http://purl.obolibrary.org/obo/HP_0000592	http://purl.obolibrary.org/obo/HP_0000703	http://www.orpha.net/ORDO/Orphanet_666	http://purl.obolibrary.org/obo/HP_0005855	http://purl.obolibrary.org/obo/HP_0003023	http://purl.obolibrary.org/obo/HP_0002757	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0000325	http://purl.obolibrary.org/obo/HP_0000765
-SPASTIC PARAPLEGIA 33	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002064	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0002061	http://purl.obolibrary.org/obo/HP_0007340	http://purl.obolibrary.org/obo/HP_0011448
-Congenital heart defects	http://purl.obolibrary.org/obo/HP_0001650	http://purl.obolibrary.org/obo/HP_0001680	http://purl.obolibrary.org/obo/HP_0001636	http://purl.obolibrary.org/obo/HP_0004383	http://purl.obolibrary.org/obo/HP_0006695	http://purl.obolibrary.org/obo/HP_0001629
-JOUBERT SYNDROME 7	http://www.orpha.net/ORDO/Orphanet_220497	http://www.orpha.net/ORDO/Orphanet_1454	http://www.orpha.net/ORDO/Orphanet_564
-Symphalangism-brachydactyly syndrome	http://purl.obolibrary.org/obo/HP_0010554	http://purl.obolibrary.org/obo/HP_0010109	http://purl.obolibrary.org/obo/HP_0006152	http://purl.obolibrary.org/obo/HP_0000879	http://purl.obolibrary.org/obo/HP_0003416	http://purl.obolibrary.org/obo/HP_0003468	http://purl.obolibrary.org/obo/HP_0008607	http://purl.obolibrary.org/obo/HP_0006385	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0001032	http://purl.obolibrary.org/obo/HP_0000215	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0008368	http://purl.obolibrary.org/obo/HP_0009816	http://purl.obolibrary.org/obo/HP_0008460	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0009843	http://purl.obolibrary.org/obo/HP_0000322	http://purl.obolibrary.org/obo/HP_0001773	http://purl.obolibrary.org/obo/HP_0000920	http://purl.obolibrary.org/obo/HP_0001798	http://purl.obolibrary.org/obo/HP_0003083	http://purl.obolibrary.org/obo/HP_0030084	http://purl.obolibrary.org/obo/HP_0004691	http://purl.obolibrary.org/obo/HP_0000430	http://purl.obolibrary.org/obo/HP_0002967	http://purl.obolibrary.org/obo/HP_0005104	http://purl.obolibrary.org/obo/HP_0009466	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0009702	http://purl.obolibrary.org/obo/HP_0010624	http://purl.obolibrary.org/obo/HP_0000381	http://purl.obolibrary.org/obo/HP_0000954	http://purl.obolibrary.org/obo/HP_0006187	http://purl.obolibrary.org/obo/HP_0005807	http://purl.obolibrary.org/obo/HP_0002515	http://purl.obolibrary.org/obo/HP_0000275	http://purl.obolibrary.org/obo/HP_0005792
+SPINOCEREBELLAR ATAXIA 1	http://purl.obolibrary.org/obo/HP_0002070
+OSTEOGENESIS IMPERFECTA	http://purl.obolibrary.org/obo/HP_0008921
+SPASTIC PARAPLEGIA 33	http://purl.obolibrary.org/obo/HP_0001762
+Congenital heart defects	http://purl.obolibrary.org/obo/HP_0001650
+JOUBERT SYNDROME 7	http://www.orpha.net/ORDO/Orphanet_220497
+Symphalangism-brachydactyly syndrome	http://purl.obolibrary.org/obo/HP_0010554
 NONAKA MYOPATHY	http://www.ebi.ac.uk/efo/EFO_0007323
 Meier-Gorlin syndrome 3	http://www.orpha.net/ORDO/Orphanet_2554
 Recessive dystrophic epidermolysis bullosa	http://www.orpha.net/ORDO/Orphanet_303
 Parkinson disease 9	http://www.ebi.ac.uk/efo/EFO_0002508
-Walker-Warburg congenital muscular dystrophy	http://www.orpha.net/ORDO/Orphanet_97242	http://www.orpha.net/ORDO/Orphanet_899	http://www.orpha.net/ORDO/Orphanet_263
-Choreoathetosis/spasticity	http://purl.obolibrary.org/obo/HP_0002131	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0100660	http://purl.obolibrary.org/obo/HP_0007256	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0002062	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001266	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0003401	http://purl.obolibrary.org/obo/HP_0002315	http://purl.obolibrary.org/obo/HP_0000651
+Walker-Warburg congenital muscular dystrophy	http://www.orpha.net/ORDO/Orphanet_97242
+Choreoathetosis/spasticity	http://purl.obolibrary.org/obo/HP_0002131
 MULTIPLE MYELOMA	http://www.ebi.ac.uk/efo/EFO_0001378
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 12	http://purl.obolibrary.org/obo/HP_0008347	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0001403	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0003200	http://purl.obolibrary.org/obo/HP_0002352	http://purl.obolibrary.org/obo/HP_0011924	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001396	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0002067	http://purl.obolibrary.org/obo/HP_0006989	http://purl.obolibrary.org/obo/HP_0011923	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0000602	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001285	http://purl.obolibrary.org/obo/HP_0002376
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 12	http://purl.obolibrary.org/obo/HP_0008347
 Neuroblastoma 2	http://www.ebi.ac.uk/efo/EFO_0000621
-LONG QT SYNDROME 15	http://purl.obolibrary.org/obo/HP_0001695	http://purl.obolibrary.org/obo/HP_0001657	http://purl.obolibrary.org/obo/HP_0001662
+LONG QT SYNDROME 15	http://purl.obolibrary.org/obo/HP_0001695
 Congenital short bowel syndrome	http://www.orpha.net/ORDO/Orphanet_2301
 BARDET-BIEDL SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_110
-Weill-Marchesani-like syndrome	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000501	http://purl.obolibrary.org/obo/HP_0001083
-Dilated cardiomyopathy 1A	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318
+Weill-Marchesani-like syndrome	http://purl.obolibrary.org/obo/HP_0000007
+Dilated cardiomyopathy 1A	http://www.ebi.ac.uk/efo/EFO_0000407
 Autosomal dominant hypophosphatemic rickets	http://www.orpha.net/ORDO/Orphanet_89937
 WARSAW BREAKAGE SYNDROME	http://www.orpha.net/ORDO/Orphanet_280558
 Pitt-Hopkins-like syndrome 1	http://www.orpha.net/ORDO/Orphanet_221150
-Familial hypertrophic cardiomyopathy 16	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+Familial hypertrophic cardiomyopathy 16	http://www.ebi.ac.uk/efo/EFO_0000318
 Osteochondritis dissecans	http://purl.obolibrary.org/obo/HP_0010886
-Distal myopathy Markesbery-Griggs type	http://www.orpha.net/ORDO/Orphanet_98912	http://www.orpha.net/ORDO/Orphanet_263
-JOUBERT SYNDROME 21	http://www.orpha.net/ORDO/Orphanet_475	http://www.orpha.net/ORDO/Orphanet_564
+Distal myopathy Markesbery-Griggs type	http://www.orpha.net/ORDO/Orphanet_98912
+JOUBERT SYNDROME 21	http://www.orpha.net/ORDO/Orphanet_475
 First degree atrioventricular block	http://purl.obolibrary.org/obo/HP_0011705
-Mental retardation	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0000582	http://www.ebi.ac.uk/efo/EFO_0003847	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0001852	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0004295	http://purl.obolibrary.org/obo/HP_0000817	http://purl.obolibrary.org/obo/HP_0000708	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000276	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0002317	http://purl.obolibrary.org/obo/HP_0000635	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001647	http://purl.obolibrary.org/obo/HP_0000336	http://purl.obolibrary.org/obo/HP_0000678	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0005469	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0002521	http://purl.obolibrary.org/obo/HP_0003477	http://purl.obolibrary.org/obo/HP_0001357	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0002136	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000189	http://purl.obolibrary.org/obo/HP_0000742	http://purl.obolibrary.org/obo/HP_0000049	http://purl.obolibrary.org/obo/HP_0000311	http://purl.obolibrary.org/obo/HP_0000752	http://purl.obolibrary.org/obo/HP_0006855	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0100704	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0000340	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0011228	http://purl.obolibrary.org/obo/HP_0000718	http://purl.obolibrary.org/obo/HP_0000280	http://purl.obolibrary.org/obo/HP_0000400	http://purl.obolibrary.org/obo/HP_0000733	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0000664	http://purl.obolibrary.org/obo/HP_0000713	http://purl.obolibrary.org/obo/HP_0011304	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0003429	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000565	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0002058	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0010804	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002307	http://purl.obolibrary.org/obo/HP_0000322	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000490	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0000233	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0040080	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0000574	http://purl.obolibrary.org/obo/HP_0000506	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0001760	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0002384	http://purl.obolibrary.org/obo/HP_0000194	http://purl.obolibrary.org/obo/HP_0002020	http://purl.obolibrary.org/obo/HP_0000179	http://purl.obolibrary.org/obo/HP_0000960	http://purl.obolibrary.org/obo/HP_0002719	http://purl.obolibrary.org/obo/HP_0000448	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0002360	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0002540	http://purl.obolibrary.org/obo/HP_0002465	http://purl.obolibrary.org/obo/HP_0007370	http://purl.obolibrary.org/obo/HP_0000720	http://www.ebi.ac.uk/efo/EFO_0000474	http://purl.obolibrary.org/obo/HP_0002751	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0000722	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0003307	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0012448	http://purl.obolibrary.org/obo/HP_0002059
-Pancreatic adenocarcinoma	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_1000044	http://www.ebi.ac.uk/efo/EFO_0002618
-FETAL HEMOGLOBIN QUANTITATIVE TRAIT LOCUS 1	http://purl.obolibrary.org/obo/HP_0010472	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001935	http://purl.obolibrary.org/obo/HP_0011904
+Mental retardation	http://purl.obolibrary.org/obo/HP_0001371
+Pancreatic adenocarcinoma	http://www.ebi.ac.uk/efo/EFO_0000311
+FETAL HEMOGLOBIN QUANTITATIVE TRAIT LOCUS 1	http://purl.obolibrary.org/obo/HP_0010472
 Spastic paraplegia 8	http://purl.obolibrary.org/obo/HP_0001258
 Severe myoclonic epilepsy in infancy	http://www.orpha.net/ORDO/Orphanet_33069
 Marinesco-Sjogren syndrome	http://www.orpha.net/ORDO/Orphanet_559
-MANDIBULOACRAL DYSPLASIA WITH TYPE B LIPODYSTROPHY	http://www.orpha.net/ORDO/Orphanet_90154	http://www.orpha.net/ORDO/Orphanet_1662
-HYPERMETHIONINEMIA WITH S-ADENOSYLHOMOCYSTEINE HYDROLASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001638	http://purl.obolibrary.org/obo/HP_0000164	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0003235	http://purl.obolibrary.org/obo/HP_0001249
+MANDIBULOACRAL DYSPLASIA WITH TYPE B LIPODYSTROPHY	http://www.orpha.net/ORDO/Orphanet_90154
+HYPERMETHIONINEMIA WITH S-ADENOSYLHOMOCYSTEINE HYDROLASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
 Antithrombin deficiency	http://www.orpha.net/ORDO/Orphanet_82
 Iga nephropathy	http://www.ebi.ac.uk/efo/EFO_0004194
 Hodgkin lymphoma	http://www.ebi.ac.uk/efo/EFO_0000183
-THREE M SYNDROME 2	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0000307	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0005274	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003691	http://purl.obolibrary.org/obo/HP_0012471	http://purl.obolibrary.org/obo/HP_0000411	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0012428	http://purl.obolibrary.org/obo/HP_0003307	http://purl.obolibrary.org/obo/HP_0003100	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000325	http://purl.obolibrary.org/obo/HP_0000268	http://purl.obolibrary.org/obo/HP_0002007
+THREE M SYNDROME 2	http://purl.obolibrary.org/obo/HP_0000272
 Marles Greenberg Persaud syndrome	http://www.orpha.net/ORDO/Orphanet_2717
 Myositis	http://www.ebi.ac.uk/efo/EFO_0000783
 WAARDENBURG SYNDROME TYPE 1	http://www.orpha.net/ORDO/Orphanet_894
-Polycystic kidney disease	http://www.orpha.net/ORDO/Orphanet_731	http://purl.obolibrary.org/obo/HP_0000113
+Polycystic kidney disease	http://www.orpha.net/ORDO/Orphanet_731
 Scalp ear nipple syndrome	http://www.orpha.net/ORDO/Orphanet_2036
 Ghosal syndrome	http://www.orpha.net/ORDO/Orphanet_1802
 Li-Fraumeni syndrome	http://www.orpha.net/ORDO/Orphanet_524
 LEBER CONGENITAL AMAUROSIS 13	http://www.orpha.net/ORDO/Orphanet_65
-Persistent hyperplastic primary vitreous	http://purl.obolibrary.org/obo/HP_0000555	http://purl.obolibrary.org/obo/HP_0011886	http://purl.obolibrary.org/obo/HP_0007968	http://purl.obolibrary.org/obo/HP_0000565	http://purl.obolibrary.org/obo/HP_0000612	http://purl.obolibrary.org/obo/HP_0000554	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000667	http://purl.obolibrary.org/obo/HP_0009917	http://purl.obolibrary.org/obo/HP_0008052	http://purl.obolibrary.org/obo/HP_0011484	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0000594	http://purl.obolibrary.org/obo/HP_0000557	http://purl.obolibrary.org/obo/HP_0012043	http://purl.obolibrary.org/obo/HP_0007957	http://purl.obolibrary.org/obo/HP_0007899	http://purl.obolibrary.org/obo/HP_0000568
+Persistent hyperplastic primary vitreous	http://purl.obolibrary.org/obo/HP_0000555
 Nephronophthisis 14	http://www.orpha.net/ORDO/Orphanet_2318
 SUBCORTICAL LAMINAR HETEROTOPIA	http://www.orpha.net/ORDO/Orphanet_99796
 EPIPHYSEAL DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_251
 THYROID DYSHORMONOGENESIS 6	http://www.orpha.net/ORDO/Orphanet_95716
 RHABDOMYOSARCOMA	http://www.ebi.ac.uk/efo/EFO_0002918
 X-linked agammaglobulinemia with growth hormone deficiency	http://www.orpha.net/ORDO/Orphanet_632
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 15	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0002317	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0007256	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001513	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0001716	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002500	http://purl.obolibrary.org/obo/HP_0002490	http://purl.obolibrary.org/obo/HP_0001629
-Incontinentia pigmenti syndrome	http://www.ebi.ac.uk/efo/EFO_1000672	http://www.ebi.ac.uk/efo/EFO_1000716
-Renal cell carcinoma	http://www.ebi.ac.uk/efo/EFO_0000681	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0007354	http://www.ebi.ac.uk/efo/EFO_0000239
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 15	http://purl.obolibrary.org/obo/HP_0001337
+Incontinentia pigmenti syndrome	http://www.ebi.ac.uk/efo/EFO_1000672
+Renal cell carcinoma	http://www.ebi.ac.uk/efo/EFO_0000681
 ADAMS-OLIVER SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_974
 RETINITIS PIGMENTOSA 1	http://www.orpha.net/ORDO/Orphanet_791
 Episodic ataxia	http://www.orpha.net/ORDO/Orphanet_211062
-INTESTINAL PSEUDOOBSTRUCTION	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0002021	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0000319	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0000126	http://purl.obolibrary.org/obo/HP_0002566	http://purl.obolibrary.org/obo/HP_0004389	http://purl.obolibrary.org/obo/HP_0011877	http://purl.obolibrary.org/obo/HP_0003270	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0001264
-Parkinson disease 20	http://purl.obolibrary.org/obo/HP_0001268	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000658	http://purl.obolibrary.org/obo/HP_0002067	http://purl.obolibrary.org/obo/HP_0001300	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000605	http://purl.obolibrary.org/obo/HP_0002362	http://purl.obolibrary.org/obo/HP_0002172	http://purl.obolibrary.org/obo/HP_0003676
+INTESTINAL PSEUDOOBSTRUCTION	http://purl.obolibrary.org/obo/HP_0008872
+Parkinson disease 20	http://purl.obolibrary.org/obo/HP_0001268
 Rhizomelic chondrodysplasia punctata	http://www.orpha.net/ORDO/Orphanet_177
 Maturity-onset diabetes of the young	http://www.ebi.ac.uk/efo/EFO_0000400
 Generalized epilepsy with febrile seizures plus type 5	http://www.ebi.ac.uk/efo/EFO_0000474
 RETINITIS PIGMENTOSA 66	http://www.orpha.net/ORDO/Orphanet_791
-Familial hypertrophic cardiomyopathy 3	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+Familial hypertrophic cardiomyopathy 3	http://www.ebi.ac.uk/efo/EFO_0000318
 Autosomal dominant progressive external ophthalmoplegia with mitochondrial DNA deletions 2	http://www.ebi.ac.uk/efo/EFO_0002509
-Galactosylceramide beta-galactosidase deficiency	http://purl.obolibrary.org/obo/HP_0007141	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0001973	http://purl.obolibrary.org/obo/HP_0001954	http://purl.obolibrary.org/obo/HP_0002180	http://purl.obolibrary.org/obo/HP_0002506	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000762	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0006801	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0011096	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002191	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0007928	http://purl.obolibrary.org/obo/HP_0002333	http://purl.obolibrary.org/obo/HP_0002922	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0007305
-Alzheimer disease	http://www.ebi.ac.uk/efo/EFO_0003096	http://www.ebi.ac.uk/efo/EFO_0000249
+Galactosylceramide beta-galactosidase deficiency	http://purl.obolibrary.org/obo/HP_0007141
+Alzheimer disease	http://www.ebi.ac.uk/efo/EFO_0003096
 SPONDYLOEPIPHYSEAL DYSPLASIA CONGENITA	http://www.orpha.net/ORDO/Orphanet_94068
 4-Alpha-hydroxyphenylpyruvate hydroxylase deficiency	http://www.orpha.net/ORDO/Orphanet_2118
-MYOCLONIC-ATONIC EPILEPSY	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0002121
+MYOCLONIC-ATONIC EPILEPSY	http://purl.obolibrary.org/obo/HP_0002650
 MENTAL RETARDATION-HYPOTONIC FACIES SYNDROME	http://www.ebi.ac.uk/efo/EFO_0003847
 C-like syndrome	http://www.orpha.net/ORDO/Orphanet_97297
 NEPHRONOPHTHISIS 1	http://www.orpha.net/ORDO/Orphanet_655
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 6	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002375	http://purl.obolibrary.org/obo/HP_0001271	http://purl.obolibrary.org/obo/HP_0002134	http://purl.obolibrary.org/obo/HP_0002445	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0003200	http://purl.obolibrary.org/obo/HP_0011398	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0002747	http://purl.obolibrary.org/obo/HP_0002380	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0009025	http://purl.obolibrary.org/obo/HP_0002490	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0003542
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 6	http://purl.obolibrary.org/obo/HP_0002151
 Pili torti-deafness syndrome	http://www.orpha.net/ORDO/Orphanet_123
-Primordial Dwarfism	http://purl.obolibrary.org/obo/HP_0008551	http://purl.obolibrary.org/obo/HP_0100864	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0200055	http://purl.obolibrary.org/obo/HP_0000276	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0009882	http://purl.obolibrary.org/obo/HP_0000164	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0010743	http://purl.obolibrary.org/obo/HP_0000490	http://purl.obolibrary.org/obo/HP_0000798	http://purl.obolibrary.org/obo/HP_0003187	http://purl.obolibrary.org/obo/HP_0004590	http://purl.obolibrary.org/obo/HP_0000060	http://purl.obolibrary.org/obo/HP_0000307	http://purl.obolibrary.org/obo/HP_0010579	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0010049	http://purl.obolibrary.org/obo/HP_0000448	http://purl.obolibrary.org/obo/HP_0008839	http://purl.obolibrary.org/obo/HP_0000819	http://purl.obolibrary.org/obo/HP_0001792	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0008070	http://purl.obolibrary.org/obo/HP_0002515	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0000325	http://purl.obolibrary.org/obo/HP_0003498	http://purl.obolibrary.org/obo/HP_0001620	http://purl.obolibrary.org/obo/HP_0000256
-GLUCOCORTICOID DEFICIENCY 2	http://purl.obolibrary.org/obo/HP_0000953	http://purl.obolibrary.org/obo/HP_0008163	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003154	http://purl.obolibrary.org/obo/HP_0001988
+Primordial Dwarfism	http://purl.obolibrary.org/obo/HP_0008551
+GLUCOCORTICOID DEFICIENCY 2	http://purl.obolibrary.org/obo/HP_0000953
 Bamforth syndrome	http://www.orpha.net/ORDO/Orphanet_1226
-Digitorenocerebral syndrome	http://purl.obolibrary.org/obo/HP_0001305	http://purl.obolibrary.org/obo/HP_0008404	http://purl.obolibrary.org/obo/HP_0000104	http://purl.obolibrary.org/obo/HP_0002714	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0011003	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0009882	http://purl.obolibrary.org/obo/HP_0002164	http://purl.obolibrary.org/obo/HP_0000951	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0001798	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0030680	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0000232	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0008619	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000448	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0001199	http://purl.obolibrary.org/obo/HP_0000414	http://purl.obolibrary.org/obo/HP_0011476	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0000800	http://purl.obolibrary.org/obo/HP_0000280	http://purl.obolibrary.org/obo/HP_0002059
+Digitorenocerebral syndrome	http://purl.obolibrary.org/obo/HP_0001305
 Non-syndromic genetic deafness	http://www.orpha.net/ORDO/Orphanet_87884
 Mitochondrial DNA-depletion syndrome 3	http://www.orpha.net/ORDO/Orphanet_68380
 BETHLEM MYOPATHY 2	http://www.orpha.net/ORDO/Orphanet_610
-Preaxial polydactyly 2	http://purl.obolibrary.org/obo/HP_0100258	http://purl.obolibrary.org/obo/HP_0001199
+Preaxial polydactyly 2	http://purl.obolibrary.org/obo/HP_0100258
 BARE LYMPHOCYTE SYNDROME	http://www.orpha.net/ORDO/Orphanet_572
 Cranioectodermal dysplasia 2	http://www.orpha.net/ORDO/Orphanet_1515
 RETINITIS PIGMENTOSA 23	http://www.orpha.net/ORDO/Orphanet_791
-HYPOMAGNESEMIA 5	http://purl.obolibrary.org/obo/HP_0000787	http://purl.obolibrary.org/obo/HP_0005567	http://purl.obolibrary.org/obo/HP_0012637	http://purl.obolibrary.org/obo/HP_0000112	http://purl.obolibrary.org/obo/HP_0000567	http://purl.obolibrary.org/obo/HP_0012622	http://purl.obolibrary.org/obo/HP_0100530	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0012608	http://purl.obolibrary.org/obo/HP_0000790	http://purl.obolibrary.org/obo/HP_0000121	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000010	http://purl.obolibrary.org/obo/HP_0002150	http://purl.obolibrary.org/obo/HP_0001116	http://purl.obolibrary.org/obo/HP_0002917	http://purl.obolibrary.org/obo/HP_0000547	http://purl.obolibrary.org/obo/HP_0007703	http://purl.obolibrary.org/obo/HP_0000639
+HYPOMAGNESEMIA 5	http://purl.obolibrary.org/obo/HP_0000787
 LATHOSTEROLOSIS	http://www.orpha.net/ORDO/Orphanet_46059
-LEUKOENCEPHALOPATHY	http://www.orpha.net/ORDO/Orphanet_135	http://purl.obolibrary.org/obo/HP_0002514	http://purl.obolibrary.org/obo/HP_0011344	http://purl.obolibrary.org/obo/HP_0002305	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0001251	http://www.orpha.net/ORDO/Orphanet_99853	http://purl.obolibrary.org/obo/HP_0000295	http://purl.obolibrary.org/obo/HP_0002352	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0002465	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0007042	http://purl.obolibrary.org/obo/HP_0011400	http://purl.obolibrary.org/obo/HP_0000639
+LEUKOENCEPHALOPATHY	http://www.orpha.net/ORDO/Orphanet_135
 CANCER PROGRESSION AND TUMOR CELL MOTILITY	http://www.ebi.ac.uk/efo/EFO_0000311
-Microcornea	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0000445	http://purl.obolibrary.org/obo/HP_0000506	http://purl.obolibrary.org/obo/HP_0000455	http://purl.obolibrary.org/obo/HP_0007787
+Microcornea	http://purl.obolibrary.org/obo/HP_0000007
 MYH-associated polyposis	http://www.orpha.net/ORDO/Orphanet_220460
-ALTERNATING HEMIPLEGIA OF CHILDHOOD 2	http://www.orpha.net/ORDO/Orphanet_71517	http://www.orpha.net/ORDO/Orphanet_2131
-Noonan syndrome with multiple lentigines	http://www.orpha.net/ORDO/Orphanet_500	http://www.orpha.net/ORDO/Orphanet_648
+ALTERNATING HEMIPLEGIA OF CHILDHOOD 2	http://www.orpha.net/ORDO/Orphanet_71517
+Noonan syndrome with multiple lentigines	http://www.orpha.net/ORDO/Orphanet_500
 Noonan-like facies	http://purl.obolibrary.org/obo/HP_0001642
 BODY MASS INDEX QUANTITATIVE TRAIT LOCUS 12	http://www.ebi.ac.uk/efo/EFO_0004340
 FOVEAL HYPOPLASIA 1 WITH CATARACT	http://www.orpha.net/ORDO/Orphanet_2253
-SPLIT-HAND/FOOT MALFORMATION 1 WITH SENSORINEURAL HEARING LOSS	http://purl.obolibrary.org/obo/HP_0001839	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001597	http://purl.obolibrary.org/obo/HP_0001171	http://purl.obolibrary.org/obo/HP_0001182	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0003510
+SPLIT-HAND/FOOT MALFORMATION 1 WITH SENSORINEURAL HEARING LOSS	http://purl.obolibrary.org/obo/HP_0001839
 Osteogenesis imperfecta type 9	http://www.orpha.net/ORDO/Orphanet_666
-Mirror movements	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0001335
+Mirror movements	http://purl.obolibrary.org/obo/HP_0000006
 JACKSON-WEISS SYNDROME	http://www.orpha.net/ORDO/Orphanet_1540
-Familial hypertrophic cardiomyopathy 18	http://www.ebi.ac.uk/efo/EFO_0004278	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+Familial hypertrophic cardiomyopathy 18	http://www.ebi.ac.uk/efo/EFO_0004278
 Porencephaly 2	http://www.orpha.net/ORDO/Orphanet_2940
-HYPERINSULINEMIC HYPOGLYCEMIA	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002173	http://purl.obolibrary.org/obo/HP_0008283	http://purl.obolibrary.org/obo/HP_0000825	http://purl.obolibrary.org/obo/HP_0001325	http://purl.obolibrary.org/obo/HP_0000819	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001249
+HYPERINSULINEMIC HYPOGLYCEMIA	http://purl.obolibrary.org/obo/HP_0000007
 Metachondromatosis	http://www.orpha.net/ORDO/Orphanet_2499
-Freeman-Sheldon syndrome	http://www.orpha.net/ORDO/Orphanet_2053	http://www.orpha.net/ORDO/Orphanet_1147
-TREMOR	http://purl.obolibrary.org/obo/HP_0002174	http://purl.obolibrary.org/obo/HP_0000006
-OSTEOGENESIS IMPERFECTA TYPE I	http://www.orpha.net/ORDO/Orphanet_216796	http://www.orpha.net/ORDO/Orphanet_216820
-NOONAN SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_500	http://www.orpha.net/ORDO/Orphanet_648
-Multiple myeloma	http://www.ebi.ac.uk/efo/EFO_0001378	http://www.ebi.ac.uk/efo/EFO_0005584
-Influenza	http://www.ebi.ac.uk/efo/EFO_0001669	http://www.ebi.ac.uk/efo/EFO_0007328
-MEGALENCEPHALIC LEUKOENCEPHALOPATHY WITH SUBCORTICAL CYSTS 2A	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001355	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0007341	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002344	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0002059
+Freeman-Sheldon syndrome	http://www.orpha.net/ORDO/Orphanet_2053
+TREMOR	http://purl.obolibrary.org/obo/HP_0002174
+OSTEOGENESIS IMPERFECTA TYPE I	http://www.orpha.net/ORDO/Orphanet_216796
+NOONAN SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_500
+Multiple myeloma	http://www.ebi.ac.uk/efo/EFO_0001378
+Influenza	http://www.ebi.ac.uk/efo/EFO_0001669
+MEGALENCEPHALIC LEUKOENCEPHALOPATHY WITH SUBCORTICAL CYSTS 2A	http://purl.obolibrary.org/obo/HP_0001270
 Progressive supranuclear ophthalmoplegia	http://www.orpha.net/ORDO/Orphanet_683
 Hereditary factor II deficiency disease	http://www.orpha.net/ORDO/Orphanet_325
 Familial platelet disorder with associated myeloid malignancy	http://www.orpha.net/ORDO/Orphanet_71290
-Benign Familial Neonatal Infantile Seizures	http://www.orpha.net/ORDO/Orphanet_140927	http://www.orpha.net/ORDO/Orphanet_1934
+Benign Familial Neonatal Infantile Seizures	http://www.orpha.net/ORDO/Orphanet_140927
 FLECK CORNEAL DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_98970
-GLAUCOMA 3	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007957	http://purl.obolibrary.org/obo/HP_0008007	http://purl.obolibrary.org/obo/HP_0001083	http://purl.obolibrary.org/obo/HP_0000613
+GLAUCOMA 3	http://purl.obolibrary.org/obo/HP_0000007
 Chronic intestinal pseudoobstruction	http://www.orpha.net/ORDO/Orphanet_2978
-facial dysmorphism	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0001176
-Astrocytoma	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0000272
+facial dysmorphism	http://purl.obolibrary.org/obo/HP_0001999
+Astrocytoma	http://www.ebi.ac.uk/efo/EFO_0000311
 Osteogenesis imperfecta type 12	http://www.orpha.net/ORDO/Orphanet_666
-MEGALOCORNEA	http://purl.obolibrary.org/obo/HP_0011487	http://purl.obolibrary.org/obo/HP_0001132	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0007836	http://purl.obolibrary.org/obo/HP_0000485	http://purl.obolibrary.org/obo/HP_0000541	http://purl.obolibrary.org/obo/HP_0001084	http://purl.obolibrary.org/obo/HP_0000483	http://purl.obolibrary.org/obo/HP_0100693
-Combined oxidative phosphorylation deficiency 18	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001972
+MEGALOCORNEA	http://purl.obolibrary.org/obo/HP_0011487
+Combined oxidative phosphorylation deficiency 18	http://purl.obolibrary.org/obo/HP_0002151
 NEPHRONOPHTHISIS 18	http://www.orpha.net/ORDO/Orphanet_655
-SLOWED NERVE CONDUCTION VELOCITY	http://purl.obolibrary.org/obo/HP_0003383	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000762	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0011096
+SLOWED NERVE CONDUCTION VELOCITY	http://purl.obolibrary.org/obo/HP_0003383
 NEPHRONOPHTHISIS 12	http://www.orpha.net/ORDO/Orphanet_655
 PSEUDOHYPOPARATHYROIDISM	http://www.orpha.net/ORDO/Orphanet_97593
 Methylmalonic acidemia with homocystinuria	http://www.orpha.net/ORDO/Orphanet_26
 WARBURG MICRO SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_2510
 Seizures	http://purl.obolibrary.org/obo/HP_0001250
-GLUTAMINE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0001987	http://purl.obolibrary.org/obo/HP_0003429	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0001298	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002416	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001662	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0007109	http://purl.obolibrary.org/obo/HP_0011344	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0002104	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0000988	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0002983	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0001522	http://purl.obolibrary.org/obo/HP_0012444
+GLUTAMINE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001371
 Meier-Gorlin syndrome 1	http://www.orpha.net/ORDO/Orphanet_2554
 JOUBERT SYNDROME 16	http://www.orpha.net/ORDO/Orphanet_475
 RETINITIS PIGMENTOSA 70	http://www.orpha.net/ORDO/Orphanet_791
 SAETHRE-CHOTZEN SYNDROME WITH EYELID ANOMALIES	http://www.orpha.net/ORDO/Orphanet_794
-DIARRHEA 5	http://purl.obolibrary.org/obo/HP_0001369	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0011473	http://purl.obolibrary.org/obo/HP_0002041	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0001508
-Immunodeficiency 36	http://purl.obolibrary.org/obo/HP_0002718	http://purl.obolibrary.org/obo/HP_0004313	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0002721
+DIARRHEA 5	http://purl.obolibrary.org/obo/HP_0001369
+Immunodeficiency 36	http://purl.obolibrary.org/obo/HP_0002718
 Dystonia 1	http://purl.obolibrary.org/obo/HP_0001332
 Atrial myxoma	http://www.orpha.net/ORDO/Orphanet_615
 MASP2 DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_331187
-CYSTIC FIBROSIS	http://www.orpha.net/ORDO/Orphanet_586	http://www.orpha.net/ORDO/Orphanet_48	http://www.orpha.net/ORDO/Orphanet_676
-SPASTIC PARAPLEGIA 49	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000475	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000678	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0002871	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000294	http://purl.obolibrary.org/obo/HP_0002064	http://purl.obolibrary.org/obo/HP_0000311	http://purl.obolibrary.org/obo/HP_0002020	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002059
-B cell non-Hodgkin lymphoma	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0000574
+CYSTIC FIBROSIS	http://www.orpha.net/ORDO/Orphanet_586
+SPASTIC PARAPLEGIA 49	http://purl.obolibrary.org/obo/HP_0001310
+B cell non-Hodgkin lymphoma	http://www.ebi.ac.uk/efo/EFO_0000311
 Meier-Gorlin syndrome 4	http://www.orpha.net/ORDO/Orphanet_2554
-Hypertrophic cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
-Dilated cardiomyopathy 1R	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318
+Hypertrophic cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000407
+Dilated cardiomyopathy 1R	http://www.ebi.ac.uk/efo/EFO_0000407
 Sideroblastic anemia	http://www.orpha.net/ORDO/Orphanet_1047
-Atypical Rett syndrome	http://www.orpha.net/ORDO/Orphanet_3095	http://www.orpha.net/ORDO/Orphanet_1934
+Atypical Rett syndrome	http://www.orpha.net/ORDO/Orphanet_3095
 Familial encephalopathy with neuroserpin inclusion bodies	http://www.orpha.net/ORDO/Orphanet_85110
 Pyknodysostosis	http://www.orpha.net/ORDO/Orphanet_763
 Congenital cystic disease of liver	http://www.orpha.net/ORDO/Orphanet_2924
 LETHAL CONGENITAL CONTRACTURAL SYNDROME 3	http://www.ebi.ac.uk/efo/EFO_0003899
 LYSINURIC PROTEIN INTOLERANCE	http://www.orpha.net/ORDO/Orphanet_470
-ENDPLATE ACETYLCHOLINESTERASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0003436	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0003473	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002747	http://purl.obolibrary.org/obo/HP_0003443	http://purl.obolibrary.org/obo/HP_0003388	http://purl.obolibrary.org/obo/HP_0003690	http://purl.obolibrary.org/obo/HP_0000597	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002715	http://purl.obolibrary.org/obo/HP_0003403	http://purl.obolibrary.org/obo/HP_0003324	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0003199	http://purl.obolibrary.org/obo/HP_0001612	http://purl.obolibrary.org/obo/HP_0003554	http://purl.obolibrary.org/obo/HP_0003307
+ENDPLATE ACETYLCHOLINESTERASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000508
 MITOCHONDRIAL PYRUVATE CARRIER DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_447784
 CHILD SYNDROME	http://www.orpha.net/ORDO/Orphanet_139
 Congenital amegakaryocytic thrombocytopenia	http://www.orpha.net/ORDO/Orphanet_3319
 MELNICK-NEEDLES SYNDROME	http://www.orpha.net/ORDO/Orphanet_2484
 PYRUVATE DEHYDROGENASE E2 DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_79244
 Non-ketotic hyperglycinemia	http://www.orpha.net/ORDO/Orphanet_407
-Legionellosis	http://www.ebi.ac.uk/efo/EFO_0002690	http://www.ebi.ac.uk/efo/EFO_0007342
+Legionellosis	http://www.ebi.ac.uk/efo/EFO_0002690
 Enamel-renal syndrome	http://www.orpha.net/ORDO/Orphanet_1031
 Peroxisome biogenesis disorder 13A	http://www.orpha.net/ORDO/Orphanet_79189
 ACHALASIA-ALACRIMA SYNDROME	http://www.orpha.net/ORDO/Orphanet_869
 Down syndrome	http://www.ebi.ac.uk/efo/EFO_0001064
 MULTIPLE SYNOSTOSES SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_3237
-CARBONIC ANHYDRASE VA DEFICIENCY	http://purl.obolibrary.org/obo/HP_0003348	http://purl.obolibrary.org/obo/HP_0002789	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0001987	http://purl.obolibrary.org/obo/HP_0001993	http://purl.obolibrary.org/obo/HP_0001950	http://purl.obolibrary.org/obo/HP_0001254	http://purl.obolibrary.org/obo/HP_0001942	http://purl.obolibrary.org/obo/HP_0001943
-Indifference to pain	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000458	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0004409	http://purl.obolibrary.org/obo/HP_0007021	http://purl.obolibrary.org/obo/HP_0002661
-Turcot syndrome	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0003401	http://purl.obolibrary.org/obo/HP_0200008	http://purl.obolibrary.org/obo/HP_0100615	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0100743	http://purl.obolibrary.org/obo/HP_0000738	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0010784	http://purl.obolibrary.org/obo/HP_0002888	http://purl.obolibrary.org/obo/HP_0002027	http://purl.obolibrary.org/obo/HP_0003006	http://purl.obolibrary.org/obo/HP_0010786	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0007256	http://purl.obolibrary.org/obo/HP_0100576	http://purl.obolibrary.org/obo/HP_0001824	http://purl.obolibrary.org/obo/HP_0002239	http://purl.obolibrary.org/obo/HP_0002894	http://purl.obolibrary.org/obo/HP_0002885	http://purl.obolibrary.org/obo/HP_0001438	http://purl.obolibrary.org/obo/HP_0002017	http://purl.obolibrary.org/obo/HP_0001123	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0002354	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0100273	http://purl.obolibrary.org/obo/HP_0001034	http://purl.obolibrary.org/obo/HP_0100843	http://purl.obolibrary.org/obo/HP_0100835	http://purl.obolibrary.org/obo/HP_0000997	http://purl.obolibrary.org/obo/HP_0010524	http://purl.obolibrary.org/obo/HP_0001909	http://purl.obolibrary.org/obo/HP_0002665	http://purl.obolibrary.org/obo/HP_0007018	http://purl.obolibrary.org/obo/HP_0100242	http://purl.obolibrary.org/obo/HP_0002896	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0010622	http://purl.obolibrary.org/obo/HP_0002671	http://purl.obolibrary.org/obo/HP_0002859	http://purl.obolibrary.org/obo/HP_0002516	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0008069	http://purl.obolibrary.org/obo/HP_0009733	http://purl.obolibrary.org/obo/HP_0004374	http://purl.obolibrary.org/obo/HP_0000957	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0001274	http://purl.obolibrary.org/obo/HP_0100031	http://purl.obolibrary.org/obo/HP_0002024
-Familial hypertrophic cardiomyopathy 17	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+CARBONIC ANHYDRASE VA DEFICIENCY	http://purl.obolibrary.org/obo/HP_0003348
+Indifference to pain	http://purl.obolibrary.org/obo/HP_0000007
+Turcot syndrome	http://purl.obolibrary.org/obo/HP_0001371
+Familial hypertrophic cardiomyopathy 17	http://www.ebi.ac.uk/efo/EFO_0000318
 SHORT-RIB THORACIC DYSPLASIA WITHOUT POLYDACTYLY	http://www.orpha.net/ORDO/Orphanet_2913
 ATRIAL SEPTAL DEFECT 2	http://www.ebi.ac.uk/efo/EFO_1000825
-SCAPULOPERONEAL SPINAL MUSCULAR ATROPHY	http://www.orpha.net/ORDO/Orphanet_431255	http://www.orpha.net/ORDO/Orphanet_166	http://www.orpha.net/ORDO/Orphanet_206713
+SCAPULOPERONEAL SPINAL MUSCULAR ATROPHY	http://www.orpha.net/ORDO/Orphanet_431255
 PORPHYRIA	http://www.orpha.net/ORDO/Orphanet_738
 Monoamine oxidase A deficiency	http://www.orpha.net/ORDO/Orphanet_3057
 Spastic paraplegia 26	http://purl.obolibrary.org/obo/HP_0001258
 Early infantile epileptic encephalopathy 18	http://www.orpha.net/ORDO/Orphanet_1934
 Mitochondrial DNA depletion syndrome 5 (encephalomyopathic with or without methylmalonic aciduria)	http://www.orpha.net/ORDO/Orphanet_35698
-Congenital diaphragmatic hernia	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0003777	http://www.ebi.ac.uk/efo/EFO_0007216
-Thrombocytopenia	http://www.orpha.net/ORDO/Orphanet_853	http://www.ebi.ac.uk/efo/EFO_0004272	http://purl.obolibrary.org/obo/HP_0001873
-HENNEKAM LYMPHANGIECTASIA-LYMPHEDEMA SYNDROME 2	http://purl.obolibrary.org/obo/HP_0008551	http://purl.obolibrary.org/obo/HP_0012368	http://purl.obolibrary.org/obo/HP_0002593	http://purl.obolibrary.org/obo/HP_0005183	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0000581	http://purl.obolibrary.org/obo/HP_0012385	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0001004	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0006521	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0040079
+Congenital diaphragmatic hernia	http://www.ebi.ac.uk/efo/EFO_0000311
+Thrombocytopenia	http://www.orpha.net/ORDO/Orphanet_853
+HENNEKAM LYMPHANGIECTASIA-LYMPHEDEMA SYNDROME 2	http://purl.obolibrary.org/obo/HP_0008551
 SAETHRE-CHOTZEN SYNDROME	http://www.orpha.net/ORDO/Orphanet_794
 COWDEN SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_201
 Obesity	http://www.ebi.ac.uk/efo/EFO_0001073
-THYROID HORMONE RESISTANCE	http://purl.obolibrary.org/obo/HP_0000853	http://purl.obolibrary.org/obo/HP_0007018	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0010655	http://purl.obolibrary.org/obo/HP_0002925	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0000836	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0011788	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002930	http://www.orpha.net/ORDO/Orphanet_3221
+THYROID HORMONE RESISTANCE	http://purl.obolibrary.org/obo/HP_0000853
 Parkinson disease 6	http://www.ebi.ac.uk/efo/EFO_0002508
 GLIOMA SUSCEPTIBILITY 9	http://www.orpha.net/ORDO/Orphanet_182067
 Bilateral right-sidedness sequence	http://www.orpha.net/ORDO/Orphanet_97548
 Picks disease	http://www.ebi.ac.uk/efo/EFO_0003096
-SEVERE COMBINED IMMUNODEFICIENCY	http://www.orpha.net/ORDO/Orphanet_39041	http://www.orpha.net/ORDO/Orphanet_183660
+SEVERE COMBINED IMMUNODEFICIENCY	http://www.orpha.net/ORDO/Orphanet_39041
 Acrocallosal syndrome	http://www.orpha.net/ORDO/Orphanet_36
 BLEPHAROPHIMOSIS	http://www.orpha.net/ORDO/Orphanet_233
 Congenital aniridia	http://www.orpha.net/ORDO/Orphanet_77
 JOUBERT SYNDROME 14	http://www.orpha.net/ORDO/Orphanet_475
-Leigh syndrome	http://www.orpha.net/ORDO/Orphanet_123512	http://www.orpha.net/ORDO/Orphanet_506	http://www.orpha.net/ORDO/Orphanet_255210	http://www.orpha.net/ORDO/Orphanet_254905	http://www.orpha.net/ORDO/Orphanet_289527	http://www.orpha.net/ORDO/Orphanet_550	http://www.orpha.net/ORDO/Orphanet_104
-COLORBLINDNESS	http://purl.obolibrary.org/obo/HP_0011520	http://purl.obolibrary.org/obo/HP_0001419
+Leigh syndrome	http://www.orpha.net/ORDO/Orphanet_123512
+COLORBLINDNESS	http://purl.obolibrary.org/obo/HP_0011520
 Tietz syndrome	http://www.orpha.net/ORDO/Orphanet_42665
 LEGIUS SYNDROME	http://www.orpha.net/ORDO/Orphanet_137605
-Hyperkalemic Periodic Paralysis Type 1	http://www.orpha.net/ORDO/Orphanet_206976	http://www.orpha.net/ORDO/Orphanet_682	http://www.orpha.net/ORDO/Orphanet_684
+Hyperkalemic Periodic Paralysis Type 1	http://www.orpha.net/ORDO/Orphanet_206976
 Spondylocostal dysostosis 1	http://www.orpha.net/ORDO/Orphanet_364559
-LETHAL ARTHROGRYPOSIS WITH ANTERIOR HORN CELL DISEASE	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0003811	http://purl.obolibrary.org/obo/HP_0006802	http://purl.obolibrary.org/obo/HP_0007277	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0002804	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0001989
+LETHAL ARTHROGRYPOSIS WITH ANTERIOR HORN CELL DISEASE	http://purl.obolibrary.org/obo/HP_0000007
 DIARRHEA 8	http://purl.obolibrary.org/obo/HP_0002014
 Mental retardation 3	http://www.ebi.ac.uk/efo/EFO_0003847
 Isolated follicle-stimulating hormone deficiency	http://www.orpha.net/ORDO/Orphanet_52901
-GLUCOCORTICOID RESISTANCE	http://purl.obolibrary.org/obo/HP_0000789	http://purl.obolibrary.org/obo/HP_0000739	http://purl.obolibrary.org/obo/HP_0000858	http://purl.obolibrary.org/obo/HP_0012378	http://purl.obolibrary.org/obo/HP_0000822	http://www.orpha.net/ORDO/Orphanet_786	http://purl.obolibrary.org/obo/HP_0001943	http://purl.obolibrary.org/obo/HP_0200114
+GLUCOCORTICOID RESISTANCE	http://purl.obolibrary.org/obo/HP_0000789
 MARSHALL-SMITH SYNDROME	http://www.orpha.net/ORDO/Orphanet_561
-Cocoon syndrome	http://purl.obolibrary.org/obo/HP_0000042	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000963	http://purl.obolibrary.org/obo/HP_0009939	http://purl.obolibrary.org/obo/HP_0011136	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0009824	http://purl.obolibrary.org/obo/HP_0001539	http://purl.obolibrary.org/obo/HP_0009816	http://purl.obolibrary.org/obo/HP_0009892	http://purl.obolibrary.org/obo/HP_0010808
+Cocoon syndrome	http://purl.obolibrary.org/obo/HP_0000042
 HEPATOBLASTOMA	http://www.ebi.ac.uk/efo/EFO_1000292
 ATAXIA-TELANGIECTASIA VARIANT	http://www.orpha.net/ORDO/Orphanet_370109
 Left ventricular noncompaction 6	http://www.orpha.net/ORDO/Orphanet_54260
 OMODYSPLASIA 1	http://www.orpha.net/ORDO/Orphanet_2733
-RETINAL DYSTROPHY WITH INNER RETINAL DYSFUNCTION AND GANGLION CELLABNORMALITIES	http://purl.obolibrary.org/obo/HP_0000662	http://purl.obolibrary.org/obo/HP_0000556	http://purl.obolibrary.org/obo/HP_0000543	http://purl.obolibrary.org/obo/HP_0000613
-OVARIAN DYSGENESIS 2	http://purl.obolibrary.org/obo/HP_0008209	http://purl.obolibrary.org/obo/HP_0000786	http://purl.obolibrary.org/obo/HP_0001007	http://purl.obolibrary.org/obo/HP_0008639	http://purl.obolibrary.org/obo/HP_0000815	http://purl.obolibrary.org/obo/HP_0000130	http://purl.obolibrary.org/obo/HP_0001587
+RETINAL DYSTROPHY WITH INNER RETINAL DYSFUNCTION AND GANGLION CELLABNORMALITIES	http://purl.obolibrary.org/obo/HP_0000662
+OVARIAN DYSGENESIS 2	http://purl.obolibrary.org/obo/HP_0008209
 DIAMOND-BLACKFAN ANEMIA 9	http://purl.obolibrary.org/obo/HP_0001903
-PITUITARY HORMONE DEFICIENCY COMBINED 6	http://www.orpha.net/ORDO/Orphanet_95494	http://www.orpha.net/ORDO/Orphanet_467
-IMMUNODEFICIENCY 19	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0000403	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001888
+PITUITARY HORMONE DEFICIENCY COMBINED 6	http://www.orpha.net/ORDO/Orphanet_95494
+IMMUNODEFICIENCY 19	http://purl.obolibrary.org/obo/HP_0000007
 ACHROMATOPSIA 2	http://www.orpha.net/ORDO/Orphanet_49382
 SCHIMKE IMMUNOOSSEOUS DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_1830
 Common variable immunodeficiency 2	http://www.orpha.net/ORDO/Orphanet_1572
@@ -926,67 +926,67 @@ RETINITIS PIGMENTOSA 14	http://www.orpha.net/ORDO/Orphanet_791
 West syndrome	http://www.orpha.net/ORDO/Orphanet_3451
 PARKINSON DISEASE 14	http://www.ebi.ac.uk/efo/EFO_0002508
 Primary autosomal recessive microcephaly 3	http://www.orpha.net/ORDO/Orphanet_2512
-SPLIT-HAND/FOOT MALFORMATION 6	http://purl.obolibrary.org/obo/HP_0001839	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0001849	http://purl.obolibrary.org/obo/HP_0001171	http://purl.obolibrary.org/obo/HP_0001180	http://purl.obolibrary.org/obo/HP_0001770	http://purl.obolibrary.org/obo/HP_0006101
+SPLIT-HAND/FOOT MALFORMATION 6	http://purl.obolibrary.org/obo/HP_0001839
 Autosomal recessive congenital ichthyosis 1	http://www.orpha.net/ORDO/Orphanet_281097
 Congenital lactic acidosis	http://purl.obolibrary.org/obo/HP_0004902
-Pseudohypoaldosteronism	http://www.orpha.net/ORDO/Orphanet_300530	http://www.orpha.net/ORDO/Orphanet_300525	http://www.orpha.net/ORDO/Orphanet_757
-Hypocalcemia	http://purl.obolibrary.org/obo/HP_0002135	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003401	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0003394	http://purl.obolibrary.org/obo/HP_0002901
+Pseudohypoaldosteronism	http://www.orpha.net/ORDO/Orphanet_300530
+Hypocalcemia	http://purl.obolibrary.org/obo/HP_0002135
 Reis-Bucklers corneal dystrophy	http://www.orpha.net/ORDO/Orphanet_98961
-Tibia	http://purl.obolibrary.org/obo/HP_0010442	http://purl.obolibrary.org/obo/HP_0000437	http://purl.obolibrary.org/obo/HP_0100258	http://purl.obolibrary.org/obo/HP_0001159	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0010503	http://purl.obolibrary.org/obo/HP_0000430	http://purl.obolibrary.org/obo/HP_0001199	http://purl.obolibrary.org/obo/HP_0002974
+Tibia	http://purl.obolibrary.org/obo/HP_0010442
 Congenital muscular dystrophy	http://www.orpha.net/ORDO/Orphanet_97242
 CRANIOSYNOSTOSIS 1	http://www.orpha.net/ORDO/Orphanet_1531
 HYALINE FIBROMATOSIS SYNDROME	http://www.ebi.ac.uk/efo/EFO_0000497
-Porokeratosis	http://www.orpha.net/ORDO/Orphanet_343	http://www.orpha.net/ORDO/Orphanet_79358
+Porokeratosis	http://www.orpha.net/ORDO/Orphanet_343
 BLOOD GROUP--LUTHERAN INHIBITOR	http://purl.obolibrary.org/obo/HP_0010971
-PEROXISOME BIOGENESIS DISORDER 8B	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000556	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0008167	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001410	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000407
+PEROXISOME BIOGENESIS DISORDER 8B	http://purl.obolibrary.org/obo/HP_0001319
 Focal epilepsy with speech disorder with or without mental retardation	http://www.ebi.ac.uk/efo/EFO_0000474
-SKIN/HAIR/EYE PIGMENTATION	http://purl.obolibrary.org/obo/HP_0008034	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000478	http://purl.obolibrary.org/obo/HP_0000635	http://purl.obolibrary.org/obo/HP_0001000	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000613	http://purl.obolibrary.org/obo/HP_0009887	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001595
+SKIN/HAIR/EYE PIGMENTATION	http://purl.obolibrary.org/obo/HP_0008034
 MEGALOBLASTIC ANEMIA 1	http://www.orpha.net/ORDO/Orphanet_35858
 INFLAMMATORY BOWEL DISEASE 10	http://www.ebi.ac.uk/efo/EFO_0003767
-Myelodysplastic syndrome progressed to acute myeloid leukemia	http://www.ebi.ac.uk/efo/EFO_1000309	http://www.ebi.ac.uk/efo/EFO_0000198
-Ectodermal dysplasia	http://www.orpha.net/ORDO/Orphanet_79373	http://www.orpha.net/ORDO/Orphanet_69084
+Myelodysplastic syndrome progressed to acute myeloid leukemia	http://www.ebi.ac.uk/efo/EFO_1000309
+Ectodermal dysplasia	http://www.orpha.net/ORDO/Orphanet_79373
 Dilated cardiomyopathy 1Z	http://www.ebi.ac.uk/efo/EFO_0000407
 NOONAN SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_648
 ANTERIOR SEGMENT ANOMALIES AND CATARACT	http://www.ebi.ac.uk/efo/EFO_0001059
 Afibrinogenemia	http://www.orpha.net/ORDO/Orphanet_98880
-KLIPPEL-FEIL SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_65	http://www.orpha.net/ORDO/Orphanet_2345
+KLIPPEL-FEIL SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_65
 NEUROMUSCULAR DISEASE	http://www.orpha.net/ORDO/Orphanet_68381
-MYOTILINOPATHY	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0100303	http://purl.obolibrary.org/obo/HP_0001271	http://purl.obolibrary.org/obo/HP_0003693	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003701	http://purl.obolibrary.org/obo/HP_0001771	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0003715	http://purl.obolibrary.org/obo/HP_0003552	http://purl.obolibrary.org/obo/HP_0001638	http://purl.obolibrary.org/obo/HP_0002600	http://purl.obolibrary.org/obo/HP_0009063	http://purl.obolibrary.org/obo/HP_0003326
-DEMENTIA	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0000726	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0011970	http://purl.obolibrary.org/obo/HP_0002344
+MYOTILINOPATHY	http://purl.obolibrary.org/obo/HP_0001284
+DEMENTIA	http://purl.obolibrary.org/obo/HP_0001337
 Thoracic aortic aneurysm and aortic dissection	http://www.ebi.ac.uk/efo/EFO_0001666
-T-CELL IMMUNODEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0008165	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0001803	http://purl.obolibrary.org/obo/HP_0001807	http://purl.obolibrary.org/obo/HP_0005352
-LICHTENSTEIN-KNORR SYNDROME	http://purl.obolibrary.org/obo/HP_0002075	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002345	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0000639
+T-CELL IMMUNODEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
+LICHTENSTEIN-KNORR SYNDROME	http://purl.obolibrary.org/obo/HP_0002075
 Cutaneous polyarteritis nodosa	http://purl.obolibrary.org/obo/HP_0005294
-MACULAR DYSTROPHY	http://purl.obolibrary.org/obo/HP_0007754	http://purl.obolibrary.org/obo/HP_0030515	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000603	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0007677
+MACULAR DYSTROPHY	http://purl.obolibrary.org/obo/HP_0007754
 Craniosynostosis and dental anomalies	http://www.orpha.net/ORDO/Orphanet_284149
 Dejerine-sottas syndrome	http://www.orpha.net/ORDO/Orphanet_64748
 Hermansky-Pudlak syndrome 5	http://www.orpha.net/ORDO/Orphanet_79430
 Spondyloepimetaphyseal dysplasia with multiple dislocations	http://www.orpha.net/ORDO/Orphanet_93360
-ULLRICH CONGENITAL MUSCULAR DYSTROPHY	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0003700	http://purl.obolibrary.org/obo/HP_0007502	http://purl.obolibrary.org/obo/HP_0005072	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0006460	http://purl.obolibrary.org/obo/HP_0001533	http://purl.obolibrary.org/obo/HP_0001388	http://purl.obolibrary.org/obo/HP_0006149	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003557	http://purl.obolibrary.org/obo/HP_0003713	http://purl.obolibrary.org/obo/HP_0002747	http://purl.obolibrary.org/obo/HP_0000473	http://purl.obolibrary.org/obo/HP_0003741	http://purl.obolibrary.org/obo/HP_0003803	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0008180	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003701	http://purl.obolibrary.org/obo/HP_0000311	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0003306	http://purl.obolibrary.org/obo/HP_0000975	http://purl.obolibrary.org/obo/HP_0000411	http://purl.obolibrary.org/obo/HP_0010628	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0002783	http://purl.obolibrary.org/obo/HP_0002877	http://purl.obolibrary.org/obo/HP_0002827
-RETINITIS PIGMENTOSA 20	http://www.orpha.net/ORDO/Orphanet_65	http://www.orpha.net/ORDO/Orphanet_791
-Neurodegenerative illness	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0002395	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0002135	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0040083	http://purl.obolibrary.org/obo/HP_0002317
+ULLRICH CONGENITAL MUSCULAR DYSTROPHY	http://purl.obolibrary.org/obo/HP_0001371
+RETINITIS PIGMENTOSA 20	http://www.orpha.net/ORDO/Orphanet_65
+Neurodegenerative illness	http://purl.obolibrary.org/obo/HP_0100543
 Periampullary adenoma	http://www.ebi.ac.uk/efo/EFO_0000232
 MYELOFIBROSIS	http://purl.obolibrary.org/obo/HP_0011974
-3-@METHYLCROTONYL-CoA CARBOXYLASE 1 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0008281	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0006573	http://purl.obolibrary.org/obo/HP_0002919	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0001943	http://purl.obolibrary.org/obo/HP_0002179	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004911	http://purl.obolibrary.org/obo/HP_0001259	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001254
-Partial adenosine deaminase deficiency	http://www.orpha.net/ORDO/Orphanet_183660	http://www.orpha.net/ORDO/Orphanet_117771
+3-@METHYLCROTONYL-CoA CARBOXYLASE 1 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001347
+Partial adenosine deaminase deficiency	http://www.orpha.net/ORDO/Orphanet_183660
 HERMANSKY-PUDLAK SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_79430
 PARATHYROID ADENOMA	http://www.orpha.net/ORDO/Orphanet_99877
-Congenital myopathy with fiber type disproportion	http://www.orpha.net/ORDO/Orphanet_97242	http://www.orpha.net/ORDO/Orphanet_59135	http://www.orpha.net/ORDO/Orphanet_2020
+Congenital myopathy with fiber type disproportion	http://www.orpha.net/ORDO/Orphanet_97242
 Progressive external ophthalmoplegia	http://www.ebi.ac.uk/efo/EFO_0002509
 Cutis laxa with osteodystrophy	http://www.orpha.net/ORDO/Orphanet_209
 ATAXIA-TELANGIECTASIA WITHOUT IMMUNODEFICIENCY	http://www.orpha.net/ORDO/Orphanet_100
 CEREBRORETINAL MICROANGIOPATHY WITH CALCIFICATIONS AND CYSTS	http://www.orpha.net/ORDO/Orphanet_313838
 Exfoliative ichthyosis	http://www.orpha.net/ORDO/Orphanet_289586
 INTERVERTEBRAL DISC DISEASE	http://www.ebi.ac.uk/efo/EFO_0004994
-Cardiac arrhythmia	http://www.ebi.ac.uk/efo/EFO_0004269	http://www.ebi.ac.uk/efo/EFO_0004278	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0005303	http://www.ebi.ac.uk/efo/EFO_0005306	http://www.ebi.ac.uk/efo/EFO_0004287	http://www.ebi.ac.uk/efo/EFO_0005307	http://www.ebi.ac.uk/efo/EFO_0000275
-Glut1 deficiency syndrome 1	http://www.orpha.net/ORDO/Orphanet_158410	http://www.orpha.net/ORDO/Orphanet_71277
+Cardiac arrhythmia	http://www.ebi.ac.uk/efo/EFO_0004269
+Glut1 deficiency syndrome 1	http://www.orpha.net/ORDO/Orphanet_158410
 Keppen-Lubinsky syndrome	http://www.orpha.net/ORDO/Orphanet_435628
-DIGITAL ARTHROPATHY-BRACHYDACTYLY	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0009882	http://purl.obolibrary.org/obo/HP_0005872	http://purl.obolibrary.org/obo/HP_0005819	http://purl.obolibrary.org/obo/HP_0009466	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001857	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0003795	http://purl.obolibrary.org/obo/HP_0003040
-PREMATURE OVARIAN FAILURE 2B	http://purl.obolibrary.org/obo/HP_0000098	http://purl.obolibrary.org/obo/HP_0000164	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0000786	http://purl.obolibrary.org/obo/HP_0008209
+DIGITAL ARTHROPATHY-BRACHYDACTYLY	http://purl.obolibrary.org/obo/HP_0001156
+PREMATURE OVARIAN FAILURE 2B	http://purl.obolibrary.org/obo/HP_0000098
 ATOPY	http://www.ebi.ac.uk/efo/EFO_0002686
 Severe global developmental delay	http://purl.obolibrary.org/obo/HP_0011344
-Glycogen storage disease type II	http://www.orpha.net/ORDO/Orphanet_365	http://www.orpha.net/ORDO/Orphanet_79201
-METACARPAL 4-5 FUSION	http://purl.obolibrary.org/obo/HP_0001163	http://purl.obolibrary.org/obo/HP_0005867	http://purl.obolibrary.org/obo/HP_0001419
+Glycogen storage disease type II	http://www.orpha.net/ORDO/Orphanet_365
+METACARPAL 4-5 FUSION	http://purl.obolibrary.org/obo/HP_0001163
 Bartter syndrome type 4	http://www.orpha.net/ORDO/Orphanet_89938
 Tyrosinase-positive oculocutaneous albinism	http://www.orpha.net/ORDO/Orphanet_79432
 Adams-Oliver syndrome 2	http://www.orpha.net/ORDO/Orphanet_974
@@ -994,68 +994,68 @@ INTERMEDIATE MUSCULAR DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_98473
 MASTOCYTOSIS	http://www.orpha.net/ORDO/Orphanet_98292
 MYELOPEROXIDASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_2587
 Congenital heart disease	http://www.ebi.ac.uk/efo/EFO_0005207
-COMPLEMENT COMPONENT 6 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0005381	http://purl.obolibrary.org/obo/HP_0004431	http://purl.obolibrary.org/obo/HP_0001939
-POPLITEAL PTERYGIUM SYNDROME	http://www.orpha.net/ORDO/Orphanet_294963	http://www.ebi.ac.uk/efo/EFO_0000678
-OSTEOARTHRITIS WITH MILD CHONDRODYSPLASIA	http://purl.obolibrary.org/obo/HP_0012313	http://purl.obolibrary.org/obo/HP_0005086	http://purl.obolibrary.org/obo/HP_0030041	http://purl.obolibrary.org/obo/HP_0001387	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0008843	http://purl.obolibrary.org/obo/HP_0000926	http://purl.obolibrary.org/obo/HP_0004568	http://purl.obolibrary.org/obo/HP_0003301
+COMPLEMENT COMPONENT 6 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
+POPLITEAL PTERYGIUM SYNDROME	http://www.orpha.net/ORDO/Orphanet_294963
+OSTEOARTHRITIS WITH MILD CHONDRODYSPLASIA	http://purl.obolibrary.org/obo/HP_0012313
 Cholecystitis	http://purl.obolibrary.org/obo/HP_0001082
 Microspherophakia	http://www.orpha.net/ORDO/Orphanet_2551
 INFERTILITY	http://www.ebi.ac.uk/efo/EFO_0000545
 Congenital lactase deficiency	http://www.orpha.net/ORDO/Orphanet_53690
 RHEGMATOGENOUS RETINAL DETACHMENT	http://www.ebi.ac.uk/efo/EFO_0005240
 Marie Unna hereditary hypotrichosis 1	http://www.orpha.net/ORDO/Orphanet_444
-Myofibrillar myopathy	http://www.ebi.ac.uk/efo/EFO_0004145	http://www.orpha.net/ORDO/Orphanet_593
-GLUT1 DEFICIENCY SYNDROME 2	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001266	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000737	http://purl.obolibrary.org/obo/HP_0100660	http://purl.obolibrary.org/obo/HP_0011972	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0001923	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0002059
+Myofibrillar myopathy	http://www.ebi.ac.uk/efo/EFO_0004145
+GLUT1 DEFICIENCY SYNDROME 2	http://purl.obolibrary.org/obo/HP_0100543
 FATAL FAMILIAL INSOMNIA	http://www.orpha.net/ORDO/Orphanet_466
 Congenital disorder of glycosylation type 1u	http://www.orpha.net/ORDO/Orphanet_137
 Renal coloboma syndrome	http://www.orpha.net/ORDO/Orphanet_1475
 Geroderma osteodysplastica	http://www.orpha.net/ORDO/Orphanet_2078
-Juvenile retinitis pigmentosa	http://www.orpha.net/ORDO/Orphanet_65	http://www.orpha.net/ORDO/Orphanet_791
-Microcephaly and chorioretinopathy	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0000543	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000448	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0009879	http://purl.obolibrary.org/obo/HP_0000488	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0000340	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0002059	http://purl.obolibrary.org/obo/HP_0000568	http://purl.obolibrary.org/obo/HP_0007401
-Epiphyseal chondrodysplasia	http://purl.obolibrary.org/obo/HP_0010055	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0001847	http://purl.obolibrary.org/obo/HP_0001166
-SHORT-RIB THORACIC DYSPLASIA 11 WITH OR WITHOUT POLYDACTYLY	http://purl.obolibrary.org/obo/HP_0006644	http://purl.obolibrary.org/obo/HP_0003026	http://purl.obolibrary.org/obo/HP_0001513	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000121	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0000774	http://purl.obolibrary.org/obo/HP_0000888	http://purl.obolibrary.org/obo/HP_0100259	http://purl.obolibrary.org/obo/HP_0001591	http://purl.obolibrary.org/obo/HP_0001561
+Juvenile retinitis pigmentosa	http://www.orpha.net/ORDO/Orphanet_65
+Microcephaly and chorioretinopathy	http://purl.obolibrary.org/obo/HP_0001511
+Epiphyseal chondrodysplasia	http://purl.obolibrary.org/obo/HP_0010055
+SHORT-RIB THORACIC DYSPLASIA 11 WITH OR WITHOUT POLYDACTYLY	http://purl.obolibrary.org/obo/HP_0006644
 HYPERHOMOCYSTEINEMIA	http://www.orpha.net/ORDO/Orphanet_394
 Muscle AMP deaminase deficiency	http://www.orpha.net/ORDO/Orphanet_45
 Pulmonary arterial hypertension related to hereditary hemorrhagic telangiectasia	http://www.orpha.net/ORDO/Orphanet_774
-TREACHER COLLINS SYNDROME 2	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000452	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000453
+TREACHER COLLINS SYNDROME 2	http://purl.obolibrary.org/obo/HP_0000347
 3 beta-Hydroxysteroid dehydrogenase deficiency	http://www.orpha.net/ORDO/Orphanet_90791
 LIPOYLTRANSFERASE 1 DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_401862
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 19	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002098	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0001397	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001319
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 19	http://purl.obolibrary.org/obo/HP_0000007
 Leukonychia totalis	http://www.orpha.net/ORDO/Orphanet_2387
-SPONDYLOPERIPHERAL DYSPLASIA	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0009290	http://purl.obolibrary.org/obo/HP_0006110	http://purl.obolibrary.org/obo/HP_0011304	http://purl.obolibrary.org/obo/HP_0002997	http://purl.obolibrary.org/obo/HP_0003022	http://purl.obolibrary.org/obo/HP_0006144	http://purl.obolibrary.org/obo/HP_0001169	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0009882	http://purl.obolibrary.org/obo/HP_0002655	http://purl.obolibrary.org/obo/HP_0000944	http://purl.obolibrary.org/obo/HP_0002644	http://purl.obolibrary.org/obo/HP_0100734	http://purl.obolibrary.org/obo/HP_0004180	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0010743	http://purl.obolibrary.org/obo/HP_0001773	http://purl.obolibrary.org/obo/HP_0003370	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001831	http://purl.obolibrary.org/obo/HP_0004227	http://purl.obolibrary.org/obo/HP_0005068	http://purl.obolibrary.org/obo/HP_0003312	http://purl.obolibrary.org/obo/HP_0009566	http://purl.obolibrary.org/obo/HP_0000339	http://purl.obolibrary.org/obo/HP_0010579	http://purl.obolibrary.org/obo/HP_0000768	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0010049	http://purl.obolibrary.org/obo/HP_0009778	http://purl.obolibrary.org/obo/HP_0003180	http://purl.obolibrary.org/obo/HP_0000926	http://purl.obolibrary.org/obo/HP_0001163	http://purl.obolibrary.org/obo/HP_0001377	http://purl.obolibrary.org/obo/HP_0002983	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0001552	http://purl.obolibrary.org/obo/HP_0010230	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0010454	http://purl.obolibrary.org/obo/HP_0001376
-MICROCEPHALY AND CHORIORETINOPATHY	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0000568	http://purl.obolibrary.org/obo/HP_0007731	http://purl.obolibrary.org/obo/HP_0000639
-EPSILON-TRIMETHYLLYSINE HYDROXYLASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000717	http://purl.obolibrary.org/obo/HP_0001249
+SPONDYLOPERIPHERAL DYSPLASIA	http://purl.obolibrary.org/obo/HP_0000272
+MICROCEPHALY AND CHORIORETINOPATHY	http://purl.obolibrary.org/obo/HP_0007663
+EPSILON-TRIMETHYLLYSINE HYDROXYLASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001250
 PERSISTENT MULLERIAN DUCT SYNDROME	http://www.orpha.net/ORDO/Orphanet_2856
 Congenital disorder of glycosylation type 1q	http://www.orpha.net/ORDO/Orphanet_137
 NEPHROTIC SYNDROME	http://www.ebi.ac.uk/efo/EFO_0004255
 PERRAULT SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_2855
-MEGALENCEPHALY-POLYMICROGYRIA-POLYDACTYLY-HYDROCEPHALUS SYNDROME 2	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0001090	http://purl.obolibrary.org/obo/HP_0001355	http://purl.obolibrary.org/obo/HP_0001302	http://purl.obolibrary.org/obo/HP_0002943	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0010775	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000974	http://purl.obolibrary.org/obo/HP_0002187	http://purl.obolibrary.org/obo/HP_0006380	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0100259	http://purl.obolibrary.org/obo/HP_0002126	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0007206	http://purl.obolibrary.org/obo/HP_0000637	http://purl.obolibrary.org/obo/HP_0001653	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0007074	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0001162	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0000965	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0001629
-BILE ACID MALABSORPTION	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0002630	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0002028	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002570
-Epidermolysis Bullosa with Pyloric Atresia	http://purl.obolibrary.org/obo/HP_0000119	http://purl.obolibrary.org/obo/HP_0001056	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0003341	http://purl.obolibrary.org/obo/HP_0008404	http://purl.obolibrary.org/obo/HP_0006297	http://purl.obolibrary.org/obo/HP_0001030	http://purl.obolibrary.org/obo/HP_0002804	http://purl.obolibrary.org/obo/HP_0001057	http://purl.obolibrary.org/obo/HP_0001075	http://purl.obolibrary.org/obo/HP_0002032	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0006254	http://purl.obolibrary.org/obo/HP_0002164	http://purl.obolibrary.org/obo/HP_0004399	http://purl.obolibrary.org/obo/HP_0002041	http://purl.obolibrary.org/obo/HP_0001798	http://purl.obolibrary.org/obo/HP_0001522	http://purl.obolibrary.org/obo/HP_0001561	http://purl.obolibrary.org/obo/HP_0000656	http://purl.obolibrary.org/obo/HP_0001060
+MEGALENCEPHALY-POLYMICROGYRIA-POLYDACTYLY-HYDROCEPHALUS SYNDROME 2	http://purl.obolibrary.org/obo/HP_0000508
+BILE ACID MALABSORPTION	http://purl.obolibrary.org/obo/HP_0000007
+Epidermolysis Bullosa with Pyloric Atresia	http://purl.obolibrary.org/obo/HP_0000119
 Beta-D-mannosidosis	http://www.orpha.net/ORDO/Orphanet_118
-METHYLMALONIC ACIDURIA DUE TO METHYLMALONYL-CoA MUTASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0100806	http://purl.obolibrary.org/obo/HP_0001970	http://purl.obolibrary.org/obo/HP_0001882	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0012120	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002170	http://purl.obolibrary.org/obo/HP_0002027	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002912	http://purl.obolibrary.org/obo/HP_0000091	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0001944	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0001874	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002154	http://purl.obolibrary.org/obo/HP_0002017	http://purl.obolibrary.org/obo/HP_0002188	http://purl.obolibrary.org/obo/HP_0001259	http://purl.obolibrary.org/obo/HP_0004372	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0001987	http://purl.obolibrary.org/obo/HP_0002072	http://purl.obolibrary.org/obo/HP_0002039	http://purl.obolibrary.org/obo/HP_0003774	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0001638	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001254	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0004374	http://purl.obolibrary.org/obo/HP_0001733	http://purl.obolibrary.org/obo/HP_0005979	http://purl.obolibrary.org/obo/HP_0002453	http://purl.obolibrary.org/obo/HP_0011695	http://purl.obolibrary.org/obo/HP_0001263
+METHYLMALONIC ACIDURIA DUE TO METHYLMALONYL-CoA MUTASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0100806
 WOLFRAM SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_3463
 Autosomal recessive congenital ichthyosis 9	http://www.orpha.net/ORDO/Orphanet_281097
 Islet cell hyperplasia	http://www.ebi.ac.uk/efo/EFO_0007318
 Niemann-Pick disease type C1	http://www.ebi.ac.uk/efo/EFO_0003096
-FACTOR V DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000421	http://purl.obolibrary.org/obo/HP_0000132	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001892	http://purl.obolibrary.org/obo/HP_0003225	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0003645	http://purl.obolibrary.org/obo/HP_0005542	http://purl.obolibrary.org/obo/HP_0003010
+FACTOR V DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000421
 Neutral 1 amino acid transport defect	http://www.orpha.net/ORDO/Orphanet_2116
 KININOGEN DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_122875
 Recurrent infections	http://purl.obolibrary.org/obo/HP_0002719
 SENSORINEURAL DEAFNESS WITH MILD RENAL DYSFUNCTION	http://www.ebi.ac.uk/efo/EFO_0001063
 NEMALINE MYOPATHY 1	http://www.orpha.net/ORDO/Orphanet_607
-POROKERATOSIS 8	http://purl.obolibrary.org/obo/HP_0200034	http://purl.obolibrary.org/obo/HP_0200044
+POROKERATOSIS 8	http://purl.obolibrary.org/obo/HP_0200034
 KALLMANN SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_478
-HYDROCEPHALUS	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0009879	http://purl.obolibrary.org/obo/HP_0001250	http://www.orpha.net/ORDO/Orphanet_388	http://purl.obolibrary.org/obo/HP_0001334	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0001249
+HYDROCEPHALUS	http://purl.obolibrary.org/obo/HP_0000007
 CARPENTER SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_65759
 RETINITIS PIGMENTOSA 38	http://www.orpha.net/ORDO/Orphanet_791
 COLD-INDUCED SWEATING SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_157820
 Autosomal dominant progressive external ophthalmoplegia with mitochondrial DNA deletions 3	http://www.ebi.ac.uk/efo/EFO_0002509
-RIEGER ANOMALY	http://www.orpha.net/ORDO/Orphanet_377	http://www.orpha.net/ORDO/Orphanet_91483	http://www.orpha.net/ORDO/Orphanet_3366
-MEVALONIC ACIDURIA	http://www.orpha.net/ORDO/Orphanet_29	http://www.orpha.net/ORDO/Orphanet_343	http://www.orpha.net/ORDO/Orphanet_79358
-Spondylocostal dysostosis 6	http://purl.obolibrary.org/obo/HP_0003416	http://purl.obolibrary.org/obo/HP_0002947
-Acute myeloid leukemia	http://www.ebi.ac.uk/efo/EFO_0000198	http://www.ebi.ac.uk/efo/EFO_0000222	http://www.ebi.ac.uk/efo/EFO_0000220	http://www.ebi.ac.uk/efo/EFO_0000616
-USHER SYNDROME TYPE 1J	http://purl.obolibrary.org/obo/HP_0001751	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0001270
-KANZAKI DISEASE	http://www.orpha.net/ORDO/Orphanet_3137	http://www.orpha.net/ORDO/Orphanet_79280
+RIEGER ANOMALY	http://www.orpha.net/ORDO/Orphanet_377
+MEVALONIC ACIDURIA	http://www.orpha.net/ORDO/Orphanet_29
+Spondylocostal dysostosis 6	http://purl.obolibrary.org/obo/HP_0003416
+Acute myeloid leukemia	http://www.ebi.ac.uk/efo/EFO_0000198
+USHER SYNDROME TYPE 1J	http://purl.obolibrary.org/obo/HP_0001751
+KANZAKI DISEASE	http://www.orpha.net/ORDO/Orphanet_3137
 Megalencephaly polymicrogyria-polydactyly hydrocephalus syndrome	http://www.orpha.net/ORDO/Orphanet_2477
 Dyskeratosis congenita autosomal dominant	http://www.orpha.net/ORDO/Orphanet_1775
 Common variable immunodeficiency 11	http://www.orpha.net/ORDO/Orphanet_1572
@@ -1063,16 +1063,16 @@ Frontotemporal dementia and/or amyotrophic lateral sclerosis 2	http://www.orpha.
 Cerebro-costo-mandibular syndrome	http://www.orpha.net/ORDO/Orphanet_1393
 Skeletal dysplasia	http://purl.obolibrary.org/obo/HP_0002652
 DIHYDROPYRIMIDINASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_38874
-Immunodeficiency 27b	http://purl.obolibrary.org/obo/HP_0005661	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002755	http://purl.obolibrary.org/obo/HP_0011274
+Immunodeficiency 27b	http://purl.obolibrary.org/obo/HP_0005661
 Autosomal recessive congenital ichthyosis 6	http://www.orpha.net/ORDO/Orphanet_281097
-OSTEOGLOPHONIC DYSPLASIA	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000706	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0009804	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0009803	http://purl.obolibrary.org/obo/HP_0002659	http://purl.obolibrary.org/obo/HP_0001739	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0006487	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0004279	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0001800	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0010049	http://purl.obolibrary.org/obo/HP_0000926	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0001363	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0005864	http://purl.obolibrary.org/obo/HP_0000453	http://purl.obolibrary.org/obo/HP_0001230	http://purl.obolibrary.org/obo/HP_0004348	http://purl.obolibrary.org/obo/HP_0000882	http://purl.obolibrary.org/obo/HP_0001783	http://purl.obolibrary.org/obo/HP_0000041	http://purl.obolibrary.org/obo/HP_0000377	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0001169	http://purl.obolibrary.org/obo/HP_0001769	http://purl.obolibrary.org/obo/HP_0001742	http://purl.obolibrary.org/obo/HP_0009826	http://purl.obolibrary.org/obo/HP_0000889	http://purl.obolibrary.org/obo/HP_0001773	http://purl.obolibrary.org/obo/HP_0010743	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0002676	http://purl.obolibrary.org/obo/HP_0003312	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0008905	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0004299	http://purl.obolibrary.org/obo/HP_0002098	http://purl.obolibrary.org/obo/HP_0006009	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0000586	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0000023
+OSTEOGLOPHONIC DYSPLASIA	http://purl.obolibrary.org/obo/HP_0000272
 Autoimmune disease 6	http://www.ebi.ac.uk/efo/EFO_0005140
-VITAMIN D HYDROXYLATION-DEFICIENT RICKETS	http://purl.obolibrary.org/obo/HP_0002748	http://purl.obolibrary.org/obo/HP_0002980	http://purl.obolibrary.org/obo/HP_0002355	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003698	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0002752	http://purl.obolibrary.org/obo/HP_0003155	http://purl.obolibrary.org/obo/HP_0002148	http://purl.obolibrary.org/obo/HP_0003029	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0003020	http://purl.obolibrary.org/obo/HP_0002753	http://purl.obolibrary.org/obo/HP_0002982	http://purl.obolibrary.org/obo/HP_0010502	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003025	http://purl.obolibrary.org/obo/HP_0000886	http://purl.obolibrary.org/obo/HP_0002663	http://purl.obolibrary.org/obo/HP_0003013	http://purl.obolibrary.org/obo/HP_0002979	http://purl.obolibrary.org/obo/HP_0004492	http://purl.obolibrary.org/obo/HP_0005469	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0000920	http://purl.obolibrary.org/obo/HP_0002757	http://purl.obolibrary.org/obo/HP_0002653	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0000893	http://purl.obolibrary.org/obo/HP_0002007
+VITAMIN D HYDROXYLATION-DEFICIENT RICKETS	http://purl.obolibrary.org/obo/HP_0002748
 NANOPHTHALMOS 2	http://www.ebi.ac.uk/efo/EFO_0005569
 SOTOS SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_821
 Laron syndrome with elevated serum gh-binding protein	http://www.orpha.net/ORDO/Orphanet_633
 VARIEGATE PORPHYRIA	http://www.orpha.net/ORDO/Orphanet_79473
-Temtamy syndrome	http://www.orpha.net/ORDO/Orphanet_1777	http://www.orpha.net/ORDO/Orphanet_98938
+Temtamy syndrome	http://www.orpha.net/ORDO/Orphanet_1777
 MAJOR DEPRESSIVE DISORDER	http://www.ebi.ac.uk/efo/EFO_0003761
 COFFIN-LOWRY SYNDROME	http://www.orpha.net/ORDO/Orphanet_192
 Joubert syndrome 12	http://www.orpha.net/ORDO/Orphanet_475
@@ -1080,24 +1080,24 @@ DEJERINE-SOTTAS NEUROPATHY	http://www.orpha.net/ORDO/Orphanet_64748
 Severe microlissencephaly	http://purl.obolibrary.org/obo/HP_0002267
 Peroxisome biogenesis disorder 3A	http://www.orpha.net/ORDO/Orphanet_79189
 Generalized seizures	http://purl.obolibrary.org/obo/HP_0002197
-OVARIAN CANCER	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0001075
-Usher syndrome	http://www.orpha.net/ORDO/Orphanet_886	http://www.orpha.net/ORDO/Orphanet_231183	http://www.orpha.net/ORDO/Orphanet_231178	http://www.orpha.net/ORDO/Orphanet_791
+OVARIAN CANCER	http://www.ebi.ac.uk/efo/EFO_0000311
+Usher syndrome	http://www.orpha.net/ORDO/Orphanet_886
 Hermansky-Pudlak syndrome 9	http://www.orpha.net/ORDO/Orphanet_79430
 Familial hypocalciuric hypercalcemia	http://www.orpha.net/ORDO/Orphanet_405
-DYSKERATOSIS CONGENITA	http://www.orpha.net/ORDO/Orphanet_1775	http://purl.obolibrary.org/obo/HP_0002216	http://purl.obolibrary.org/obo/HP_0008404	http://purl.obolibrary.org/obo/HP_0000958	http://purl.obolibrary.org/obo/HP_0003743	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0002028	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0010885	http://purl.obolibrary.org/obo/HP_0001876	http://purl.obolibrary.org/obo/HP_0007427	http://purl.obolibrary.org/obo/HP_0001882	http://www.orpha.net/ORDO/Orphanet_88	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0000164	http://purl.obolibrary.org/obo/HP_0002164	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0004313	http://purl.obolibrary.org/obo/HP_0000670	http://purl.obolibrary.org/obo/HP_0002206	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001915	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0000972	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001000	http://purl.obolibrary.org/obo/HP_0002043	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0002514	http://purl.obolibrary.org/obo/HP_0009926	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0002583	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0002860	http://purl.obolibrary.org/obo/HP_0002745	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0000488	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0008070	http://purl.obolibrary.org/obo/HP_0010450	http://purl.obolibrary.org/obo/HP_0012227	http://purl.obolibrary.org/obo/HP_0005528
+DYSKERATOSIS CONGENITA	http://www.orpha.net/ORDO/Orphanet_1775
 Dicarboxylic aminoaciduria	http://www.orpha.net/ORDO/Orphanet_2195
-SPASTIC PARAPLEGIA 30	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0007210	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0002064	http://purl.obolibrary.org/obo/HP_0002061	http://purl.obolibrary.org/obo/HP_0011448	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002839	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0003477	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0007340
+SPASTIC PARAPLEGIA 30	http://purl.obolibrary.org/obo/HP_0001347
 Lethal congenital contracture syndrome 5	http://www.orpha.net/ORDO/Orphanet_294965
 PARKINSON DISEASE 23	http://www.ebi.ac.uk/efo/EFO_0002508
 Myoclonic epilepsy myopathy sensory ataxia	http://www.ebi.ac.uk/efo/EFO_0000474
 Dowling-Degos disease 2	http://www.orpha.net/ORDO/Orphanet_79145
-BAINBRIDGE-ROPERS SYNDROME	http://purl.obolibrary.org/obo/HP_0008850	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0011344	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0002553
+BAINBRIDGE-ROPERS SYNDROME	http://purl.obolibrary.org/obo/HP_0008850
 ADRENOCORTICAL CARCINOMA	http://www.orpha.net/ORDO/Orphanet_1501
 Thiel-Behnke corneal dystrophy	http://www.orpha.net/ORDO/Orphanet_98960
 COWDEN SYNDROME 5	http://www.orpha.net/ORDO/Orphanet_201
 Idiopathic basal ganglia calcification 5	http://www.orpha.net/ORDO/Orphanet_1980
 BASAL CELL CARCINOMA	http://www.ebi.ac.uk/efo/EFO_0004193
-Stickler syndrome type 1	http://www.orpha.net/ORDO/Orphanet_90653	http://www.orpha.net/ORDO/Orphanet_485
+Stickler syndrome type 1	http://www.orpha.net/ORDO/Orphanet_90653
 NEPHRONOPHTHISIS 15	http://www.orpha.net/ORDO/Orphanet_655
 Curry-Hall syndrome	http://www.orpha.net/ORDO/Orphanet_952
 Congenital disorder of glycosylation type 1t	http://www.orpha.net/ORDO/Orphanet_137
@@ -1105,98 +1105,98 @@ Morbid obesity	http://www.ebi.ac.uk/efo/EFO_0001074
 CEREBROOCULOFACIOSKELETAL SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_1466
 HOLT-ORAM SYNDROME	http://www.orpha.net/ORDO/Orphanet_392
 DIAMOND-BLACKFAN ANEMIA 1	http://www.orpha.net/ORDO/Orphanet_124
-LEUKOENCEPHALOPATHY WITH ATAXIA	http://purl.obolibrary.org/obo/HP_0001138	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0001123	http://purl.obolibrary.org/obo/HP_0002315	http://purl.obolibrary.org/obo/HP_0000532	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0002352
-Osteoporosis with pseudoglioma	http://www.orpha.net/ORDO/Orphanet_2788	http://www.orpha.net/ORDO/Orphanet_98668
+LEUKOENCEPHALOPATHY WITH ATAXIA	http://purl.obolibrary.org/obo/HP_0001138
+Osteoporosis with pseudoglioma	http://www.orpha.net/ORDO/Orphanet_2788
 COWDEN SYNDROME 7	http://www.orpha.net/ORDO/Orphanet_201
 Mitochondrial DNA depletion syndrome 9 (encephalomyopathic with methylmalonic aciduria)	http://www.orpha.net/ORDO/Orphanet_35698
 Asperger syndrome X-linked 1	http://www.ebi.ac.uk/efo/EFO_0003757
 THYROID DYSHORMONOGENESIS 1	http://www.orpha.net/ORDO/Orphanet_95716
-Cerebro-oculo-facio-skeletal syndrome	http://www.orpha.net/ORDO/Orphanet_276258	http://www.orpha.net/ORDO/Orphanet_1466
+Cerebro-oculo-facio-skeletal syndrome	http://www.orpha.net/ORDO/Orphanet_276258
 LEBER CONGENITAL AMAUROSIS 7	http://www.orpha.net/ORDO/Orphanet_65
 Pyruvate dehydrogenase phosphatase deficiency	http://www.orpha.net/ORDO/Orphanet_79246
 CHYLOMICRON RETENTION DISEASE	http://www.orpha.net/ORDO/Orphanet_71
 CATARACT 15	http://www.orpha.net/ORDO/Orphanet_91492
-Infantile hypophosphatasia	http://www.orpha.net/ORDO/Orphanet_247651	http://www.orpha.net/ORDO/Orphanet_247676	http://www.orpha.net/ORDO/Orphanet_247667	http://www.orpha.net/ORDO/Orphanet_436
+Infantile hypophosphatasia	http://www.orpha.net/ORDO/Orphanet_247651
 HEIMLER SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_3220
 Neuroendocrine neoplasm	http://purl.obolibrary.org/obo/HP_0100634
 Cataract 39	http://www.ebi.ac.uk/efo/EFO_0001059
-Global developmental delay	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0003355	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0002171	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001522	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0002059
+Global developmental delay	http://purl.obolibrary.org/obo/HP_0002151
 Berger disease	http://www.ebi.ac.uk/efo/EFO_0004194
 Lucey-Driscoll syndrome	http://www.orpha.net/ORDO/Orphanet_2312
 NEUROFIBROSARCOMA	http://www.ebi.ac.uk/efo/EFO_0000760
-BOOMERANG DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_1263	http://www.orpha.net/ORDO/Orphanet_1190
-ECTODERMAL DYSPLASIA 11A	http://www.orpha.net/ORDO/Orphanet_1810	http://www.orpha.net/ORDO/Orphanet_79373
+BOOMERANG DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_1263
+ECTODERMAL DYSPLASIA 11A	http://www.orpha.net/ORDO/Orphanet_1810
 Persistent truncus arteriosus	http://www.orpha.net/ORDO/Orphanet_3384
 CHOREOACANTHOCYTOSIS	http://www.orpha.net/ORDO/Orphanet_2388
 Malignant hyperthermia	http://www.orpha.net/ORDO/Orphanet_423
 Glycogen storage disease type X	http://www.orpha.net/ORDO/Orphanet_97234
-FG SYNDROME 4	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001417	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0000316
+FG SYNDROME 4	http://purl.obolibrary.org/obo/HP_0002650
 Hypermanganesemia with dystonia	http://www.ebi.ac.uk/efo/EFO_0001422
 Congenital defect of folate absorption	http://www.orpha.net/ORDO/Orphanet_90045
 Premature ovarian failure 5	http://www.ebi.ac.uk/efo/EFO_0004266
 Dilated cardiomyopathy 1G	http://www.ebi.ac.uk/efo/EFO_0000407
 Familial hypoalphalipoproteinemia	http://www.orpha.net/ORDO/Orphanet_425
 Familial hyperaldosteronism type 3	http://www.orpha.net/ORDO/Orphanet_251274
-ICHTHYOSIS	http://purl.obolibrary.org/obo/HP_0000653	http://purl.obolibrary.org/obo/HP_0000958	http://purl.obolibrary.org/obo/HP_0000682	http://purl.obolibrary.org/obo/HP_0030151	http://purl.obolibrary.org/obo/HP_0010783	http://purl.obolibrary.org/obo/HP_0007475	http://purl.obolibrary.org/obo/HP_0009804	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0001409	http://purl.obolibrary.org/obo/HP_0040162	http://purl.obolibrary.org/obo/HP_0000956	http://purl.obolibrary.org/obo/HP_0001036	http://purl.obolibrary.org/obo/HP_0001871	http://purl.obolibrary.org/obo/HP_0000668	http://purl.obolibrary.org/obo/HP_0000972	http://purl.obolibrary.org/obo/HP_0001006	http://purl.obolibrary.org/obo/HP_0006297	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000677	http://purl.obolibrary.org/obo/HP_0100840	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0000952	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0000499
+ICHTHYOSIS	http://purl.obolibrary.org/obo/HP_0000653
 IMMUNODEFICIENCY 40	http://purl.obolibrary.org/obo/HP_0002721
 Mandibular hypoplasia	http://www.ebi.ac.uk/efo/EFO_0001063
 PHOSPHORIBOSYLPYROPHOSPHATE SYNTHETASE SUPERACTIVITY	http://www.orpha.net/ORDO/Orphanet_3222
-VENTRICULAR FIBRILLATION	http://purl.obolibrary.org/obo/HP_0001663	http://purl.obolibrary.org/obo/HP_0001645
-SARCOIDOSIS	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0012220
-FG SYNDROME 2	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0001417	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0011246	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0002003
+VENTRICULAR FIBRILLATION	http://purl.obolibrary.org/obo/HP_0001663
+SARCOIDOSIS	http://purl.obolibrary.org/obo/HP_0000006
+FG SYNDROME 2	http://purl.obolibrary.org/obo/HP_0000750
 Plasminogen activator inhibitor type 1 deficiency	http://www.orpha.net/ORDO/Orphanet_117886
-COMPLEMENT FACTOR D DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0004431	http://purl.obolibrary.org/obo/HP_0002718
+COMPLEMENT FACTOR D DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
 Dyslexia 1	http://www.ebi.ac.uk/efo/EFO_0005424
 Atrioventricular block	http://purl.obolibrary.org/obo/HP_0001678
 Gingival fibromatosis with hypertrichosis	http://www.ebi.ac.uk/efo/EFO_0000497
 Glucocorticoid deficiency with achalasia	http://www.orpha.net/ORDO/Orphanet_869
-LEOPARD SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_500	http://www.orpha.net/ORDO/Orphanet_1340
+LEOPARD SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_500
 CARNEY COMPLEX TYPE 1	http://www.orpha.net/ORDO/Orphanet_1359
-Hyperphosphatasia with mental retardation syndrome 4	http://purl.obolibrary.org/obo/HP_0000582	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003155	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0002540	http://purl.obolibrary.org/obo/HP_0010804	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000455	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0003763	http://purl.obolibrary.org/obo/HP_0004305
+Hyperphosphatasia with mental retardation syndrome 4	http://purl.obolibrary.org/obo/HP_0000582
 PEUTZ-JEGHERS SYNDROME	http://www.orpha.net/ORDO/Orphanet_2869
 Hereditary cerebral amyloid angiopathy	http://www.orpha.net/ORDO/Orphanet_85458
-NEUROLOGIC	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000577	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001395	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000821	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0100732	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000049	http://purl.obolibrary.org/obo/HP_0002570	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002460	http://purl.obolibrary.org/obo/HP_0009623	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0002827
-CALCIFICATION OF JOINTS AND ARTERIES	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001367	http://purl.obolibrary.org/obo/HP_0003207	http://purl.obolibrary.org/obo/HP_0000925	http://purl.obolibrary.org/obo/HP_0011986
+NEUROLOGIC	http://purl.obolibrary.org/obo/HP_0000219
+CALCIFICATION OF JOINTS AND ARTERIES	http://purl.obolibrary.org/obo/HP_0000007
 EPILEPTIC ENCEPHALOPATHY EARLY INFANTILE 1	http://www.ebi.ac.uk/efo/EFO_0000474
 PIERSON SYNDROME	http://www.orpha.net/ORDO/Orphanet_2670
-AGAMMAGLOBULINEMIA 6	http://purl.obolibrary.org/obo/HP_0011109	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0006532	http://purl.obolibrary.org/obo/HP_0002837	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000403	http://purl.obolibrary.org/obo/HP_0000509	http://purl.obolibrary.org/obo/HP_0002718	http://purl.obolibrary.org/obo/HP_0004432
-OVARIAN DYSGENESIS 1	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0000837	http://purl.obolibrary.org/obo/HP_0000786	http://purl.obolibrary.org/obo/HP_0000133
-LEUKOCYTE ADHESION DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_99844	http://www.orpha.net/ORDO/Orphanet_2968
+AGAMMAGLOBULINEMIA 6	http://purl.obolibrary.org/obo/HP_0011109
+OVARIAN DYSGENESIS 1	http://purl.obolibrary.org/obo/HP_0000007
+LEUKOCYTE ADHESION DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_99844
 Primary open angle glaucoma juvenile onset 1	http://www.ebi.ac.uk/efo/EFO_0000516
 Subcortical band heterotopia	http://www.orpha.net/ORDO/Orphanet_99796
-CEREBRAL CAVERNOUS MALFORMATIONS 2	http://purl.obolibrary.org/obo/HP_0001297	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001009	http://purl.obolibrary.org/obo/HP_0002315
-GLYCOGEN STORAGE DISEASE IXc	http://purl.obolibrary.org/obo/HP_0001408	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0001394	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002155	http://purl.obolibrary.org/obo/HP_0003162	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0001946
-CONE-ROD DYSTROPHY 9	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000548	http://purl.obolibrary.org/obo/HP_0000505
+CEREBRAL CAVERNOUS MALFORMATIONS 2	http://purl.obolibrary.org/obo/HP_0001297
+GLYCOGEN STORAGE DISEASE IXc	http://purl.obolibrary.org/obo/HP_0001408
+CONE-ROD DYSTROPHY 9	http://purl.obolibrary.org/obo/HP_0000007
 TANGIER DISEASE	http://www.orpha.net/ORDO/Orphanet_31150
 Richieri Costa Pereira syndrome	http://www.orpha.net/ORDO/Orphanet_3102
 RH-NULL HEMOLYTIC ANEMIA	http://www.ebi.ac.uk/efo/EFO_0005558
-PERIODIC FEVER	http://purl.obolibrary.org/obo/HP_0200067	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001945
+PERIODIC FEVER	http://purl.obolibrary.org/obo/HP_0200067
 small Atrial septal defect	http://purl.obolibrary.org/obo/HP_0001750
 JOUBERT SYNDROME 8	http://www.orpha.net/ORDO/Orphanet_475
 Spastic paraplegia 3	http://purl.obolibrary.org/obo/HP_0001258
-NEPHROLITHIASIS/OSTEOPOROSIS	http://purl.obolibrary.org/obo/HP_0000787	http://purl.obolibrary.org/obo/HP_0003109	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0002659	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0002150	http://www.orpha.net/ORDO/Orphanet_244305	http://purl.obolibrary.org/obo/HP_0002148	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000117
+NEPHROLITHIASIS/OSTEOPOROSIS	http://purl.obolibrary.org/obo/HP_0000787
 Hypobetalipoproteinemia	http://www.orpha.net/ORDO/Orphanet_31154
 Pachydermoperiostosis syndrome	http://www.orpha.net/ORDO/Orphanet_2796
 Syndromic mental retardation	http://www.ebi.ac.uk/efo/EFO_0003847
-RIPPLING MUSCLE DISEASE 2	http://www.orpha.net/ORDO/Orphanet_97238	http://www.orpha.net/ORDO/Orphanet_599	http://www.orpha.net/ORDO/Orphanet_263
-Mandibuloacral dysostosis	http://www.orpha.net/ORDO/Orphanet_2457	http://www.orpha.net/ORDO/Orphanet_166	http://www.orpha.net/ORDO/Orphanet_2670
+RIPPLING MUSCLE DISEASE 2	http://www.orpha.net/ORDO/Orphanet_97238
+Mandibuloacral dysostosis	http://www.orpha.net/ORDO/Orphanet_2457
 Atypical hemolytic-uremic syndrome 6	http://www.orpha.net/ORDO/Orphanet_2134
-Polyglandular autoimmune syndrome	http://www.orpha.net/ORDO/Orphanet_282196	http://www.orpha.net/ORDO/Orphanet_3453
+Polyglandular autoimmune syndrome	http://www.orpha.net/ORDO/Orphanet_282196
 Talipes equinovarus	http://purl.obolibrary.org/obo/HP_0001762
 Charcot-Marie-Tooth disease type 2K	http://www.orpha.net/ORDO/Orphanet_166
-Megalencephaly-polymicrogyria-polydactyly-hydrocephalus syndrome 3	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0001162	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0001355	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002126	http://purl.obolibrary.org/obo/HP_0000256
+Megalencephaly-polymicrogyria-polydactyly-hydrocephalus syndrome 3	http://purl.obolibrary.org/obo/HP_0002119
 WARBURG MICRO SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_2510
 GRANULOMATOUS DISEASE	http://www.orpha.net/ORDO/Orphanet_379
 Catel Manzke syndrome	http://www.orpha.net/ORDO/Orphanet_1388
-Lymphedema	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0001004	http://purl.obolibrary.org/obo/HP_0100797	http://purl.obolibrary.org/obo/HP_0001581	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0100658	http://purl.obolibrary.org/obo/HP_0000034
-SKELETAL DEFECTS	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0005736	http://purl.obolibrary.org/obo/HP_0003022	http://purl.obolibrary.org/obo/HP_0006501	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0005815	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0009777	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0003097	http://purl.obolibrary.org/obo/HP_0003038	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000233	http://purl.obolibrary.org/obo/HP_0000054
-HYPERPHOSPHATASIA WITH MENTAL RETARDATION SYNDROME 2	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0003155	http://purl.obolibrary.org/obo/HP_0000076	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0010055	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0010804	http://purl.obolibrary.org/obo/HP_0002023	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000455	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001357	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0002025	http://purl.obolibrary.org/obo/HP_0000637	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0000316
-FACTOR V AND FACTOR VIII	http://purl.obolibrary.org/obo/HP_0000421	http://purl.obolibrary.org/obo/HP_0000132	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001934	http://purl.obolibrary.org/obo/HP_0003225	http://purl.obolibrary.org/obo/HP_0003125
-C1q DEFICIENCY	http://purl.obolibrary.org/obo/HP_0002725	http://purl.obolibrary.org/obo/HP_0005356	http://purl.obolibrary.org/obo/HP_0002719	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000793
+Lymphedema	http://purl.obolibrary.org/obo/HP_0003829
+SKELETAL DEFECTS	http://purl.obolibrary.org/obo/HP_0000160
+HYPERPHOSPHATASIA WITH MENTAL RETARDATION SYNDROME 2	http://purl.obolibrary.org/obo/HP_0003577
+FACTOR V AND FACTOR VIII	http://purl.obolibrary.org/obo/HP_0000421
+C1q DEFICIENCY	http://purl.obolibrary.org/obo/HP_0002725
 Congenital Stromal Corneal Dystrophy	http://www.orpha.net/ORDO/Orphanet_101068
 X-Linked mental retardation 90	http://www.ebi.ac.uk/efo/EFO_0003847
-DEJERINE-SOTTAS SYNDROME	http://www.orpha.net/ORDO/Orphanet_101082	http://www.orpha.net/ORDO/Orphanet_64748	http://www.orpha.net/ORDO/Orphanet_166
-AORTIC VALVE DISEASE 2	http://purl.obolibrary.org/obo/HP_0001647	http://purl.obolibrary.org/obo/HP_0001680	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0004963
+DEJERINE-SOTTAS SYNDROME	http://www.orpha.net/ORDO/Orphanet_101082
+AORTIC VALVE DISEASE 2	http://purl.obolibrary.org/obo/HP_0001647
 THROMBOPHILIA DUE TO ACTIVATED PROTEIN C RESISTANCE	http://www.orpha.net/ORDO/Orphanet_217454
 Atypical hemolytic-uremic syndrome 1	http://www.orpha.net/ORDO/Orphanet_2134
 Spherocytosis type 2	http://www.orpha.net/ORDO/Orphanet_822
@@ -1205,136 +1205,136 @@ COMPLEMENT COMPONENT 9 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0012308
 HEMANGIOBLASTOMA	http://purl.obolibrary.org/obo/HP_0006880
 Gilbert syndrome	http://www.ebi.ac.uk/efo/EFO_0005556
 Autosomal recessive hypophosphatemic bone disease	http://www.ebi.ac.uk/efo/EFO_0004260
-Mitochondrial trifunctional protein deficiency	http://www.orpha.net/ORDO/Orphanet_5	http://www.orpha.net/ORDO/Orphanet_746
+Mitochondrial trifunctional protein deficiency	http://www.orpha.net/ORDO/Orphanet_5
 Resting heart rate	http://www.ebi.ac.uk/efo/EFO_0004351
-SILVER SPASTIC PARAPLEGIA SYNDROME	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002166	http://purl.obolibrary.org/obo/HP_0003392	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0003393	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0002064	http://purl.obolibrary.org/obo/HP_0003426	http://purl.obolibrary.org/obo/HP_0002061	http://purl.obolibrary.org/obo/HP_0003427	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0007340	http://purl.obolibrary.org/obo/HP_0001761
+SILVER SPASTIC PARAPLEGIA SYNDROME	http://purl.obolibrary.org/obo/HP_0001347
 Diffuse cerebellar atrophy	http://purl.obolibrary.org/obo/HP_0100275
 Carnitine palmitoyltransferase II deficiency	http://www.orpha.net/ORDO/Orphanet_157
-CORONARY ARTERY SPASM 1	http://www.ebi.ac.uk/efo/EFO_0000537	http://www.ebi.ac.uk/efo/EFO_1000013	http://www.ebi.ac.uk/efo/EFO_0000712
+CORONARY ARTERY SPASM 1	http://www.ebi.ac.uk/efo/EFO_0000537
 Hypogonadotropic hypogonadism 16 with or without anosmia	http://www.orpha.net/ORDO/Orphanet_478
 Juvenile macular degeneration and hypotrichosis	http://www.ebi.ac.uk/efo/EFO_0001365
 EMERY-DREIFUSS MUSCULAR DYSTROPHY 1	http://www.orpha.net/ORDO/Orphanet_261
 Congenital central hypoventilation	http://www.orpha.net/ORDO/Orphanet_661
 Acute intermittent porphyria	http://www.orpha.net/ORDO/Orphanet_79276
-AUTOIMMUNE INTERSTITIAL LUNG	http://purl.obolibrary.org/obo/HP_0002789	http://purl.obolibrary.org/obo/HP_0002094	http://purl.obolibrary.org/obo/HP_0008653	http://purl.obolibrary.org/obo/HP_0003565	http://purl.obolibrary.org/obo/HP_0002829	http://purl.obolibrary.org/obo/HP_0006530	http://purl.obolibrary.org/obo/HP_0012735
+AUTOIMMUNE INTERSTITIAL LUNG	http://purl.obolibrary.org/obo/HP_0002789
 PREKALLIKREIN DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_749
 BRANCHIOOTORENAL SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_107
-Permanent neonatal diabetes mellitus	http://www.orpha.net/ORDO/Orphanet_224	http://www.orpha.net/ORDO/Orphanet_99885
+Permanent neonatal diabetes mellitus	http://www.orpha.net/ORDO/Orphanet_224
 Lebers optic atrophy	http://www.orpha.net/ORDO/Orphanet_104
 Muscular hypotonia	http://purl.obolibrary.org/obo/HP_0001252
-DYSTONIA 3	http://purl.obolibrary.org/obo/HP_0001304	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0002548	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0002072
+DYSTONIA 3	http://purl.obolibrary.org/obo/HP_0001304
 CYSTINOSIS OCULAR NONNEPHROPATHIC	http://www.orpha.net/ORDO/Orphanet_213
-Trichohepatoenteric syndrome	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000445	http://purl.obolibrary.org/obo/HP_0001636	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0009886	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0001642	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0001396	http://purl.obolibrary.org/obo/HP_0002715	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0006267	http://purl.obolibrary.org/obo/HP_0001399	http://purl.obolibrary.org/obo/HP_0004734	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0011877	http://purl.obolibrary.org/obo/HP_0000952	http://purl.obolibrary.org/obo/HP_0000193	http://purl.obolibrary.org/obo/HP_0001732	http://purl.obolibrary.org/obo/HP_0002041	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0008070	http://purl.obolibrary.org/obo/HP_0008551	http://purl.obolibrary.org/obo/HP_0001894	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0003073	http://purl.obolibrary.org/obo/HP_0002213	http://purl.obolibrary.org/obo/HP_0001394	http://purl.obolibrary.org/obo/HP_0001395	http://purl.obolibrary.org/obo/HP_0011031	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003235	http://purl.obolibrary.org/obo/HP_0001659	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000457	http://purl.obolibrary.org/obo/HP_0002299	http://purl.obolibrary.org/obo/HP_0012023	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0002212	http://purl.obolibrary.org/obo/HP_0009891	http://purl.obolibrary.org/obo/HP_0002224	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0011473	http://purl.obolibrary.org/obo/HP_0001561	http://purl.obolibrary.org/obo/HP_0001629
+Trichohepatoenteric syndrome	http://purl.obolibrary.org/obo/HP_0000494
 Crigler Najjar syndrome	http://www.orpha.net/ORDO/Orphanet_79234
 Ischiopatellar dysplasia	http://www.orpha.net/ORDO/Orphanet_1509
-Persistent hyperinsulinemic hypoglycemia of infancy	http://www.orpha.net/ORDO/Orphanet_657	http://www.orpha.net/ORDO/Orphanet_276525
-METACHROMATIC LEUKODYSTROPHY	http://www.orpha.net/ORDO/Orphanet_512	http://www.orpha.net/ORDO/Orphanet_309263	http://www.orpha.net/ORDO/Orphanet_309271
+Persistent hyperinsulinemic hypoglycemia of infancy	http://www.orpha.net/ORDO/Orphanet_657
+METACHROMATIC LEUKODYSTROPHY	http://www.orpha.net/ORDO/Orphanet_512
 Erythrokeratodermia variabilis	http://www.orpha.net/ORDO/Orphanet_317
-GLYCOGEN STORAGE DISEASE 0	http://purl.obolibrary.org/obo/HP_0003546	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001638	http://purl.obolibrary.org/obo/HP_0012270	http://purl.obolibrary.org/obo/HP_0002069	http://purl.obolibrary.org/obo/HP_0001712
-Arrhythmogenic right ventricular cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0005306
+GLYCOGEN STORAGE DISEASE 0	http://purl.obolibrary.org/obo/HP_0003546
+Arrhythmogenic right ventricular cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000407
 BARDET-BIEDL SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_110
 PARKINSON DISEASE 11	http://www.orpha.net/ORDO/Orphanet_411602
 ALAGILLE SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_52
 LEBER CONGENITAL AMAUROSIS 15	http://www.orpha.net/ORDO/Orphanet_65
 ISOVALERIC ACIDEMIA	http://www.orpha.net/ORDO/Orphanet_33
-Triphalangeal thumb	http://purl.obolibrary.org/obo/HP_0100258	http://purl.obolibrary.org/obo/HP_0001199
+Triphalangeal thumb	http://purl.obolibrary.org/obo/HP_0100258
 Parkinson disease 2	http://www.orpha.net/ORDO/Orphanet_2828
-MALE GERM CELL TUMOR	http://www.ebi.ac.uk/efo/EFO_0000588	http://www.ebi.ac.uk/efo/EFO_0000574	http://www.ebi.ac.uk/efo/EFO_0000514
-Familial hypertrophic cardiomyopathy 12	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 14	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0003355	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0002171	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001522	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0002059
+MALE GERM CELL TUMOR	http://www.ebi.ac.uk/efo/EFO_0000588
+Familial hypertrophic cardiomyopathy 12	http://www.ebi.ac.uk/efo/EFO_0000318
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 14	http://purl.obolibrary.org/obo/HP_0002151
 COFFIN-SIRIS SYNDROME	http://www.orpha.net/ORDO/Orphanet_1465
 CEREBRAL AUTOSOMAL RECESSIVE ARTERIOPATHY WITH SUBCORTICAL INFARCTS AND LEUKOENCEPHALOPATHY	http://www.orpha.net/ORDO/Orphanet_199354
-ERYTHROCYTOSIS	http://purl.obolibrary.org/obo/HP_0001899	http://purl.obolibrary.org/obo/HP_0001900	http://www.orpha.net/ORDO/Orphanet_238557	http://www.orpha.net/ORDO/Orphanet_90042	http://purl.obolibrary.org/obo/HP_0000006	http://www.orpha.net/ORDO/Orphanet_892	http://purl.obolibrary.org/obo/HP_0001898
+ERYTHROCYTOSIS	http://purl.obolibrary.org/obo/HP_0001899
 Currarino triad	http://www.orpha.net/ORDO/Orphanet_1552
 Mental retardation 63	http://www.ebi.ac.uk/efo/EFO_0003847
 Branchio-otic syndrome	http://www.orpha.net/ORDO/Orphanet_52429
-Renal hypodysplasia/aplasia 2	http://purl.obolibrary.org/obo/HP_0002009	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002089	http://purl.obolibrary.org/obo/HP_0001582
-Diamond-Blackfan anemia 13	http://purl.obolibrary.org/obo/HP_0001897	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0030270	http://purl.obolibrary.org/obo/HP_0011463
+Renal hypodysplasia/aplasia 2	http://purl.obolibrary.org/obo/HP_0002009
+Diamond-Blackfan anemia 13	http://purl.obolibrary.org/obo/HP_0001897
 FAMILIAL ADENOMATOUS POLYPOSIS 3	http://www.orpha.net/ORDO/Orphanet_733
 CORNELIA DE LANGE SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_199
 Hirschsprung disease 4	http://www.orpha.net/ORDO/Orphanet_388
-Spongy degeneration of central nervous system	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0007703	http://purl.obolibrary.org/obo/HP_0004372	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0002179	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002197	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0000649	http://purl.obolibrary.org/obo/HP_0002977	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0012444	http://purl.obolibrary.org/obo/HP_0007305	http://purl.obolibrary.org/obo/HP_0001476
+Spongy degeneration of central nervous system	http://purl.obolibrary.org/obo/HP_0001371
 CATARACT 19	http://www.ebi.ac.uk/efo/EFO_0001059
 Myoclonic encephalopathy	http://www.orpha.net/ORDO/Orphanet_1935
 Advanced sleep phase syndrome	http://www.orpha.net/ORDO/Orphanet_164736
-Epidermolysis bullosa simplex with nail dystrophy	http://purl.obolibrary.org/obo/HP_0008404	http://purl.obolibrary.org/obo/HP_0007556
+Epidermolysis bullosa simplex with nail dystrophy	http://purl.obolibrary.org/obo/HP_0008404
 Focal segmental glomerulosclerosis 8	http://www.ebi.ac.uk/efo/EFO_0004236
 congenital disorder of glycosylation type 1N	http://www.orpha.net/ORDO/Orphanet_244310
-OSTEOPETROSIS	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0002756	http://purl.obolibrary.org/obo/HP_0003155	http://purl.obolibrary.org/obo/HP_0001876	http://purl.obolibrary.org/obo/HP_0002754	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0030328	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0006532	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0100671	http://purl.obolibrary.org/obo/HP_0004313	http://purl.obolibrary.org/obo/HP_0000670	http://purl.obolibrary.org/obo/HP_0000529	http://purl.obolibrary.org/obo/HP_0003034	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0100959	http://purl.obolibrary.org/obo/HP_0011002	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0007807	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0006335	http://purl.obolibrary.org/obo/HP_0002812	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0003015	http://purl.obolibrary.org/obo/HP_0000597	http://purl.obolibrary.org/obo/HP_0001978	http://purl.obolibrary.org/obo/HP_0001433	http://purl.obolibrary.org/obo/HP_0004975	http://purl.obolibrary.org/obo/HP_0003826	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0004618	http://purl.obolibrary.org/obo/HP_0004437	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0007626	http://www.orpha.net/ORDO/Orphanet_2781	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0004499	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0010628	http://purl.obolibrary.org/obo/HP_0002757	http://purl.obolibrary.org/obo/HP_0002857	http://purl.obolibrary.org/obo/HP_0001281	http://purl.obolibrary.org/obo/HP_0007209	http://purl.obolibrary.org/obo/HP_0000256
+OSTEOPETROSIS	http://purl.obolibrary.org/obo/HP_0000303
 Congenital disorder of glycosylation type 1F	http://www.orpha.net/ORDO/Orphanet_79323
-BEAULIEU-BOYCOTT-INNES SYNDROME	http://purl.obolibrary.org/obo/HP_0000582	http://purl.obolibrary.org/obo/HP_0030127	http://purl.obolibrary.org/obo/HP_0003189	http://purl.obolibrary.org/obo/HP_0000581	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0012745	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000010	http://purl.obolibrary.org/obo/HP_0009890	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000670	http://purl.obolibrary.org/obo/HP_0009765	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000490	http://purl.obolibrary.org/obo/HP_0000689	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0000085
-DIAMOND-BLACKFAN ANEMIA 10	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000086	http://purl.obolibrary.org/obo/HP_0008551	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0005321	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0000413	http://purl.obolibrary.org/obo/HP_0000776	http://purl.obolibrary.org/obo/HP_0001896	http://purl.obolibrary.org/obo/HP_0002880	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001972	http://purl.obolibrary.org/obo/HP_0000453	http://purl.obolibrary.org/obo/HP_0001629
+BEAULIEU-BOYCOTT-INNES SYNDROME	http://purl.obolibrary.org/obo/HP_0000582
+DIAMOND-BLACKFAN ANEMIA 10	http://purl.obolibrary.org/obo/HP_0000272
 MYOPIA 24	http://purl.obolibrary.org/obo/HP_0000545
 NANCE-HORAN SYNDROME	http://www.orpha.net/ORDO/Orphanet_627
 MERRF/MELAS overlap syndrome	http://www.orpha.net/ORDO/Orphanet_138900
-PANCREATIC AGENESIS	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0000857	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002594	http://purl.obolibrary.org/obo/HP_0001738
+PANCREATIC AGENESIS	http://purl.obolibrary.org/obo/HP_0000007
 Iminoglycinuria	http://www.orpha.net/ORDO/Orphanet_42062
 Left ventricular noncompaction 5	http://www.orpha.net/ORDO/Orphanet_54260
-APLASTIC ANEMIA	http://purl.obolibrary.org/obo/HP_0005528	http://purl.obolibrary.org/obo/HP_0001915
-TREACHER COLLINS SYNDROME 1	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000377	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0007678	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0000636	http://purl.obolibrary.org/obo/HP_0009555	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000384	http://purl.obolibrary.org/obo/HP_0007633	http://purl.obolibrary.org/obo/HP_0009554	http://purl.obolibrary.org/obo/HP_0030680	http://purl.obolibrary.org/obo/HP_0007776	http://purl.obolibrary.org/obo/HP_0000197	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000572	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000652	http://purl.obolibrary.org/obo/HP_0000185	http://purl.obolibrary.org/obo/HP_0000453	http://purl.obolibrary.org/obo/HP_0000372
-Combined oxidative phosphorylation deficiency 24	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0010628	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0003198
+APLASTIC ANEMIA	http://purl.obolibrary.org/obo/HP_0005528
+TREACHER COLLINS SYNDROME 1	http://purl.obolibrary.org/obo/HP_0000272
+Combined oxidative phosphorylation deficiency 24	http://purl.obolibrary.org/obo/HP_0000252
 CONE DYSTROPHY 5	http://www.orpha.net/ORDO/Orphanet_16
 Congenital disorder of glycosylation type 1v	http://www.orpha.net/ORDO/Orphanet_137
 Thrombophilia due to thrombomodulin defect	http://www.orpha.net/ORDO/Orphanet_436169
 KOWARSKI SYNDROME	http://www.orpha.net/ORDO/Orphanet_629
-MOLYBDENUM COFACTOR DEFICIENCY	http://purl.obolibrary.org/obo/HP_0003643	http://purl.obolibrary.org/obo/HP_0002510	http://purl.obolibrary.org/obo/HP_0011943	http://purl.obolibrary.org/obo/HP_0011814	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000276	http://purl.obolibrary.org/obo/HP_0000804	http://purl.obolibrary.org/obo/HP_0003447	http://purl.obolibrary.org/obo/HP_0003570	http://purl.obolibrary.org/obo/HP_0011942	http://purl.obolibrary.org/obo/HP_0001083	http://purl.obolibrary.org/obo/HP_0011935	http://purl.obolibrary.org/obo/HP_0003359	http://purl.obolibrary.org/obo/HP_0002179	http://purl.obolibrary.org/obo/HP_0010934	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003537	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0003739	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002171	http://purl.obolibrary.org/obo/HP_0011096	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002932	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0003534	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0000293	http://purl.obolibrary.org/obo/HP_0003166	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0003606	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0012471	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0001285	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0002059
+MOLYBDENUM COFACTOR DEFICIENCY	http://purl.obolibrary.org/obo/HP_0003643
 Spondylocostal dysostosis 3	http://www.orpha.net/ORDO/Orphanet_364559
 Odontotrichomelic syndrome	http://www.orpha.net/ORDO/Orphanet_2723
-Limb-girdle muscular dystrophy-dystroglycanopathy	http://www.orpha.net/ORDO/Orphanet_371024	http://www.orpha.net/ORDO/Orphanet_263
-RETINAL DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_65	http://www.orpha.net/ORDO/Orphanet_71862
+Limb-girdle muscular dystrophy-dystroglycanopathy	http://www.orpha.net/ORDO/Orphanet_371024
+RETINAL DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_65
 Chromophobe renal cell carcinoma	http://www.ebi.ac.uk/efo/EFO_0000335
-OCULODENTODIGITAL DYSPLASIA	http://purl.obolibrary.org/obo/HP_0003189	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000653	http://purl.obolibrary.org/obo/HP_0200055	http://purl.obolibrary.org/obo/HP_0000682	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0009748	http://purl.obolibrary.org/obo/HP_0009917	http://purl.obolibrary.org/obo/HP_0000678	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0000684	http://purl.obolibrary.org/obo/HP_0006482	http://purl.obolibrary.org/obo/HP_0005769	http://purl.obolibrary.org/obo/HP_0007930	http://purl.obolibrary.org/obo/HP_0001773	http://purl.obolibrary.org/obo/HP_0000689	http://purl.obolibrary.org/obo/HP_0004322	http://www.orpha.net/ORDO/Orphanet_2710	http://purl.obolibrary.org/obo/HP_0000233	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0000430	http://purl.obolibrary.org/obo/HP_0000675	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0010705	http://purl.obolibrary.org/obo/HP_0000460	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0000506	http://purl.obolibrary.org/obo/HP_0005622	http://purl.obolibrary.org/obo/HP_0012745	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0005768	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0000327	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000685	http://purl.obolibrary.org/obo/HP_0000568
+OCULODENTODIGITAL DYSPLASIA	http://purl.obolibrary.org/obo/HP_0003189
 Familial restrictive cardiomyopathy 1	http://www.orpha.net/ORDO/Orphanet_217635
-Bone marrow failure syndrome 2	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001882	http://purl.obolibrary.org/obo/HP_0005528	http://purl.obolibrary.org/obo/HP_0001319
-MITOCHONDRIAL DNA DEPLETION SYNDROME 4B (MNGIE TYPE)	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0002579	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000590	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0003324	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003434	http://purl.obolibrary.org/obo/HP_0003270	http://purl.obolibrary.org/obo/HP_0004395	http://purl.obolibrary.org/obo/HP_0003737	http://purl.obolibrary.org/obo/HP_0004326	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002024	http://purl.obolibrary.org/obo/HP_0002027	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002500
-Congenital long QT syndrome	http://www.orpha.net/ORDO/Orphanet_768	http://www.orpha.net/ORDO/Orphanet_130	http://www.orpha.net/ORDO/Orphanet_51083
+Bone marrow failure syndrome 2	http://purl.obolibrary.org/obo/HP_0000007
+MITOCHONDRIAL DNA DEPLETION SYNDROME 4B (MNGIE TYPE)	http://purl.obolibrary.org/obo/HP_0003828
+Congenital long QT syndrome	http://www.orpha.net/ORDO/Orphanet_768
 Focal segmental glomerulosclerosis 7	http://www.ebi.ac.uk/efo/EFO_0004236
 Dysfibrinogenemia	http://purl.obolibrary.org/obo/HP_0011901
 Short rib-polydactyly syndrome	http://www.orpha.net/ORDO/Orphanet_93269
 HYDRANENCEPHALY WITH ABNORMAL GENITALIA	http://www.orpha.net/ORDO/Orphanet_2177
-Dilated cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+Dilated cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000407
 Craniofrontonasal dysplasia	http://www.orpha.net/ORDO/Orphanet_1520
-GM2-GANGLIOSIDOSIS	http://www.orpha.net/ORDO/Orphanet_309144	http://www.orpha.net/ORDO/Orphanet_845
+GM2-GANGLIOSIDOSIS	http://www.orpha.net/ORDO/Orphanet_309144
 Joubert syndrome 9/15	http://www.orpha.net/ORDO/Orphanet_475
 Generalized epilepsy with febrile seizures plus 3	http://www.ebi.ac.uk/efo/EFO_0000474
-Familial hypertrophic cardiomyopathy 4	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+Familial hypertrophic cardiomyopathy 4	http://www.ebi.ac.uk/efo/EFO_0000318
 Glycogen storage disease type IXa1	http://www.orpha.net/ORDO/Orphanet_79201
-LONG QT SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_768	http://www.orpha.net/ORDO/Orphanet_130
-Congenital Muscular Dystrophy	http://www.orpha.net/ORDO/Orphanet_97242	http://www.orpha.net/ORDO/Orphanet_899	http://www.orpha.net/ORDO/Orphanet_263
-Cranioectodermal dysplasia 4	http://www.orpha.net/ORDO/Orphanet_1515	http://www.orpha.net/ORDO/Orphanet_3156
+LONG QT SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_768
+Congenital Muscular Dystrophy	http://www.orpha.net/ORDO/Orphanet_97242
+Cranioectodermal dysplasia 4	http://www.orpha.net/ORDO/Orphanet_1515
 Limb hypertonia	http://purl.obolibrary.org/obo/HP_0002509
 Atypical hemolytic-uremic syndrome 3	http://www.orpha.net/ORDO/Orphanet_2134
 Familial hemiplegic migraine type 1	http://www.ebi.ac.uk/efo/EFO_0003821
 Ciliopathy	http://www.ebi.ac.uk/efo/EFO_0003900
-Autoinflammation with infantile enterocolitis	http://purl.obolibrary.org/obo/HP_0001945	http://purl.obolibrary.org/obo/HP_0005521	http://purl.obolibrary.org/obo/HP_0003281	http://purl.obolibrary.org/obo/HP_0004387	http://purl.obolibrary.org/obo/HP_0002829	http://purl.obolibrary.org/obo/HP_0001876	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003326	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001744
-VAN BUCHEM DISEASE	http://www.orpha.net/ORDO/Orphanet_3416	http://www.orpha.net/ORDO/Orphanet_2790
-DIARRHEA 3	http://purl.obolibrary.org/obo/HP_0005208	http://purl.obolibrary.org/obo/HP_0000588	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000073	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000143	http://purl.obolibrary.org/obo/HP_0002566	http://purl.obolibrary.org/obo/HP_0002023	http://purl.obolibrary.org/obo/HP_0001561	http://purl.obolibrary.org/obo/HP_0003270	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0200020	http://purl.obolibrary.org/obo/HP_0000453	http://purl.obolibrary.org/obo/HP_0000256
-SPASTIC PARAPLEGIA 50	http://purl.obolibrary.org/obo/HP_0001181	http://purl.obolibrary.org/obo/HP_0006887	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0002510	http://purl.obolibrary.org/obo/HP_0000341	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002307	http://purl.obolibrary.org/obo/HP_0002171	http://purl.obolibrary.org/obo/HP_0010864	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000322	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0012811	http://purl.obolibrary.org/obo/HP_0002200	http://purl.obolibrary.org/obo/HP_0000414	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0100021	http://purl.obolibrary.org/obo/HP_0012444	http://purl.obolibrary.org/obo/HP_0000280
+Autoinflammation with infantile enterocolitis	http://purl.obolibrary.org/obo/HP_0001945
+VAN BUCHEM DISEASE	http://www.orpha.net/ORDO/Orphanet_3416
+DIARRHEA 3	http://purl.obolibrary.org/obo/HP_0005208
+SPASTIC PARAPLEGIA 50	http://purl.obolibrary.org/obo/HP_0001181
 Hemolytic anemia	http://www.ebi.ac.uk/efo/EFO_0005558
-Fukuyama congenital muscular dystrophy	http://www.orpha.net/ORDO/Orphanet_97242	http://www.orpha.net/ORDO/Orphanet_272
-Hypogonadotropic hypogonadism 21 with or without anosmia	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0000939
-Primary hyperoxaluria	http://www.orpha.net/ORDO/Orphanet_93599	http://www.orpha.net/ORDO/Orphanet_93598	http://www.orpha.net/ORDO/Orphanet_93600
+Fukuyama congenital muscular dystrophy	http://www.orpha.net/ORDO/Orphanet_97242
+Hypogonadotropic hypogonadism 21 with or without anosmia	http://purl.obolibrary.org/obo/HP_0000938
+Primary hyperoxaluria	http://www.orpha.net/ORDO/Orphanet_93599
 Hereditary Spastic Paraplegia	http://www.orpha.net/ORDO/Orphanet_685
 Dilated cardiomyopathy 1HH	http://www.ebi.ac.uk/efo/EFO_0000407
 BERNARD SOULIER SYNDROME	http://www.orpha.net/ORDO/Orphanet_274
 Severe congenital neutropenia autosomal dominant	http://www.orpha.net/ORDO/Orphanet_42738
-Early infantile epileptic encephalopathy 2	http://www.orpha.net/ORDO/Orphanet_3095	http://www.orpha.net/ORDO/Orphanet_1934
+Early infantile epileptic encephalopathy 2	http://www.orpha.net/ORDO/Orphanet_3095
 Navajo neurohepatopathy	http://www.orpha.net/ORDO/Orphanet_255229
 RETINITIS PIGMENTOSA 35	http://www.orpha.net/ORDO/Orphanet_791
 SPASTIC PARAPLEGIA 75	http://purl.obolibrary.org/obo/HP_0001258
-SUDDEN INFANT DEATH SYNDROME	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0005303	http://www.ebi.ac.uk/efo/EFO_0004269	http://www.ebi.ac.uk/efo/EFO_0000365
+SUDDEN INFANT DEATH SYNDROME	http://www.ebi.ac.uk/efo/EFO_0000318
 Isovaleryl-CoA dehydrogenase deficiency	http://www.orpha.net/ORDO/Orphanet_33
 Myopathy with tubular aggregates	http://www.orpha.net/ORDO/Orphanet_2593
-HYPERPHOSPHATASIA WITH MENTAL RETARDATION SYNDROME 1	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000582	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0001216	http://purl.obolibrary.org/obo/HP_0001090	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0002714	http://purl.obolibrary.org/obo/HP_0003155	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0000204	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0009882	http://purl.obolibrary.org/obo/HP_0001545	http://purl.obolibrary.org/obo/HP_0010804	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0010864	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0001182	http://purl.obolibrary.org/obo/HP_0000455	http://purl.obolibrary.org/obo/HP_0000322	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001831	http://purl.obolibrary.org/obo/HP_0001357	http://purl.obolibrary.org/obo/HP_0000637	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0002251	http://purl.obolibrary.org/obo/HP_0001792	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0002553	http://purl.obolibrary.org/obo/HP_0000316
+HYPERPHOSPHATASIA WITH MENTAL RETARDATION SYNDROME 1	http://purl.obolibrary.org/obo/HP_0000272
 Familial dysautonomia	http://www.orpha.net/ORDO/Orphanet_1764
 AMYOTROPHIC LATERAL SCLEROSIS 15 WITH OR WITHOUT FRONTOTEMPORAL DEMENTIA	http://www.ebi.ac.uk/efo/EFO_0000253
 Retinitis pigmentosa 15	http://www.orpha.net/ORDO/Orphanet_791
 Sepsis	http://www.ebi.ac.uk/efo/EFO_0001420
-EMERY-DREIFUSS MUSCULAR DYSTROPHY	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0001645	http://purl.obolibrary.org/obo/HP_0004631	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0001771	http://purl.obolibrary.org/obo/HP_0011463	http://purl.obolibrary.org/obo/HP_0000464	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0002515	http://purl.obolibrary.org/obo/HP_0001692	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0011807	http://purl.obolibrary.org/obo/HP_0002987	http://purl.obolibrary.org/obo/HP_0001678
+EMERY-DREIFUSS MUSCULAR DYSTROPHY	http://purl.obolibrary.org/obo/HP_0003236
 GM1-GANGLIOSIDOSIS	http://www.orpha.net/ORDO/Orphanet_354
 Primary autosomal recessive microcephaly 5	http://www.orpha.net/ORDO/Orphanet_2512
 DYSTONIA 2	http://www.orpha.net/ORDO/Orphanet_99657
-FRONTOTEMPORAL DEMENTIA AND/OR AMYOTROPHIC LATERAL SCLEROSIS 4	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000751	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0000741	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0001283	http://purl.obolibrary.org/obo/HP_0002300	http://purl.obolibrary.org/obo/HP_0002145	http://purl.obolibrary.org/obo/HP_0007354	http://purl.obolibrary.org/obo/HP_0002380	http://purl.obolibrary.org/obo/HP_0002366	http://purl.obolibrary.org/obo/HP_0000734	http://purl.obolibrary.org/obo/HP_0002463	http://purl.obolibrary.org/obo/HP_0001265
+FRONTOTEMPORAL DEMENTIA AND/OR AMYOTROPHIC LATERAL SCLEROSIS 4	http://purl.obolibrary.org/obo/HP_0001347
 Retinitis pigmentosa 53	http://www.orpha.net/ORDO/Orphanet_791
 Familial benign pemphigus	http://www.orpha.net/ORDO/Orphanet_2841
 NEPHRONOPHTHISIS 9	http://www.orpha.net/ORDO/Orphanet_655
@@ -1345,22 +1345,22 @@ Pituitary stalk interruption syndrome	http://www.orpha.net/ORDO/Orphanet_95496
 Spermatogenic failure 3	http://purl.obolibrary.org/obo/HP_0000006
 Spastic paraplegia 5A	http://www.orpha.net/ORDO/Orphanet_100986
 RETINITIS PIGMENTOSA 13	http://www.orpha.net/ORDO/Orphanet_791
-ALPHA-THALASSEMIA-2	http://www.orpha.net/ORDO/Orphanet_846	http://www.orpha.net/ORDO/Orphanet_93616
+ALPHA-THALASSEMIA-2	http://www.orpha.net/ORDO/Orphanet_846
 Brain tumor-polyposis syndrome 2	http://www.ebi.ac.uk/efo/EFO_0003833
-Lowe syndrome	http://www.orpha.net/ORDO/Orphanet_534	http://www.orpha.net/ORDO/Orphanet_93623
-LEBER CONGENITAL AMAUROSIS 10	http://www.orpha.net/ORDO/Orphanet_65	http://www.orpha.net/ORDO/Orphanet_475
+Lowe syndrome	http://www.orpha.net/ORDO/Orphanet_534
+LEBER CONGENITAL AMAUROSIS 10	http://www.orpha.net/ORDO/Orphanet_65
 IMMUNODEFICIENCY 45	http://purl.obolibrary.org/obo/HP_0002721
 LEBER CONGENITAL AMAUROSIS 6	http://www.orpha.net/ORDO/Orphanet_65
-METHYLMALONIC ACIDURIA AND HOMOCYSTINURIA	http://purl.obolibrary.org/obo/HP_0001875	http://purl.obolibrary.org/obo/HP_0002789	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0002533	http://purl.obolibrary.org/obo/HP_0012120	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001680	http://purl.obolibrary.org/obo/HP_0006610	http://purl.obolibrary.org/obo/HP_0001254	http://purl.obolibrary.org/obo/HP_0002912	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002020	http://purl.obolibrary.org/obo/HP_0002156	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0002092	http://purl.obolibrary.org/obo/HP_0002160	http://purl.obolibrary.org/obo/HP_0003145	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0003524	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0003223	http://purl.obolibrary.org/obo/HP_0000023	http://purl.obolibrary.org/obo/HP_0002059
-INFANTILE LIVER FAILURE SYNDROME 1	http://purl.obolibrary.org/obo/HP_0003256	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0000293	http://purl.obolibrary.org/obo/HP_0010511	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0006554	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0002194	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001972	http://purl.obolibrary.org/obo/HP_0100807	http://purl.obolibrary.org/obo/HP_0001397	http://purl.obolibrary.org/obo/HP_0002007
+METHYLMALONIC ACIDURIA AND HOMOCYSTINURIA	http://purl.obolibrary.org/obo/HP_0001875
+INFANTILE LIVER FAILURE SYNDROME 1	http://purl.obolibrary.org/obo/HP_0003256
 LOEYS-DIETZ SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_60030
 Fibrous dysplasia of jaw	http://www.orpha.net/ORDO/Orphanet_184
-FABRY DISEASE	http://www.orpha.net/ORDO/Orphanet_99739	http://www.orpha.net/ORDO/Orphanet_324
-Morbid obesity and spermatogenic failure	http://purl.obolibrary.org/obo/HP_0000789	http://purl.obolibrary.org/obo/HP_0000855	http://purl.obolibrary.org/obo/HP_0005978	http://purl.obolibrary.org/obo/HP_0001513	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0003124	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002155	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0003233	http://purl.obolibrary.org/obo/HP_0003141	http://purl.obolibrary.org/obo/HP_0001658	http://purl.obolibrary.org/obo/HP_0000798	http://purl.obolibrary.org/obo/HP_0001397	http://purl.obolibrary.org/obo/HP_0005181	http://purl.obolibrary.org/obo/HP_0000027
-CONE-ROD DYSTROPHY 20	http://purl.obolibrary.org/obo/HP_0000551	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0000548	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001133
+FABRY DISEASE	http://www.orpha.net/ORDO/Orphanet_99739
+Morbid obesity and spermatogenic failure	http://purl.obolibrary.org/obo/HP_0000789
+CONE-ROD DYSTROPHY 20	http://purl.obolibrary.org/obo/HP_0000551
 Spastic paraplegia 1	http://purl.obolibrary.org/obo/HP_0001258
 RETINITIS PIGMENTOSA 48	http://www.orpha.net/ORDO/Orphanet_791
-Acromelic frontonasal dysostosis	http://purl.obolibrary.org/obo/HP_0006951	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0000506	http://purl.obolibrary.org/obo/HP_0001159	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0004122	http://purl.obolibrary.org/obo/HP_0002084	http://purl.obolibrary.org/obo/HP_0000204	http://purl.obolibrary.org/obo/HP_0000501	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0010806	http://purl.obolibrary.org/obo/HP_0001274	http://purl.obolibrary.org/obo/HP_0001805	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0010559	http://purl.obolibrary.org/obo/HP_0040075	http://purl.obolibrary.org/obo/HP_0100258	http://purl.obolibrary.org/obo/HP_0002190	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000455	http://purl.obolibrary.org/obo/HP_0002435	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0002690	http://purl.obolibrary.org/obo/HP_0011803	http://purl.obolibrary.org/obo/HP_0000429
+Acromelic frontonasal dysostosis	http://purl.obolibrary.org/obo/HP_0006951
 VON HIPPEL-LINDAU SYNDROME	http://www.orpha.net/ORDO/Orphanet_892
 Deafness - enamel hypoplasia - nail defects	http://www.orpha.net/ORDO/Orphanet_3220
 Bronchiectasis	http://purl.obolibrary.org/obo/HP_0002110
@@ -1371,13 +1371,13 @@ OSTEOPOROSIS	http://www.ebi.ac.uk/efo/EFO_0003882
 Nephronophthisis 19	http://www.orpha.net/ORDO/Orphanet_655
 Osteogenesis imperfecta type 8	http://www.orpha.net/ORDO/Orphanet_666
 Congenital disorder of glycosylation type 1H	http://www.orpha.net/ORDO/Orphanet_79325
-Combined oxidative phosphorylation deficiency 21	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0002509	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0001397
-ATAXIA-OCULOMOTOR APRAXIA 4	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0009830	http://purl.obolibrary.org/obo/HP_0002445	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000657
-DYSTONIA 27	http://purl.obolibrary.org/obo/HP_0012048	http://purl.obolibrary.org/obo/HP_0002356	http://purl.obolibrary.org/obo/HP_0002174	http://purl.obolibrary.org/obo/HP_0012049
+Combined oxidative phosphorylation deficiency 21	http://purl.obolibrary.org/obo/HP_0002151
+ATAXIA-OCULOMOTOR APRAXIA 4	http://purl.obolibrary.org/obo/HP_0100543
+DYSTONIA 27	http://purl.obolibrary.org/obo/HP_0012048
 Glucose transporter type 1 deficiency syndrome	http://www.orpha.net/ORDO/Orphanet_71277
-DIABETES MELLITUS	http://www.ebi.ac.uk/efo/EFO_0000400	http://www.ebi.ac.uk/efo/EFO_0001360	http://www.ebi.ac.uk/efo/EFO_0001359
-Alpha-B crystallinopathy	http://purl.obolibrary.org/obo/HP_0000467	http://purl.obolibrary.org/obo/HP_0009027	http://purl.obolibrary.org/obo/HP_0003555	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0003458	http://purl.obolibrary.org/obo/HP_0003736	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0009072	http://purl.obolibrary.org/obo/HP_0002747	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0002460	http://purl.obolibrary.org/obo/HP_0003325	http://purl.obolibrary.org/obo/HP_0003560	http://purl.obolibrary.org/obo/HP_0003694
-DE LA CHAPELLE DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_628	http://www.orpha.net/ORDO/Orphanet_56304
+DIABETES MELLITUS	http://www.ebi.ac.uk/efo/EFO_0000400
+Alpha-B crystallinopathy	http://purl.obolibrary.org/obo/HP_0000467
+DE LA CHAPELLE DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_628
 Osteogenesis imperfecta type 13	http://www.orpha.net/ORDO/Orphanet_666
 Warburg micro syndrome 4	http://www.orpha.net/ORDO/Orphanet_2510
 PULMONARY ALVEOLAR MICROLITHIASIS	http://www.orpha.net/ORDO/Orphanet_60025
@@ -1387,139 +1387,139 @@ Truncal obesity	http://purl.obolibrary.org/obo/HP_0001956
 HYPOMYELINATION WITH BRAINSTEM AND SPINAL CORD INVOLVEMENT AND LEG SPASTICITY	http://www.orpha.net/ORDO/Orphanet_363412
 SENIOR-LOKEN SYNDROME 5	http://www.orpha.net/ORDO/Orphanet_3156
 Seckel syndrome 8	http://www.orpha.net/ORDO/Orphanet_808
-Corneal dystrophy	http://purl.obolibrary.org/obo/HP_0000006	http://www.orpha.net/ORDO/Orphanet_98974	http://purl.obolibrary.org/obo/HP_0001131
-Osteopetrosis autosomal dominant type 1	http://purl.obolibrary.org/obo/HP_0002644	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000925	http://purl.obolibrary.org/obo/HP_0002315	http://purl.obolibrary.org/obo/HP_0002684	http://purl.obolibrary.org/obo/HP_0005789	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0001939
-PARAGANGLIOMA AND GASTRIC STROMAL SARCOMA	http://www.orpha.net/ORDO/Orphanet_44890	http://www.orpha.net/ORDO/Orphanet_139411	http://www.orpha.net/ORDO/Orphanet_97286
+Corneal dystrophy	http://purl.obolibrary.org/obo/HP_0000006
+Osteopetrosis autosomal dominant type 1	http://purl.obolibrary.org/obo/HP_0002644
+PARAGANGLIOMA AND GASTRIC STROMAL SARCOMA	http://www.orpha.net/ORDO/Orphanet_44890
 Hirschsprung disease	http://www.orpha.net/ORDO/Orphanet_388
 Microcephaly with or without chorioretinopathy	http://www.ebi.ac.uk/efo/EFO_0003847
-Systemic lupus erythematosus 10	http://www.ebi.ac.uk/efo/EFO_0000685	http://www.ebi.ac.uk/efo/EFO_0002690
-Delayed puberty	http://purl.obolibrary.org/obo/HP_0000823	http://purl.obolibrary.org/obo/HP_0000044
-Age-related macular degeneration 2	http://www.ebi.ac.uk/efo/EFO_0001365	http://www.ebi.ac.uk/efo/EFO_0000474
-Hereditary Paraganglioma-Pheochromocytoma Syndromes	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0000239
-Dominant hereditary optic atrophy	http://www.orpha.net/ORDO/Orphanet_103	http://www.orpha.net/ORDO/Orphanet_98672
-CHONDROCALCINOSIS 2	http://purl.obolibrary.org/obo/HP_0002758	http://purl.obolibrary.org/obo/HP_0003674	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0005017	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0003040
+Systemic lupus erythematosus 10	http://www.ebi.ac.uk/efo/EFO_0000685
+Delayed puberty	http://purl.obolibrary.org/obo/HP_0000823
+Age-related macular degeneration 2	http://www.ebi.ac.uk/efo/EFO_0001365
+Hereditary Paraganglioma-Pheochromocytoma Syndromes	http://www.ebi.ac.uk/efo/EFO_0000311
+Dominant hereditary optic atrophy	http://www.orpha.net/ORDO/Orphanet_103
+CHONDROCALCINOSIS 2	http://purl.obolibrary.org/obo/HP_0002758
 Congenital disorder of glycosylation type 1P	http://www.orpha.net/ORDO/Orphanet_280071
 Kabuki make-up syndrome	http://www.orpha.net/ORDO/Orphanet_2322
-Cortical dysplasia	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002510	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0007973	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0002539	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0009879	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0002365	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002521	http://purl.obolibrary.org/obo/HP_0002126	http://purl.obolibrary.org/obo/HP_0000568
-MACROCEPHALY/AUTISM SYNDROME	http://purl.obolibrary.org/obo/HP_0001513	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000337	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0005490	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0004422	http://purl.obolibrary.org/obo/HP_0000717	http://purl.obolibrary.org/obo/HP_0002007
-Juvenile GM1 gangliosidosis	http://www.orpha.net/ORDO/Orphanet_79256	http://www.orpha.net/ORDO/Orphanet_309144	http://www.orpha.net/ORDO/Orphanet_309310	http://www.orpha.net/ORDO/Orphanet_79255
+Cortical dysplasia	http://purl.obolibrary.org/obo/HP_0001321
+MACROCEPHALY/AUTISM SYNDROME	http://purl.obolibrary.org/obo/HP_0001513
+Juvenile GM1 gangliosidosis	http://www.orpha.net/ORDO/Orphanet_79256
 CRANIOFACIAL-DEAFNESS-HAND SYNDROME	http://www.orpha.net/ORDO/Orphanet_1529
 HEREDITARY PERSISTENCE OF FETAL HEMOGLOBIN	http://www.orpha.net/ORDO/Orphanet_46532
 RETINITIS PIGMENTOSA 50	http://www.orpha.net/ORDO/Orphanet_791
 PAROXYSMAL EXTREME PAIN DISORDER	http://www.orpha.net/ORDO/Orphanet_46348
-Neonatal intrahepatic cholestasis caused by citrin deficiency	http://www.orpha.net/ORDO/Orphanet_247585	http://www.orpha.net/ORDO/Orphanet_247598
-Familial hypertrophic cardiomyopathy 9	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+Neonatal intrahepatic cholestasis caused by citrin deficiency	http://www.orpha.net/ORDO/Orphanet_247585
+Familial hypertrophic cardiomyopathy 9	http://www.ebi.ac.uk/efo/EFO_0000318
 Short rib polydactyly syndrome 6	http://www.orpha.net/ORDO/Orphanet_2913
-46	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000729	http://purl.obolibrary.org/obo/HP_0003380	http://purl.obolibrary.org/obo/HP_0012245	http://purl.obolibrary.org/obo/HP_0000062	http://purl.obolibrary.org/obo/HP_0001271	http://www.orpha.net/ORDO/Orphanet_2138	http://purl.obolibrary.org/obo/HP_0000063	http://purl.obolibrary.org/obo/HP_0008668	http://purl.obolibrary.org/obo/HP_0000133	http://purl.obolibrary.org/obo/HP_0000037
-Sacral agenesis with vertebral anomalies	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003468	http://purl.obolibrary.org/obo/HP_0003577
-Bosch-boonstra-schaaf optic atrophy syndrome	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0001123	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0000543	http://purl.obolibrary.org/obo/HP_0001182	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000639
+46	http://purl.obolibrary.org/obo/HP_0000028
+Sacral agenesis with vertebral anomalies	http://purl.obolibrary.org/obo/HP_0000007
+Bosch-boonstra-schaaf optic atrophy syndrome	http://purl.obolibrary.org/obo/HP_0007663
 Groenouw corneal dystrophy type I	http://www.orpha.net/ORDO/Orphanet_34533
-Hypogonadotropic hypogonadism 19 with or without anosmia	http://www.orpha.net/ORDO/Orphanet_478	http://www.orpha.net/ORDO/Orphanet_432
+Hypogonadotropic hypogonadism 19 with or without anosmia	http://www.orpha.net/ORDO/Orphanet_478
 Perrault syndrome 4	http://www.orpha.net/ORDO/Orphanet_2855
 Kindlers syndrome	http://www.orpha.net/ORDO/Orphanet_2908
 CLEFT PALATE WITH ANKYLOGLOSSIA	http://purl.obolibrary.org/obo/HP_0000175
-2	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002161	http://purl.obolibrary.org/obo/HP_0005972	http://purl.obolibrary.org/obo/HP_0001319
-OLIGODONTIA-COLORECTAL CANCER SYNDROME	http://purl.obolibrary.org/obo/HP_0005227	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002209	http://purl.obolibrary.org/obo/HP_0000677
-PARAGANGLIOMAS 5	http://purl.obolibrary.org/obo/HP_0002668	http://purl.obolibrary.org/obo/HP_0000006
+2	http://purl.obolibrary.org/obo/HP_0000007
+OLIGODONTIA-COLORECTAL CANCER SYNDROME	http://purl.obolibrary.org/obo/HP_0005227
+PARAGANGLIOMAS 5	http://purl.obolibrary.org/obo/HP_0002668
 AMYOTROPHIC LATERAL SCLEROSIS 17	http://www.ebi.ac.uk/efo/EFO_0000253
-Primary microcephaly	http://purl.obolibrary.org/obo/HP_0002514	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001339	http://purl.obolibrary.org/obo/HP_0001249
+Primary microcephaly	http://purl.obolibrary.org/obo/HP_0002514
 Reticulate acropigmentation of Kitamura	http://www.orpha.net/ORDO/Orphanet_178307
 Singleton-Merten syndrome	http://www.orpha.net/ORDO/Orphanet_85191
 Shy-Drager syndrome	http://www.ebi.ac.uk/efo/EFO_1001050
 Congenital myasthenic syndrome	http://www.orpha.net/ORDO/Orphanet_98913
-SALLA DISEASE	http://www.orpha.net/ORDO/Orphanet_309334	http://www.orpha.net/ORDO/Orphanet_309324
+SALLA DISEASE	http://www.orpha.net/ORDO/Orphanet_309334
 Gastrointestinal stromal tumor	http://www.orpha.net/ORDO/Orphanet_44890
 Farber's lipogranulomatosis	http://www.orpha.net/ORDO/Orphanet_333
 ACYL-CoA DEHYDROGENASE FAMILY	http://www.orpha.net/ORDO/Orphanet_99901
 Dilated cardiomyopathy 1EE	http://www.ebi.ac.uk/efo/EFO_0000407
 Early infantile epileptic encephalopathy 14	http://www.orpha.net/ORDO/Orphanet_1934
-URIC ACID CONCENTRATION	http://purl.obolibrary.org/obo/HP_0001997	http://purl.obolibrary.org/obo/HP_0001369	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000951	http://purl.obolibrary.org/obo/HP_0002149
+URIC ACID CONCENTRATION	http://purl.obolibrary.org/obo/HP_0001997
 Uridine 5-prime monophosphate hydrolase deficiency	http://www.ebi.ac.uk/efo/EFO_0004272
 VENTRICULAR SEPTAL DEFECT 3	http://www.orpha.net/ORDO/Orphanet_1480
-Lebers amaurosis	http://www.orpha.net/ORDO/Orphanet_65	http://www.orpha.net/ORDO/Orphanet_178826	http://www.orpha.net/ORDO/Orphanet_791
+Lebers amaurosis	http://www.orpha.net/ORDO/Orphanet_65
 CARBONIC ANHYDRASE II VARIANT	http://www.orpha.net/ORDO/Orphanet_2785
-Stargardts disease	http://www.orpha.net/ORDO/Orphanet_1872	http://www.orpha.net/ORDO/Orphanet_827	http://www.orpha.net/ORDO/Orphanet_117623
+Stargardts disease	http://www.orpha.net/ORDO/Orphanet_1872
 GLUTAMATE FORMIMINOTRANSFERASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_51208
-Muscular dystrophy	http://purl.obolibrary.org/obo/HP_0001427	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0003677	http://www.orpha.net/ORDO/Orphanet_97242	http://www.orpha.net/ORDO/Orphanet_98473	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://www.orpha.net/ORDO/Orphanet_371024	http://purl.obolibrary.org/obo/HP_0002465	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0003391	http://www.orpha.net/ORDO/Orphanet_263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002515	http://purl.obolibrary.org/obo/HP_0010628	http://purl.obolibrary.org/obo/HP_0003741	http://purl.obolibrary.org/obo/HP_0003198
+Muscular dystrophy	http://purl.obolibrary.org/obo/HP_0001427
 MOHR-TRANEBJAERG SYNDROME	http://www.orpha.net/ORDO/Orphanet_52368
 NEPHRONOPHTHISIS 4	http://www.orpha.net/ORDO/Orphanet_655
-Proteus-like syndrome	http://www.orpha.net/ORDO/Orphanet_2969	http://www.orpha.net/ORDO/Orphanet_306498
+Proteus-like syndrome	http://www.orpha.net/ORDO/Orphanet_2969
 Sarcoma	http://www.ebi.ac.uk/efo/EFO_0000691
 Spermatogenic failure 14	http://purl.obolibrary.org/obo/HP_0000027
 Retinoblastoma	http://www.orpha.net/ORDO/Orphanet_790
 AVASCULAR NECROSIS OF THE FEMORAL HEAD	http://www.orpha.net/ORDO/Orphanet_399164
-Cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.orpha.net/ORDO/Orphanet_167848	http://purl.obolibrary.org/obo/HP_0001644	http://www.ebi.ac.uk/efo/EFO_0000407	http://purl.obolibrary.org/obo/HP_0004308	http://www.ebi.ac.uk/efo/EFO_0004145	http://www.ebi.ac.uk/efo/EFO_0001063	http://www.ebi.ac.uk/efo/EFO_0002945	http://www.ebi.ac.uk/efo/EFO_0000538
-Myopia 23	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0007800	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0011003
-Dilated cardiomyopathy 3B	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318
-AICARDI-GOUTIERES SYNDROME 4	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0001876	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0003819	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0002415	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0000253	http://purl.obolibrary.org/obo/HP_0001433	http://purl.obolibrary.org/obo/HP_0000444	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0002514	http://purl.obolibrary.org/obo/HP_0011344	http://purl.obolibrary.org/obo/HP_0200149	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002059
+Cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000318
+Myopia 23	http://purl.obolibrary.org/obo/HP_0000007
+Dilated cardiomyopathy 3B	http://www.ebi.ac.uk/efo/EFO_0000407
+AICARDI-GOUTIERES SYNDROME 4	http://purl.obolibrary.org/obo/HP_0001511
 Megalencephalic leukoencephalopathy with subcortical cysts 2b	http://www.orpha.net/ORDO/Orphanet_2478
-GLIOMA SUSCEPTIBILITY 1	http://purl.obolibrary.org/obo/HP_0100843	http://purl.obolibrary.org/obo/HP_0002888	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001428	http://purl.obolibrary.org/obo/HP_0012174
+GLIOMA SUSCEPTIBILITY 1	http://purl.obolibrary.org/obo/HP_0100843
 HYPERBILIRUBINEMIA	http://www.orpha.net/ORDO/Orphanet_2312
 3-@METHYLGLUTACONIC ACIDURIA WITH CATARACTS	http://www.orpha.net/ORDO/Orphanet_289902
-Spinal Muscular Atrophy with Respiratory Distress 1	http://purl.obolibrary.org/obo/HP_0000020	http://purl.obolibrary.org/obo/HP_0005946	http://purl.obolibrary.org/obo/HP_0002789	http://purl.obolibrary.org/obo/HP_0009109	http://purl.obolibrary.org/obo/HP_0005348	http://purl.obolibrary.org/obo/HP_0003693	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0001558	http://purl.obolibrary.org/obo/HP_0009110	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0003445	http://purl.obolibrary.org/obo/HP_0000764	http://purl.obolibrary.org/obo/HP_0001622	http://purl.obolibrary.org/obo/HP_0000762	http://purl.obolibrary.org/obo/HP_0007269	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002398	http://purl.obolibrary.org/obo/HP_0000975	http://purl.obolibrary.org/obo/HP_0100490	http://purl.obolibrary.org/obo/HP_0001612	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0006597	http://purl.obolibrary.org/obo/HP_0002460	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0002878	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0003690
-Question mark ears	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0030022
+Spinal Muscular Atrophy with Respiratory Distress 1	http://purl.obolibrary.org/obo/HP_0000020
+Question mark ears	http://purl.obolibrary.org/obo/HP_0000006
 BARDET-BIEDL SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_110
 Chediak-Higashi syndrome	http://www.orpha.net/ORDO/Orphanet_167
 GOLDBERG-SHPRINTZEN MEGACOLON SYNDROME	http://www.orpha.net/ORDO/Orphanet_66629
-HEREDITARY MYOPATHY WITH EARLY RESPIRATORY FAILURE	http://purl.obolibrary.org/obo/HP_0009027	http://purl.obolibrary.org/obo/HP_0003722	http://purl.obolibrary.org/obo/HP_0009113	http://purl.obolibrary.org/obo/HP_0000006
+HEREDITARY MYOPATHY WITH EARLY RESPIRATORY FAILURE	http://purl.obolibrary.org/obo/HP_0009027
 BARDET-BIEDL SYNDROME 14	http://www.orpha.net/ORDO/Orphanet_110
 Progressive familial heart block type 1B	http://www.orpha.net/ORDO/Orphanet_871
-LEUKOENCEPHALOPATHY WITH BRAINSTEM AND SPINAL CORD INVOLVEMENT AND LACTATE ELEVATION	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0003477	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0000639
+LEUKOENCEPHALOPATHY WITH BRAINSTEM AND SPINAL CORD INVOLVEMENT AND LACTATE ELEVATION	http://purl.obolibrary.org/obo/HP_0001347
 UV-SENSITIVE SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_178338
-PARAGANGLIOMAS 1	http://purl.obolibrary.org/obo/HP_0003334	http://purl.obolibrary.org/obo/HP_0001011	http://purl.obolibrary.org/obo/HP_0001606	http://purl.obolibrary.org/obo/HP_0003001	http://purl.obolibrary.org/obo/HP_0000361	http://purl.obolibrary.org/obo/HP_0001676	http://purl.obolibrary.org/obo/HP_0001686	http://purl.obolibrary.org/obo/HP_0006715	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0001613	http://purl.obolibrary.org/obo/HP_0002886	http://purl.obolibrary.org/obo/HP_0001962	http://purl.obolibrary.org/obo/HP_0030074	http://purl.obolibrary.org/obo/HP_0000740	http://purl.obolibrary.org/obo/HP_0002331	http://purl.obolibrary.org/obo/HP_0006748	http://purl.obolibrary.org/obo/HP_0006737	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002640	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0001673	http://purl.obolibrary.org/obo/HP_0001649	http://purl.obolibrary.org/obo/HP_0000975	http://purl.obolibrary.org/obo/HP_0002377
-CONE-ROD DYSTROPHY 3	http://www.orpha.net/ORDO/Orphanet_1872	http://www.orpha.net/ORDO/Orphanet_827
+PARAGANGLIOMAS 1	http://purl.obolibrary.org/obo/HP_0003334
+CONE-ROD DYSTROPHY 3	http://www.orpha.net/ORDO/Orphanet_1872
 ATRIAL SEPTAL DEFECT 6	http://www.ebi.ac.uk/efo/EFO_1000825
 Ornithine aminotransferase deficiency	http://www.orpha.net/ORDO/Orphanet_414
 GLUTARIC ACIDEMIA IIA	http://www.orpha.net/ORDO/Orphanet_26791
 Holoprosencephaly 11	http://www.orpha.net/ORDO/Orphanet_2162
 INFLAMMATORY BOWEL DISEASE 1	http://www.ebi.ac.uk/efo/EFO_0003767
 Birt-Hogg-Dub√© syndrome	http://www.orpha.net/ORDO/Orphanet_122
-CONGENITAL DISORDER OF GLYCOSYLATION	http://purl.obolibrary.org/obo/HP_0001442	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001423	http://purl.obolibrary.org/obo/HP_0000574	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000194	http://purl.obolibrary.org/obo/HP_0002020	http://purl.obolibrary.org/obo/HP_0002719	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0012471	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0200134	http://purl.obolibrary.org/obo/HP_0002521	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0012448	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000280	http://purl.obolibrary.org/obo/HP_0002059
+CONGENITAL DISORDER OF GLYCOSYLATION	http://purl.obolibrary.org/obo/HP_0001442
 Pontocerebellar hypoplasia type 1	http://www.orpha.net/ORDO/Orphanet_2254
-IMMUNODEFICIENCY 30	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0011274
+IMMUNODEFICIENCY 30	http://purl.obolibrary.org/obo/HP_0000007
 Hypomyelination and Congenital Cataract	http://www.ebi.ac.uk/efo/EFO_0001059
 Hereditary sensory neuropathy type 1D	http://www.ebi.ac.uk/efo/EFO_0004149
-Hyperekplexia hereditary	http://www.orpha.net/ORDO/Orphanet_306773	http://www.orpha.net/ORDO/Orphanet_3197
+Hyperekplexia hereditary	http://www.orpha.net/ORDO/Orphanet_306773
 Parkinson disease 1	http://www.ebi.ac.uk/efo/EFO_0002508
 Syndactyly type 3	http://www.orpha.net/ORDO/Orphanet_93404
 Primary autosomal recessive microcephaly 4	http://www.orpha.net/ORDO/Orphanet_2512
 Neuropathy hereditary sensory and autonomic type 1	http://www.ebi.ac.uk/efo/EFO_0004149
-OHDO SYNDROME	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0004325	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0000233	http://purl.obolibrary.org/obo/HP_0030084	http://purl.obolibrary.org/obo/HP_0001382	http://purl.obolibrary.org/obo/HP_0000046	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0000581	http://purl.obolibrary.org/obo/HP_0000319	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0000957	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000448	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000414	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0000280
-HOLOPROSENCEPHALY 2	http://www.orpha.net/ORDO/Orphanet_799	http://www.orpha.net/ORDO/Orphanet_2162
-TAY-SACHS DISEASE	http://www.orpha.net/ORDO/Orphanet_309144	http://www.orpha.net/ORDO/Orphanet_309239	http://www.orpha.net/ORDO/Orphanet_845
+OHDO SYNDROME	http://purl.obolibrary.org/obo/HP_0000508
+HOLOPROSENCEPHALY 2	http://www.orpha.net/ORDO/Orphanet_799
+TAY-SACHS DISEASE	http://www.orpha.net/ORDO/Orphanet_309144
 KEARNS-SAYRE SYNDROME	http://www.orpha.net/ORDO/Orphanet_480
 BORJESON-FORSSMAN-LEHMANN SYNDROME	http://www.orpha.net/ORDO/Orphanet_127
-METHYLMALONYL-CoA EPIMERASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0012120	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001944	http://purl.obolibrary.org/obo/HP_0002919	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002020	http://purl.obolibrary.org/obo/HP_0002912	http://purl.obolibrary.org/obo/HP_0001942
-SPONGIFORM ENCEPHALOPATHY WITH NEUROPSYCHIATRIC FEATURES	http://purl.obolibrary.org/obo/HP_0000751	http://purl.obolibrary.org/obo/HP_0000726	http://purl.obolibrary.org/obo/HP_0002171	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001298
+METHYLMALONYL-CoA EPIMERASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0012120
+SPONGIFORM ENCEPHALOPATHY WITH NEUROPSYCHIATRIC FEATURES	http://purl.obolibrary.org/obo/HP_0000751
 FLECK RETINA	http://www.orpha.net/ORDO/Orphanet_363989
 Hemochromatosis	http://www.ebi.ac.uk/efo/EFO_1000642
 HOLOPROSENCEPHALY 9	http://www.orpha.net/ORDO/Orphanet_2162
-FOVEAL HYPOPLASIA 2 WITH OPTIC NERVE MISROUTING	http://purl.obolibrary.org/obo/HP_0007750	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0006934	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0007819
+FOVEAL HYPOPLASIA 2 WITH OPTIC NERVE MISROUTING	http://purl.obolibrary.org/obo/HP_0007750
 Lethal multiple pterygium syndrome	http://www.orpha.net/ORDO/Orphanet_33108
 CRANIOSYNOSTOSIS 2	http://www.orpha.net/ORDO/Orphanet_1531
 SECKEL SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_808
 Primary autosomal recessive microcephaly 12	http://www.orpha.net/ORDO/Orphanet_2512
 INTERSTITIAL LUNG AND LIVER DISEASE	http://www.orpha.net/ORDO/Orphanet_440427
-Adenocarcinoma of lung	http://www.ebi.ac.uk/efo/EFO_0000571	http://www.ebi.ac.uk/efo/EFO_0003060
-TUMOR PREDISPOSITION SYNDROME	http://purl.obolibrary.org/obo/HP_0002858	http://purl.obolibrary.org/obo/HP_0012056	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0030078	http://purl.obolibrary.org/obo/HP_0007716
+Adenocarcinoma of lung	http://www.ebi.ac.uk/efo/EFO_0000571
+TUMOR PREDISPOSITION SYNDROME	http://purl.obolibrary.org/obo/HP_0002858
 Pseudohypoaldosteronism type 2B	http://www.orpha.net/ORDO/Orphanet_88939
-Hypogonadotrophic hypogonadism	http://purl.obolibrary.org/obo/HP_0000823	http://purl.obolibrary.org/obo/HP_0000044
-PEROXISOME BIOGENESIS DISORDER 7B	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000556	http://purl.obolibrary.org/obo/HP_0001410	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000407
-Aural atresia	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0004409	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0000413
+Hypogonadotrophic hypogonadism	http://purl.obolibrary.org/obo/HP_0000823
+PEROXISOME BIOGENESIS DISORDER 7B	http://purl.obolibrary.org/obo/HP_0000007
+Aural atresia	http://purl.obolibrary.org/obo/HP_0000006
 Hidrotic ectodermal dysplasia syndrome	http://www.orpha.net/ORDO/Orphanet_189
 Primary autosomal recessive microcephaly 13	http://www.orpha.net/ORDO/Orphanet_2512
 TOURETTE SYNDROME	http://www.ebi.ac.uk/efo/EFO_0004895
-TUMORAL CALCINOSIS	http://www.orpha.net/ORDO/Orphanet_53715	http://www.ebi.ac.uk/efo/EFO_0003837
-HASHIMOTO THYROIDITIS	http://www.ebi.ac.uk/efo/EFO_0002690	http://www.ebi.ac.uk/efo/EFO_0001060	http://www.ebi.ac.uk/efo/EFO_0003779
-AGAMMAGLOBULINEMIA 7	http://purl.obolibrary.org/obo/HP_0001875	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0004432
-Gaucher disease	http://www.orpha.net/ORDO/Orphanet_77261	http://www.orpha.net/ORDO/Orphanet_355	http://www.orpha.net/ORDO/Orphanet_77259	http://www.orpha.net/ORDO/Orphanet_77260
-Familial hypertrophic cardiomyopathy 7	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
-Keratoderma palmoplantar deafness	http://www.orpha.net/ORDO/Orphanet_90641	http://www.orpha.net/ORDO/Orphanet_2202
-Retinal dystrophy and obesity	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0000541	http://purl.obolibrary.org/obo/HP_0000483	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001513
-Glomerulonephritis with sparse hair and telangiectases	http://purl.obolibrary.org/obo/HP_0005598	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0003189	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0000793	http://purl.obolibrary.org/obo/HP_0000653	http://purl.obolibrary.org/obo/HP_0007621	http://purl.obolibrary.org/obo/HP_0001006	http://purl.obolibrary.org/obo/HP_0000300	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000426	http://purl.obolibrary.org/obo/HP_0000561	http://purl.obolibrary.org/obo/HP_0000034	http://purl.obolibrary.org/obo/HP_0007543	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0012471	http://purl.obolibrary.org/obo/HP_0000535	http://purl.obolibrary.org/obo/HP_0100540	http://purl.obolibrary.org/obo/HP_0002223	http://purl.obolibrary.org/obo/HP_0003758	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0001002
+TUMORAL CALCINOSIS	http://www.orpha.net/ORDO/Orphanet_53715
+HASHIMOTO THYROIDITIS	http://www.ebi.ac.uk/efo/EFO_0002690
+AGAMMAGLOBULINEMIA 7	http://purl.obolibrary.org/obo/HP_0001875
+Gaucher disease	http://www.orpha.net/ORDO/Orphanet_77261
+Familial hypertrophic cardiomyopathy 7	http://www.ebi.ac.uk/efo/EFO_0000318
+Keratoderma palmoplantar deafness	http://www.orpha.net/ORDO/Orphanet_90641
+Retinal dystrophy and obesity	http://purl.obolibrary.org/obo/HP_0007663
+Glomerulonephritis with sparse hair and telangiectases	http://purl.obolibrary.org/obo/HP_0005598
 Lehman syndrome	http://www.orpha.net/ORDO/Orphanet_2789
-AUTOIMMUNE POLYENDOCRINOPATHY SYNDROME	http://www.orpha.net/ORDO/Orphanet_282196	http://www.orpha.net/ORDO/Orphanet_3453
-Congenital myotonia	http://www.orpha.net/ORDO/Orphanet_206973	http://www.orpha.net/ORDO/Orphanet_614
+AUTOIMMUNE POLYENDOCRINOPATHY SYNDROME	http://www.orpha.net/ORDO/Orphanet_282196
+Congenital myotonia	http://www.orpha.net/ORDO/Orphanet_206973
 LONG QT SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_768
 Sucrase-isomaltase deficiency	http://www.orpha.net/ORDO/Orphanet_35122
 Tyrosinemia type 2	http://www.orpha.net/ORDO/Orphanet_28378
@@ -1527,7 +1527,7 @@ Schizophrenia 15	http://www.ebi.ac.uk/efo/EFO_0000692
 Pitt-Hopkins-like syndrome 2	http://www.orpha.net/ORDO/Orphanet_221150
 DIASTROPHIC DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_628
 Epidermolysa bullosa simplex and limb girdle muscular dystrophy	http://www.orpha.net/ORDO/Orphanet_98473
-Familial hypertrophic cardiomyopathy 6	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+Familial hypertrophic cardiomyopathy 6	http://www.ebi.ac.uk/efo/EFO_0000318
 BRANCHIOOTORENAL SYNDROME WITH CATARACT	http://www.orpha.net/ORDO/Orphanet_107
 GTP cyclohydrolase I deficiency	http://www.orpha.net/ORDO/Orphanet_2102
 Amyotrophic lateral sclerosis type 12	http://www.ebi.ac.uk/efo/EFO_0000253
@@ -1535,12 +1535,12 @@ Amish lethal microcephaly	http://www.orpha.net/ORDO/Orphanet_99742
 Diaphanospondylodysostosis	http://www.orpha.net/ORDO/Orphanet_66637
 Multiple fibrofolliculomas	http://www.orpha.net/ORDO/Orphanet_122
 SKIN FRAGILITY-WOOLLY HAIR SYNDROME	http://www.orpha.net/ORDO/Orphanet_293165
-Neurodegeneration with optic atrophy	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002599	http://purl.obolibrary.org/obo/HP_0002411	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0000572	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002180	http://purl.obolibrary.org/obo/HP_0002486	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0002059	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0003676
+Neurodegeneration with optic atrophy	http://purl.obolibrary.org/obo/HP_0001347
 AMYOTROPHIC LATERAL SCLEROSIS	http://www.ebi.ac.uk/efo/EFO_0000253
-Dilated cardiomyopathy 1KK	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+Dilated cardiomyopathy 1KK	http://www.ebi.ac.uk/efo/EFO_0000407
 GYRATE ATROPHY OF CHOROID AND RETINA WITH PYRIDOXINE-RESPONSIVE ORNITHINEMIA	http://www.orpha.net/ORDO/Orphanet_414
-MINICORE MYOPATHY WITH EXTERNAL OPHTHALMOPLEGIA	http://purl.obolibrary.org/obo/HP_0002089	http://purl.obolibrary.org/obo/HP_0003327	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0003787	http://purl.obolibrary.org/obo/HP_0002058	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003557	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0000544	http://purl.obolibrary.org/obo/HP_0009025	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001789	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0001558	http://purl.obolibrary.org/obo/HP_0003701	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0003798	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0003324	http://purl.obolibrary.org/obo/HP_0003738	http://purl.obolibrary.org/obo/HP_0003623	http://purl.obolibrary.org/obo/HP_0010628	http://purl.obolibrary.org/obo/HP_0009046	http://purl.obolibrary.org/obo/HP_0001561	http://purl.obolibrary.org/obo/HP_0003560	http://purl.obolibrary.org/obo/HP_0001380
-Pigmentary disorder	http://purl.obolibrary.org/obo/HP_0001417	http://purl.obolibrary.org/obo/HP_0006532	http://purl.obolibrary.org/obo/HP_0002301	http://purl.obolibrary.org/obo/HP_0007759	http://purl.obolibrary.org/obo/HP_0011034	http://purl.obolibrary.org/obo/HP_0001531	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000572	http://purl.obolibrary.org/obo/HP_0004798	http://purl.obolibrary.org/obo/HP_0007599	http://purl.obolibrary.org/obo/HP_0012227	http://purl.obolibrary.org/obo/HP_0000023	http://purl.obolibrary.org/obo/HP_0001939
+MINICORE MYOPATHY WITH EXTERNAL OPHTHALMOPLEGIA	http://purl.obolibrary.org/obo/HP_0002089
+Pigmentary disorder	http://purl.obolibrary.org/obo/HP_0001417
 Hereditary diffuse leukoencephalopathy with spheroids	http://www.orpha.net/ORDO/Orphanet_313808
 ARGININE:GLYCINE AMIDINOTRANSFERASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_35704
 Primary pulmonary hypertension 2	http://www.ebi.ac.uk/efo/EFO_0001361
@@ -1548,42 +1548,42 @@ Sleep apnea	http://www.ebi.ac.uk/efo/EFO_0003877
 PSEUDO-VON WILLEBRAND DISEASE	http://www.orpha.net/ORDO/Orphanet_52530
 Marden Walker like syndrome	http://www.orpha.net/ORDO/Orphanet_2460
 Pilomatrixoma	http://www.orpha.net/ORDO/Orphanet_91414
-MIYOSHI MUSCULAR DYSTROPHY 3	http://www.orpha.net/ORDO/Orphanet_399096	http://www.orpha.net/ORDO/Orphanet_263
+MIYOSHI MUSCULAR DYSTROPHY 3	http://www.orpha.net/ORDO/Orphanet_399096
 Primary ciliary dyskinesia 24	http://www.orpha.net/ORDO/Orphanet_244
 Peripheral neuropathy	http://www.ebi.ac.uk/efo/EFO_0003100
-GENERALIZED EPILEPSY WITH FEBRILE SEIZURES PLUS	http://purl.obolibrary.org/obo/HP_0002123	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0002373	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002384	http://purl.obolibrary.org/obo/HP_0002121	http://purl.obolibrary.org/obo/HP_0010818	http://purl.obolibrary.org/obo/HP_0011463	http://purl.obolibrary.org/obo/HP_0007359	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0006813	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002069	http://purl.obolibrary.org/obo/HP_0010819
+GENERALIZED EPILEPSY WITH FEBRILE SEIZURES PLUS	http://purl.obolibrary.org/obo/HP_0002123
 Osteofibrous dysplasia	http://www.orpha.net/ORDO/Orphanet_249
 Hypotension	http://www.ebi.ac.uk/efo/EFO_0005251
-NEUROPATHY	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0007141	http://purl.obolibrary.org/obo/HP_0000522	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0001945	http://purl.obolibrary.org/obo/HP_0003093	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0002459	http://purl.obolibrary.org/obo/HP_0000559	http://purl.obolibrary.org/obo/HP_0007610	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0001760	http://purl.obolibrary.org/obo/HP_0002754	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000194	http://purl.obolibrary.org/obo/HP_0001218	http://purl.obolibrary.org/obo/HP_0002104	http://purl.obolibrary.org/obo/HP_0000331	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001649	http://www.ebi.ac.uk/efo/EFO_0004149	http://purl.obolibrary.org/obo/HP_0000975	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0001188	http://purl.obolibrary.org/obo/HP_0000763	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0000970	http://purl.obolibrary.org/obo/HP_0002460	http://purl.obolibrary.org/obo/HP_0012534	http://purl.obolibrary.org/obo/HP_0001662	http://purl.obolibrary.org/obo/HP_0007021	http://purl.obolibrary.org/obo/HP_0002936	http://purl.obolibrary.org/obo/HP_0200042
+NEUROPATHY	http://purl.obolibrary.org/obo/HP_0001371
 Spastic paraplegia 18	http://purl.obolibrary.org/obo/HP_0001258
 LEBER CONGENITAL AMAUROSIS 18	http://www.orpha.net/ORDO/Orphanet_65
 Activated PI3K-delta syndrome	http://www.orpha.net/ORDO/Orphanet_397596
 Intrauterine growth retardation	http://www.ebi.ac.uk/efo/EFO_0000495
-Intellectual disability	http://www.ebi.ac.uk/efo/EFO_0003847	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0010864
+Intellectual disability	http://www.ebi.ac.uk/efo/EFO_0003847
 Hyperalphalipoproteinemia	http://www.orpha.net/ORDO/Orphanet_181428
 MINERALOCORTICOID DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_95702
 HYPOGONADOTROPIC HYPOGONADISM 10 WITHOUT ANOSMIA	http://www.orpha.net/ORDO/Orphanet_174590
 EPIDERMOLYSIS BULLOSA DYSTROPHICA INVERSA	http://www.orpha.net/ORDO/Orphanet_303
-Immunodeficiency 13	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0011108	http://purl.obolibrary.org/obo/HP_0011945	http://purl.obolibrary.org/obo/HP_0000403	http://purl.obolibrary.org/obo/HP_0001888
-BRUGADA SYNDROME	http://www.orpha.net/ORDO/Orphanet_99739	http://www.orpha.net/ORDO/Orphanet_130	http://www.orpha.net/ORDO/Orphanet_871	http://www.orpha.net/ORDO/Orphanet_768	http://www.orpha.net/ORDO/Orphanet_166282
+Immunodeficiency 13	http://purl.obolibrary.org/obo/HP_0000006
+BRUGADA SYNDROME	http://www.orpha.net/ORDO/Orphanet_99739
 Congenital disorder of glycosylation type 1B	http://www.orpha.net/ORDO/Orphanet_79319
-MELANOMA	http://purl.obolibrary.org/obo/HP_0002860	http://purl.obolibrary.org/obo/HP_0012182	http://purl.obolibrary.org/obo/HP_0100242	http://purl.obolibrary.org/obo/HP_0006725	http://purl.obolibrary.org/obo/HP_0012142	http://purl.obolibrary.org/obo/HP_0012056	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002861
+MELANOMA	http://purl.obolibrary.org/obo/HP_0002860
 CHONDROSARCOMA	http://www.ebi.ac.uk/efo/EFO_0000333
 Sideroblastic anemia 3	http://www.ebi.ac.uk/efo/EFO_0004272
 METHIONINE ADENOSYLTRANSFERASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_168598
 MENTAL RETARDATION X-LINKED SYNDROMIC WU TYPE	http://www.ebi.ac.uk/efo/EFO_0003847
-IL21R immunodeficiency	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0200124	http://purl.obolibrary.org/obo/HP_0011108	http://purl.obolibrary.org/obo/HP_0002028	http://purl.obolibrary.org/obo/HP_0030151	http://purl.obolibrary.org/obo/HP_0002110	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0002090	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001399	http://purl.obolibrary.org/obo/HP_0001394
+IL21R immunodeficiency	http://purl.obolibrary.org/obo/HP_0000007
 ALBUMIN B	http://www.orpha.net/ORDO/Orphanet_119576
 Renal hypouricemia 2	http://www.orpha.net/ORDO/Orphanet_94088
 ATRIOVENTRICULAR SEPTAL DEFECT	http://www.orpha.net/ORDO/Orphanet_98722
 Infantile neuroaxonal dystrophy	http://www.orpha.net/ORDO/Orphanet_35069
 BARDET-BIEDL SYNDROME 6	http://www.orpha.net/ORDO/Orphanet_110
-HIRSCHSPRUNG DISEASE	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0000414	http://purl.obolibrary.org/obo/HP_0002251	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0002459	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0001182	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001795	http://purl.obolibrary.org/obo/HP_0009626	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0001629	http://purl.obolibrary.org/obo/HP_0000378
+HIRSCHSPRUNG DISEASE	http://purl.obolibrary.org/obo/HP_0001631
 Hemolytic anemia due to hexokinase deficiency	http://www.orpha.net/ORDO/Orphanet_90031
-SHORT STATURE WITH MICROCEPHALY AND DISTINCTIVE FACIES	http://purl.obolibrary.org/obo/HP_0000348	http://purl.obolibrary.org/obo/HP_0005590	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0009882	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0012736	http://purl.obolibrary.org/obo/HP_0011927	http://purl.obolibrary.org/obo/HP_0001883	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000506	http://purl.obolibrary.org/obo/HP_0003510	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0002719	http://purl.obolibrary.org/obo/HP_0004823	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0000535	http://purl.obolibrary.org/obo/HP_0001518
-Heterotaxy	http://www.orpha.net/ORDO/Orphanet_887	http://www.orpha.net/ORDO/Orphanet_450
-CUTANEOUS TELANGIECTASIA AND CANCER SYNDROME	http://purl.obolibrary.org/obo/HP_0003002	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0001807	http://purl.obolibrary.org/obo/HP_0000670	http://purl.obolibrary.org/obo/HP_0006297	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001009	http://purl.obolibrary.org/obo/HP_0000444
-INTERSTITIAL NEPHRITIS	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000093	http://purl.obolibrary.org/obo/HP_0003259	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0000790	http://purl.obolibrary.org/obo/HP_0001970	http://purl.obolibrary.org/obo/HP_0003774	http://purl.obolibrary.org/obo/HP_0000090	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0003076
+SHORT STATURE WITH MICROCEPHALY AND DISTINCTIVE FACIES	http://purl.obolibrary.org/obo/HP_0000348
+Heterotaxy	http://www.orpha.net/ORDO/Orphanet_887
+CUTANEOUS TELANGIECTASIA AND CANCER SYNDROME	http://purl.obolibrary.org/obo/HP_0003002
+INTERSTITIAL NEPHRITIS	http://purl.obolibrary.org/obo/HP_0000007
 Coloboma of optic disc	http://www.orpha.net/ORDO/Orphanet_194
 Myosin storage myopathy	http://www.ebi.ac.uk/efo/EFO_0004145
 HEMOGLOBIN H DISEASE	http://www.orpha.net/ORDO/Orphanet_93616
@@ -1592,64 +1592,64 @@ Gingival fibromatosis 1	http://purl.obolibrary.org/obo/HP_0000169
 SHORT syndrome	http://www.orpha.net/ORDO/Orphanet_3163
 CYSTINOSIS	http://www.orpha.net/ORDO/Orphanet_213
 Knobloch syndrome	http://www.orpha.net/ORDO/Orphanet_1571
-ADVANCED SLEEP PHASE SYNDROME	http://www.orpha.net/ORDO/Orphanet_164736	http://purl.obolibrary.org/obo/HP_0000006
+ADVANCED SLEEP PHASE SYNDROME	http://www.orpha.net/ORDO/Orphanet_164736
 CHEDIAK-HIGASHI SYNDROME	http://www.orpha.net/ORDO/Orphanet_167
 Melnick-Fraser syndrome	http://www.ebi.ac.uk/efo/EFO_1001251
-Craniosynostosis	http://www.orpha.net/ORDO/Orphanet_53271	http://www.orpha.net/ORDO/Orphanet_794	http://www.orpha.net/ORDO/Orphanet_1531	http://www.orpha.net/ORDO/Orphanet_91483
+Craniosynostosis	http://www.orpha.net/ORDO/Orphanet_53271
 Dendritic cell	http://www.orpha.net/ORDO/Orphanet_120152
-ENCEPHALOPATHY	http://www.orpha.net/ORDO/Orphanet_409944	http://www.orpha.net/ORDO/Orphanet_330050
+ENCEPHALOPATHY	http://www.orpha.net/ORDO/Orphanet_409944
 Noonan syndrome-like disorder with juvenile myelomonocytic leukemia	http://www.orpha.net/ORDO/Orphanet_363972
-ATRIOVENTRICULAR SEPTAL DEFECT 4	http://www.orpha.net/ORDO/Orphanet_3303	http://www.orpha.net/ORDO/Orphanet_1480	http://www.orpha.net/ORDO/Orphanet_98722
-MITOCHONDRIAL SHORT-CHAIN ENOYL-CoA HYDRATASE 1 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002490	http://purl.obolibrary.org/obo/HP_0002104	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001629
+ATRIOVENTRICULAR SEPTAL DEFECT 4	http://www.orpha.net/ORDO/Orphanet_3303
+MITOCHONDRIAL SHORT-CHAIN ENOYL-CoA HYDRATASE 1 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0002151
 Acquired long QT syndrome	http://www.ebi.ac.uk/efo/EFO_0005138
-Thrombocytopenia 4	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001873
-Ischemic stroke	http://www.ebi.ac.uk/efo/EFO_1000966	http://www.ebi.ac.uk/efo/EFO_0000712
+Thrombocytopenia 4	http://purl.obolibrary.org/obo/HP_0000006
+Ischemic stroke	http://www.ebi.ac.uk/efo/EFO_1000966
 Tobacco use disorder	http://www.ebi.ac.uk/efo/EFO_0003768
 LEYDIG CELL ADENOMA	http://www.ebi.ac.uk/efo/EFO_0000232
 Primrose syndrome	http://www.orpha.net/ORDO/Orphanet_3042
-MYOPIA 21	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0011003
-CARDIOFACIOCUTANEOUS SYNDROME	http://www.orpha.net/ORDO/Orphanet_98733	http://www.orpha.net/ORDO/Orphanet_648	http://www.orpha.net/ORDO/Orphanet_1340
-LISSENCEPHALY 7 WITH CEREBELLAR HYPOPLASIA	http://purl.obolibrary.org/obo/HP_0001007	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0001274	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001004	http://purl.obolibrary.org/obo/HP_0000293	http://purl.obolibrary.org/obo/HP_0001188	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0002804	http://purl.obolibrary.org/obo/HP_0001339
+MYOPIA 21	http://purl.obolibrary.org/obo/HP_0000006
+CARDIOFACIOCUTANEOUS SYNDROME	http://www.orpha.net/ORDO/Orphanet_98733
+LISSENCEPHALY 7 WITH CEREBELLAR HYPOPLASIA	http://purl.obolibrary.org/obo/HP_0001007
 NORTH AMERICAN INDIAN CHILDHOOD CIRRHOSIS	http://www.orpha.net/ORDO/Orphanet_168583
 Woolly hair	http://www.orpha.net/ORDO/Orphanet_170
 Neoplasm of stomach	http://purl.obolibrary.org/obo/HP_0006753
-HYPOMAGNESEMIA	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001249
-Oral-facial-digital syndrome	http://www.orpha.net/ORDO/Orphanet_140997	http://www.orpha.net/ORDO/Orphanet_373	http://www.orpha.net/ORDO/Orphanet_475
+HYPOMAGNESEMIA	http://purl.obolibrary.org/obo/HP_0000252
+Oral-facial-digital syndrome	http://www.orpha.net/ORDO/Orphanet_140997
 Hypoglycemia with deficiency of glycogen synthetase in the liver	http://purl.obolibrary.org/obo/HP_0001943
 Bulls eye maculopathy	http://purl.obolibrary.org/obo/HP_0011504
 Keutel syndrome	http://www.orpha.net/ORDO/Orphanet_85202
-HYPOTRICHOSIS 8	http://purl.obolibrary.org/obo/HP_0001803	http://purl.obolibrary.org/obo/HP_0000653	http://purl.obolibrary.org/obo/HP_0001006	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002215	http://purl.obolibrary.org/obo/HP_0002209	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001807	http://purl.obolibrary.org/obo/HP_0011359	http://purl.obolibrary.org/obo/HP_0000535	http://purl.obolibrary.org/obo/HP_0002286	http://purl.obolibrary.org/obo/HP_0002224	http://purl.obolibrary.org/obo/HP_0002208
-WILSON-TURNER X-LINKED MENTAL RETARDATION SYNDROME	http://purl.obolibrary.org/obo/HP_0000712	http://purl.obolibrary.org/obo/HP_0001369	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0000771	http://purl.obolibrary.org/obo/HP_0000664	http://purl.obolibrary.org/obo/HP_0000823	http://purl.obolibrary.org/obo/HP_0001423	http://purl.obolibrary.org/obo/HP_0000278	http://purl.obolibrary.org/obo/HP_0200055	http://purl.obolibrary.org/obo/HP_0000692	http://purl.obolibrary.org/obo/HP_0008736	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0009804	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0001608	http://purl.obolibrary.org/obo/HP_0000384	http://purl.obolibrary.org/obo/HP_0009748	http://purl.obolibrary.org/obo/HP_0000336	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0001065	http://purl.obolibrary.org/obo/HP_0001182	http://purl.obolibrary.org/obo/HP_0000490	http://purl.obolibrary.org/obo/HP_0000455	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001773	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0008734	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001956	http://purl.obolibrary.org/obo/HP_0004279	http://purl.obolibrary.org/obo/HP_0000232	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001513	http://purl.obolibrary.org/obo/HP_0009906	http://purl.obolibrary.org/obo/HP_0000574	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0000307	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0002648	http://purl.obolibrary.org/obo/HP_0000280	http://purl.obolibrary.org/obo/HP_0000135	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0003199	http://purl.obolibrary.org/obo/HP_0001004	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0100830	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0400005	http://purl.obolibrary.org/obo/HP_0100603	http://purl.obolibrary.org/obo/HP_0000400
+HYPOTRICHOSIS 8	http://purl.obolibrary.org/obo/HP_0001803
+WILSON-TURNER X-LINKED MENTAL RETARDATION SYNDROME	http://purl.obolibrary.org/obo/HP_0000712
 GASTRIC CANCER SUSCEPTIBILITY AFTER H. PYLORI INFECTION	http://www.ebi.ac.uk/efo/EFO_0000178
-Moyamoya disease 6 with achalasia	http://purl.obolibrary.org/obo/HP_0002140	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0001269	http://purl.obolibrary.org/obo/HP_0002571	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000802	http://purl.obolibrary.org/obo/HP_0000965	http://purl.obolibrary.org/obo/HP_0000822
+Moyamoya disease 6 with achalasia	http://purl.obolibrary.org/obo/HP_0002140
 Familial erythrocytosis	http://www.orpha.net/ORDO/Orphanet_90042
 CORNELIA DE LANGE SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_199
 OROFACIAL CLEFT 11	http://www.orpha.net/ORDO/Orphanet_139039
-MULTIPLE MITOCHONDRIAL DYSFUNCTIONS SYNDROME 3	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000278	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0006829	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0003287	http://purl.obolibrary.org/obo/HP_0002804	http://purl.obolibrary.org/obo/HP_0001942	http://purl.obolibrary.org/obo/HP_0001298	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0006610	http://purl.obolibrary.org/obo/HP_0002126	http://purl.obolibrary.org/obo/HP_0001561	http://purl.obolibrary.org/obo/HP_0002059
+MULTIPLE MITOCHONDRIAL DYSFUNCTIONS SYNDROME 3	http://purl.obolibrary.org/obo/HP_0003577
 CRANIOMETAPHYSEAL DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_1522
 Sturge-Weber syndrome	http://www.orpha.net/ORDO/Orphanet_3205
-ATRIAL SEPTAL DEFECT 7 WITH OR WITHOUT ATRIOVENTRICULAR CONDUCTION DEFECTS	http://www.orpha.net/ORDO/Orphanet_1478	http://www.orpha.net/ORDO/Orphanet_98722
+ATRIAL SEPTAL DEFECT 7 WITH OR WITHOUT ATRIOVENTRICULAR CONDUCTION DEFECTS	http://www.orpha.net/ORDO/Orphanet_1478
 Gonadal dysgenesis with auditory dysfunction	http://www.orpha.net/ORDO/Orphanet_2855
 PYRUVATE CARBOXYLASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_3008
 Insulin-resistant diabetes mellitus AND acanthosis nigricans	http://www.ebi.ac.uk/efo/EFO_0000400
 Autosomal dominant progressive external ophthalmoplegia with mitochondrial DNA deletions 5	http://www.ebi.ac.uk/efo/EFO_0002509
 Hypomyelinating leukodystrophy 7	http://www.orpha.net/ORDO/Orphanet_68356
 VAN DER WOUDE SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_888
-AMYOTROPHIC LATERAL SCLEROSIS 14 WITHOUT FRONTOTEMPORAL DEMENTIA	http://www.ebi.ac.uk/efo/EFO_0000253	http://www.ebi.ac.uk/efo/EFO_0003862
+AMYOTROPHIC LATERAL SCLEROSIS 14 WITHOUT FRONTOTEMPORAL DEMENTIA	http://www.ebi.ac.uk/efo/EFO_0000253
 Cutaneous malignant melanoma 6	http://www.ebi.ac.uk/efo/EFO_0000389
 Paroxysmal atrial fibrillation	http://purl.obolibrary.org/obo/HP_0004757
-SPASTIC PARAPLEGIA 73	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0003701	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0001760	http://purl.obolibrary.org/obo/HP_0002355	http://purl.obolibrary.org/obo/HP_0003487
+SPASTIC PARAPLEGIA 73	http://purl.obolibrary.org/obo/HP_0001258
 Peroxisome biogenesis disorder 6A	http://www.orpha.net/ORDO/Orphanet_79189
 FUHRMANN SYNDROME	http://www.orpha.net/ORDO/Orphanet_2854
 Distal arthrogryposis type 2B	http://www.orpha.net/ORDO/Orphanet_1147
-Mucopolysaccharidosis	http://www.orpha.net/ORDO/Orphanet_309297	http://www.orpha.net/ORDO/Orphanet_79269	http://www.orpha.net/ORDO/Orphanet_79270	http://www.orpha.net/ORDO/Orphanet_79213	http://www.orpha.net/ORDO/Orphanet_79256	http://www.orpha.net/ORDO/Orphanet_309144	http://www.orpha.net/ORDO/Orphanet_93473	http://www.orpha.net/ORDO/Orphanet_577	http://www.orpha.net/ORDO/Orphanet_791	http://www.orpha.net/ORDO/Orphanet_79255	http://www.orpha.net/ORDO/Orphanet_354	http://www.orpha.net/ORDO/Orphanet_79272	http://www.orpha.net/ORDO/Orphanet_309310	http://www.orpha.net/ORDO/Orphanet_580	http://www.orpha.net/ORDO/Orphanet_93476	http://www.orpha.net/ORDO/Orphanet_79271	http://www.orpha.net/ORDO/Orphanet_579
+Mucopolysaccharidosis	http://www.orpha.net/ORDO/Orphanet_309297
 Citrullinemia Type I	http://www.orpha.net/ORDO/Orphanet_247525
 CHRONIC MYELOID LEUKEMIA	http://www.ebi.ac.uk/efo/EFO_0000339
 CRANIOLENTICULOSUTURAL DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_50814
 OCULOPHARYNGEAL MUSCULAR DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_270
 Age-related macular degeneration 3	http://www.ebi.ac.uk/efo/EFO_0001365
 Small fiber neuropathy	http://www.ebi.ac.uk/efo/EFO_0004149
-Autosomal recessive Dejerine-Sottas syndrome	http://www.orpha.net/ORDO/Orphanet_64748	http://www.orpha.net/ORDO/Orphanet_166
+Autosomal recessive Dejerine-Sottas syndrome	http://www.orpha.net/ORDO/Orphanet_64748
 Familial episodic pain syndrome 1	http://www.orpha.net/ORDO/Orphanet_391384
 Cataract and cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000318
 Left ventricular noncompaction 9	http://www.orpha.net/ORDO/Orphanet_54260
@@ -1658,65 +1658,65 @@ Ornithine carbamoyltransferase deficiency	http://www.ebi.ac.uk/efo/EFO_0007409
 CHAR SYNDROME	http://www.orpha.net/ORDO/Orphanet_46627
 FAMILIAL COLD AUTOINFLAMMATORY SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_47045
 Premature coronary artery disease	http://purl.obolibrary.org/obo/HP_0005181
-PLATELET-ACTIVATING FACTOR ACETYLHYDROLASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0040178	http://purl.obolibrary.org/obo/HP_0040175
+PLATELET-ACTIVATING FACTOR ACETYLHYDROLASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0040178
 Congenital disorder of glycosylation type 2H	http://www.orpha.net/ORDO/Orphanet_95428
 Dyskeratosis congenita	http://www.orpha.net/ORDO/Orphanet_1775
-IMMUNODEFICIENCY 28	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0011274
+IMMUNODEFICIENCY 28	http://purl.obolibrary.org/obo/HP_0000007
 CRANIOSYNOSTOSIS	http://www.orpha.net/ORDO/Orphanet_1531
-SPASTIC PARAPLEGIA 31	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0007340	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002064	http://purl.obolibrary.org/obo/HP_0011448	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0000012	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0002936
+SPASTIC PARAPLEGIA 31	http://purl.obolibrary.org/obo/HP_0002015
 CHONDRODYSPLASIA WITH JOINT DISLOCATIONS	http://www.orpha.net/ORDO/Orphanet_280586
 MYOTONIA CONGENITA	http://www.orpha.net/ORDO/Orphanet_614
-BRANCHIOOTIC SYNDROME 3	http://purl.obolibrary.org/obo/HP_0000384	http://purl.obolibrary.org/obo/HP_0009796	http://purl.obolibrary.org/obo/HP_0004467	http://purl.obolibrary.org/obo/HP_0002710	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0007678
+BRANCHIOOTIC SYNDROME 3	http://purl.obolibrary.org/obo/HP_0000384
 Osteogenesis imperfecta	http://www.orpha.net/ORDO/Orphanet_666
 Sea-blue histiocyte syndrome	http://www.ebi.ac.uk/efo/EFO_1001170
-Familial hypertrophic cardiomyopathy 13	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+Familial hypertrophic cardiomyopathy 13	http://www.ebi.ac.uk/efo/EFO_0000318
 JOHANSON-BLIZZARD SYNDROME	http://www.orpha.net/ORDO/Orphanet_2315
 Age-related macular degeneration 7	http://www.ebi.ac.uk/efo/EFO_0001365
 LEBER CONGENITAL AMAUROSIS 3	http://www.orpha.net/ORDO/Orphanet_65
 Emery-Dreifuss muscular dystrophy 4	http://www.orpha.net/ORDO/Orphanet_261
-RETINAL CONE DYSTROPHY 4	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007984	http://purl.obolibrary.org/obo/HP_0000505
-BREAST CANCER	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0000305	http://www.ebi.ac.uk/efo/EFO_0005842	http://www.ebi.ac.uk/efo/EFO_0004288	http://www.ebi.ac.uk/efo/EFO_0000365
-SPINOCEREBELLAR ATAXIA 6	http://www.orpha.net/ORDO/Orphanet_97	http://www.orpha.net/ORDO/Orphanet_98758
-Microcephaly	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0000823	http://purl.obolibrary.org/obo/HP_0000825	http://purl.obolibrary.org/obo/HP_0000445	http://purl.obolibrary.org/obo/HP_0000786	http://purl.obolibrary.org/obo/HP_0002506	http://purl.obolibrary.org/obo/HP_0001388	http://www.orpha.net/ORDO/Orphanet_647	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0005484	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002169	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002521	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0000253
+RETINAL CONE DYSTROPHY 4	http://purl.obolibrary.org/obo/HP_0000007
+BREAST CANCER	http://www.ebi.ac.uk/efo/EFO_0000311
+SPINOCEREBELLAR ATAXIA 6	http://www.orpha.net/ORDO/Orphanet_97
+Microcephaly	http://purl.obolibrary.org/obo/HP_0001347
 OCCULT MACULAR DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_247834
-Hereditary liability to pressure palsies	http://www.orpha.net/ORDO/Orphanet_640	http://www.orpha.net/ORDO/Orphanet_101081
+Hereditary liability to pressure palsies	http://www.orpha.net/ORDO/Orphanet_640
 VATER association	http://www.orpha.net/ORDO/Orphanet_887
 Juvenile polyposis/hereditary hemorrhagic telangiectasia syndrome	http://www.orpha.net/ORDO/Orphanet_2929
 HYPEREKPLEXIA 2	http://www.orpha.net/ORDO/Orphanet_3197
-Hirschsprung disease 3	http://www.orpha.net/ORDO/Orphanet_661	http://www.orpha.net/ORDO/Orphanet_388
+Hirschsprung disease 3	http://www.orpha.net/ORDO/Orphanet_661
 Osteogenesis imperfecta type 5	http://www.orpha.net/ORDO/Orphanet_216828
-Mitochondrial DNA depletion syndrome	http://www.orpha.net/ORDO/Orphanet_254803	http://www.orpha.net/ORDO/Orphanet_255235
+Mitochondrial DNA depletion syndrome	http://www.orpha.net/ORDO/Orphanet_254803
 Mental retardation X-linked syndromic 5	http://www.ebi.ac.uk/efo/EFO_0003847
-AUTISM	http://purl.obolibrary.org/obo/HP_0001417	http://purl.obolibrary.org/obo/HP_0000733	http://purl.obolibrary.org/obo/HP_0000721	http://purl.obolibrary.org/obo/HP_0001426	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0002332	http://purl.obolibrary.org/obo/HP_0000758	http://purl.obolibrary.org/obo/HP_0011463	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000732	http://purl.obolibrary.org/obo/HP_0000723	http://purl.obolibrary.org/obo/HP_0003745	http://purl.obolibrary.org/obo/HP_0005324	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0003144	http://purl.obolibrary.org/obo/HP_0000717	http://www.ebi.ac.uk/efo/EFO_0003758
-Severe neonatal-onset encephalopathy with microcephaly	http://www.orpha.net/ORDO/Orphanet_209370	http://www.orpha.net/ORDO/Orphanet_3077	http://www.orpha.net/ORDO/Orphanet_409944	http://www.orpha.net/ORDO/Orphanet_778
-GLYCOSYLPHOSPHATIDYLINOSITOL DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0030242	http://purl.obolibrary.org/obo/HP_0001409
-MIRROR MOVEMENTS 2	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0001335
+AUTISM	http://purl.obolibrary.org/obo/HP_0001417
+Severe neonatal-onset encephalopathy with microcephaly	http://www.orpha.net/ORDO/Orphanet_209370
+GLYCOSYLPHOSPHATIDYLINOSITOL DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001250
+MIRROR MOVEMENTS 2	http://purl.obolibrary.org/obo/HP_0000006
 Acute rhabdomyolysis	http://purl.obolibrary.org/obo/HP_0008942
-Dilated cardiomyopathy 1E	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318
+Dilated cardiomyopathy 1E	http://www.ebi.ac.uk/efo/EFO_0000407
 LIPOPROTEIN GLOMERULOPATHY	http://www.orpha.net/ORDO/Orphanet_329481
-Frontotemporal dementia	http://purl.obolibrary.org/obo/HP_0000713	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0001300	http://purl.obolibrary.org/obo/HP_0002529	http://purl.obolibrary.org/obo/HP_0000738	http://purl.obolibrary.org/obo/HP_0000734	http://purl.obolibrary.org/obo/HP_0002171	http://purl.obolibrary.org/obo/HP_0002381	http://purl.obolibrary.org/obo/HP_0030214	http://purl.obolibrary.org/obo/HP_0000710	http://purl.obolibrary.org/obo/HP_0000751	http://purl.obolibrary.org/obo/HP_0030223	http://purl.obolibrary.org/obo/HP_0002357	http://purl.obolibrary.org/obo/HP_0008762	http://purl.obolibrary.org/obo/HP_0006956	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000741	http://purl.obolibrary.org/obo/HP_0007064	http://purl.obolibrary.org/obo/HP_0002300	http://purl.obolibrary.org/obo/HP_0002145	http://purl.obolibrary.org/obo/HP_0002186	http://purl.obolibrary.org/obo/HP_0002354	http://purl.obolibrary.org/obo/HP_0002591
-PLEUROPULMONARY BLASTOMA	http://purl.obolibrary.org/obo/HP_0001472	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0100528	http://purl.obolibrary.org/obo/HP_0002885	http://purl.obolibrary.org/obo/HP_0002859	http://purl.obolibrary.org/obo/HP_0001939
+Frontotemporal dementia	http://purl.obolibrary.org/obo/HP_0000713
+PLEUROPULMONARY BLASTOMA	http://purl.obolibrary.org/obo/HP_0001472
 Spinocerebellar ataxia 42	http://www.ebi.ac.uk/efo/EFO_0002624
-GAUCHER DISEASE PERINATAL LETHAL	http://www.orpha.net/ORDO/Orphanet_85212	http://www.orpha.net/ORDO/Orphanet_355
-FACTOR XIII	http://purl.obolibrary.org/obo/HP_0000421	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002170	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0005261	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0011884	http://purl.obolibrary.org/obo/HP_0004846	http://purl.obolibrary.org/obo/HP_0008357	http://purl.obolibrary.org/obo/HP_0007420
+GAUCHER DISEASE PERINATAL LETHAL	http://www.orpha.net/ORDO/Orphanet_85212
+FACTOR XIII	http://purl.obolibrary.org/obo/HP_0000421
 BRONCHIECTASIS WITH OR WITHOUT ELEVATED SWEAT CHLORIDE 2	http://www.orpha.net/ORDO/Orphanet_60033
-RENAL-HEPATIC-PANCREATIC DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_294415	http://www.orpha.net/ORDO/Orphanet_564	http://www.orpha.net/ORDO/Orphanet_655
-FIBROSIS OF EXTRAOCULAR MUSCLES	http://purl.obolibrary.org/obo/HP_0007867	http://purl.obolibrary.org/obo/HP_0001488	http://purl.obolibrary.org/obo/HP_0001477	http://purl.obolibrary.org/obo/HP_0000646	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000565	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0007911	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000577	http://purl.obolibrary.org/obo/HP_0012241	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001491	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0009891	http://purl.obolibrary.org/obo/HP_0002553	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0012242	http://purl.obolibrary.org/obo/HP_0007936
+RENAL-HEPATIC-PANCREATIC DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_294415
+FIBROSIS OF EXTRAOCULAR MUSCLES	http://purl.obolibrary.org/obo/HP_0007867
 Multiple endocrine neoplasia type 2B	http://www.orpha.net/ORDO/Orphanet_247709
-PROPERDIN DEFICIENCY	http://purl.obolibrary.org/obo/HP_0005423	http://www.orpha.net/ORDO/Orphanet_2966	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0001939
-Verheij syndrome	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0009237	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0000341	http://purl.obolibrary.org/obo/HP_0000104	http://purl.obolibrary.org/obo/HP_0002948	http://purl.obolibrary.org/obo/HP_0001671	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000089	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0000589	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002937	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000107	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0030084	http://purl.obolibrary.org/obo/HP_0002059	http://purl.obolibrary.org/obo/HP_0002827
+PROPERDIN DEFICIENCY	http://purl.obolibrary.org/obo/HP_0005423
+Verheij syndrome	http://purl.obolibrary.org/obo/HP_0002650
 Acute lymphoid leukemia	http://www.ebi.ac.uk/efo/EFO_0000220
 GLUTARIC ACIDEMIA IIB	http://www.orpha.net/ORDO/Orphanet_26791
-Episodic pain syndrome	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002459
+Episodic pain syndrome	http://purl.obolibrary.org/obo/HP_0000006
 Protein S deficiency	http://www.orpha.net/ORDO/Orphanet_743
 SECKEL SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_808
-Craniosynostosis 5	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001363
-5-@OXOPROLINASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003137	http://purl.obolibrary.org/obo/HP_0040142	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0004387	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0008672	http://purl.obolibrary.org/obo/HP_0002027
-Splenic hypoplasia	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001894	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001746	http://purl.obolibrary.org/obo/HP_0001939
-HEPARIN COFACTOR II DEFICIENCY	http://purl.obolibrary.org/obo/HP_0005521	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0004850	http://purl.obolibrary.org/obo/HP_0004761
+Craniosynostosis 5	http://purl.obolibrary.org/obo/HP_0000006
+5-@OXOPROLINASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
+Splenic hypoplasia	http://purl.obolibrary.org/obo/HP_0000007
+HEPARIN COFACTOR II DEFICIENCY	http://purl.obolibrary.org/obo/HP_0005521
 PREMATURE OVARIAN FAILURE 4	http://www.orpha.net/ORDO/Orphanet_243
-MECKEL SYNDROME	http://www.orpha.net/ORDO/Orphanet_475	http://www.orpha.net/ORDO/Orphanet_564
-SPASTIC PARAPLEGIA 48	http://purl.obolibrary.org/obo/HP_0000020	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0002064	http://purl.obolibrary.org/obo/HP_0007340	http://purl.obolibrary.org/obo/HP_0003676
+MECKEL SYNDROME	http://www.orpha.net/ORDO/Orphanet_475
+SPASTIC PARAPLEGIA 48	http://purl.obolibrary.org/obo/HP_0000020
 Microcephalic osteodysplastic primordial dwarfism type 2	http://www.orpha.net/ORDO/Orphanet_2637
 Familial type 5 hyperlipoproteinemia	http://www.orpha.net/ORDO/Orphanet_70470
 BIFID NOSE WITH OR WITHOUT ANORECTAL AND RENAL ANOMALIES	http://www.orpha.net/ORDO/Orphanet_217266
@@ -1726,14 +1726,14 @@ MOYAMOYA DISEASE 2	http://www.orpha.net/ORDO/Orphanet_2573
 Deficiency of alpha-mannosidase	http://www.orpha.net/ORDO/Orphanet_61
 IMMUNODEFICIENCY DUE TO FICOLIN 3 DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_331190
 LEBER CONGENITAL AMAUROSIS 11	http://www.orpha.net/ORDO/Orphanet_65
-ANEMIA	http://purl.obolibrary.org/obo/HP_0001924	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0010972	http://purl.obolibrary.org/obo/HP_0002470	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0002169	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0004322	http://www.ebi.ac.uk/efo/EFO_0004272	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0001789	http://purl.obolibrary.org/obo/HP_0000980	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0004840	http://purl.obolibrary.org/obo/HP_0012132	http://purl.obolibrary.org/obo/HP_0004447	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001159	http://purl.obolibrary.org/obo/HP_0011273	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0100022	http://purl.obolibrary.org/obo/HP_0002075	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0001923	http://purl.obolibrary.org/obo/HP_0000952	http://purl.obolibrary.org/obo/HP_0001792	http://purl.obolibrary.org/obo/HP_0002904
-HYPERLIPIDEMIA	http://purl.obolibrary.org/obo/HP_0008356	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001114	http://purl.obolibrary.org/obo/HP_0001658
+ANEMIA	http://purl.obolibrary.org/obo/HP_0001924
+HYPERLIPIDEMIA	http://purl.obolibrary.org/obo/HP_0008356
 Malignant lymphoma	http://www.orpha.net/ORDO/Orphanet_547
-ATAXIA	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0100651	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0002059
+ATAXIA	http://purl.obolibrary.org/obo/HP_0001272
 Athabaskan brainstem dysgenesis	http://www.orpha.net/ORDO/Orphanet_69739
 Lattice corneal dystrophy type 3A	http://www.orpha.net/ORDO/Orphanet_34533
-EOSINOPHIL PEROXIDASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001879	http://purl.obolibrary.org/obo/HP_0000007
-BRANCHED-CHAIN KETOACID DEHYDROGENASE KINASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0010892	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000717	http://purl.obolibrary.org/obo/HP_0001249
+EOSINOPHIL PEROXIDASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001879
+BRANCHED-CHAIN KETOACID DEHYDROGENASE KINASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0010892
 LONG QT SYNDROME 1/2	http://www.orpha.net/ORDO/Orphanet_768
 CITRULLINEMIA	http://www.orpha.net/ORDO/Orphanet_187
 ALCOHOLISM	http://www.ebi.ac.uk/efo/EFO_0003829
@@ -1742,158 +1742,158 @@ HYPOCHONDROPLASIA	http://www.orpha.net/ORDO/Orphanet_429
 MICROTIA	http://www.orpha.net/ORDO/Orphanet_83463
 Arginase deficiency	http://www.orpha.net/ORDO/Orphanet_90
 PIEBALDISM	http://www.orpha.net/ORDO/Orphanet_2884
-Adolescent nephronophthisis	http://www.orpha.net/ORDO/Orphanet_294415	http://www.orpha.net/ORDO/Orphanet_655
-Alzheimer's disease	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000249
-EPIDERMOLYSIS BULLOSA SIMPLEX	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0008066	http://purl.obolibrary.org/obo/HP_0000982	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001805	http://purl.obolibrary.org/obo/HP_0001597	http://purl.obolibrary.org/obo/HP_0001807	http://purl.obolibrary.org/obo/HP_0006480	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0000670	http://www.orpha.net/ORDO/Orphanet_304	http://www.orpha.net/ORDO/Orphanet_79401
-Immunodeficiency 12	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0004429	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0002718
+Adolescent nephronophthisis	http://www.orpha.net/ORDO/Orphanet_294415
+Alzheimer's disease	http://www.ebi.ac.uk/efo/EFO_0000407
+EPIDERMOLYSIS BULLOSA SIMPLEX	http://purl.obolibrary.org/obo/HP_0003577
+Immunodeficiency 12	http://purl.obolibrary.org/obo/HP_0000007
 EPIDERMOLYSIS BULLOSA PRURIGINOSA	http://www.orpha.net/ORDO/Orphanet_89843
 Age-related macular degeneration 11	http://www.ebi.ac.uk/efo/EFO_0001365
 Alternating hemiplegia of childhood 1	http://www.orpha.net/ORDO/Orphanet_2131
 DYSTONIA 12	http://www.orpha.net/ORDO/Orphanet_71517
-TRIMETHYLAMINURIA	http://purl.obolibrary.org/obo/HP_0001875	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001649	http://purl.obolibrary.org/obo/HP_0006532	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0000716	http://purl.obolibrary.org/obo/HP_0003614	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0001744
+TRIMETHYLAMINURIA	http://purl.obolibrary.org/obo/HP_0001875
 Adenoma of the adrenal gland	http://www.ebi.ac.uk/efo/EFO_0000232
 Autosomal recessive hypohidrotic ectodermal dysplasia syndrome	http://www.orpha.net/ORDO/Orphanet_248
 Congenital disorder of glycosylation type 1J	http://www.orpha.net/ORDO/Orphanet_86309
-MITOCHONDRIAL COMPLEX II DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0003200	http://purl.obolibrary.org/obo/HP_0004897	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0002352	http://purl.obolibrary.org/obo/HP_0012240	http://purl.obolibrary.org/obo/HP_0003546	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0008316	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000580	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0006980	http://purl.obolibrary.org/obo/HP_0008314	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0000602	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0002376
+MITOCHONDRIAL COMPLEX II DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001371
 Cholestanol storage disease	http://www.orpha.net/ORDO/Orphanet_909
-Myocardial infarction	http://www.ebi.ac.uk/efo/EFO_0000612	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0003778
-WOLFRAM-LIKE SYNDROME	http://www.orpha.net/ORDO/Orphanet_411590	http://www.orpha.net/ORDO/Orphanet_3463
+Myocardial infarction	http://www.ebi.ac.uk/efo/EFO_0000612
+WOLFRAM-LIKE SYNDROME	http://www.orpha.net/ORDO/Orphanet_411590
 BROWN-VIALETTO-VAN LAERE SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_97229
 ULLRICH CONGENITAL MUSCULAR DYSTROPHY 1	http://www.orpha.net/ORDO/Orphanet_97242
-Cryptorchidism	http://purl.obolibrary.org/obo/HP_0012741	http://purl.obolibrary.org/obo/HP_0000104
-Mental retardation and microcephaly with pontine and cerebellar hypoplasia	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0000543	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000609	http://purl.obolibrary.org/obo/HP_0004325	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0000455	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0000966	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0001417	http://purl.obolibrary.org/obo/HP_0000366	http://purl.obolibrary.org/obo/HP_0000567	http://purl.obolibrary.org/obo/HP_0000337	http://purl.obolibrary.org/obo/HP_0002342	http://purl.obolibrary.org/obo/HP_0001290	http://purl.obolibrary.org/obo/HP_0002198	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0000400	http://purl.obolibrary.org/obo/HP_0001423	http://purl.obolibrary.org/obo/HP_0007360	http://purl.obolibrary.org/obo/HP_0001090	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0007227	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0000300	http://purl.obolibrary.org/obo/HP_0000426	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000316
-HYPOGONADOTROPIC HYPOGONADISM 9 WITH OR WITHOUT ANOSMIA	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000044	http://purl.obolibrary.org/obo/HP_0000458
+Cryptorchidism	http://purl.obolibrary.org/obo/HP_0012741
+Mental retardation and microcephaly with pontine and cerebellar hypoplasia	http://purl.obolibrary.org/obo/HP_0001324
+HYPOGONADOTROPIC HYPOGONADISM 9 WITH OR WITHOUT ANOSMIA	http://purl.obolibrary.org/obo/HP_0000006
 RETINITIS PIGMENTOSA 73	http://www.orpha.net/ORDO/Orphanet_791
-Familial porphyria cutanea tarda	http://www.orpha.net/ORDO/Orphanet_101330	http://www.orpha.net/ORDO/Orphanet_443062
+Familial porphyria cutanea tarda	http://www.orpha.net/ORDO/Orphanet_101330
 Autism 10	http://www.ebi.ac.uk/efo/EFO_0003758
 DARIER DISEASE	http://www.orpha.net/ORDO/Orphanet_218
 RETINITIS PIGMENTOSA 18	http://www.orpha.net/ORDO/Orphanet_791
 PARKINSON DISEASE 18	http://www.orpha.net/ORDO/Orphanet_411602
 LEIGH SYNDROME DUE TO MITOCHONDRIAL COMPLEX III DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_506
-HYPERPHENYLALANINEMIA	http://www.orpha.net/ORDO/Orphanet_1578	http://www.orpha.net/ORDO/Orphanet_716	http://www.orpha.net/ORDO/Orphanet_2209	http://www.orpha.net/ORDO/Orphanet_238583
+HYPERPHENYLALANINEMIA	http://www.orpha.net/ORDO/Orphanet_1578
 RIENHOFF SYNDROME	http://www.ebi.ac.uk/efo/EFO_1000012
 Severe X-linked myotubular myopathy	http://www.orpha.net/ORDO/Orphanet_596
-CLEFT PALATE	http://purl.obolibrary.org/obo/HP_0002187	http://purl.obolibrary.org/obo/HP_0000212	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0100335	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0011094	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0009102
-Nephrogenic diabetes insipidus	http://www.orpha.net/ORDO/Orphanet_93606	http://www.orpha.net/ORDO/Orphanet_223
-AICARDI-GOUTIERES SYNDROME 1	http://purl.obolibrary.org/obo/HP_0009710	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0000967	http://purl.obolibrary.org/obo/HP_0001063	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0002352	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002187	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0002135	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0009709	http://purl.obolibrary.org/obo/HP_0000253	http://www.orpha.net/ORDO/Orphanet_51	http://purl.obolibrary.org/obo/HP_0001433	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0009704	http://purl.obolibrary.org/obo/HP_0004394	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001945	http://purl.obolibrary.org/obo/HP_0002062	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000979	http://purl.obolibrary.org/obo/HP_0007321	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002421	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0002448	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0002071	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0006579	http://purl.obolibrary.org/obo/HP_0002059
-LONG QT SYNDROME 14	http://purl.obolibrary.org/obo/HP_0001695	http://purl.obolibrary.org/obo/HP_0001657
+CLEFT PALATE	http://purl.obolibrary.org/obo/HP_0002187
+Nephrogenic diabetes insipidus	http://www.orpha.net/ORDO/Orphanet_93606
+AICARDI-GOUTIERES SYNDROME 1	http://purl.obolibrary.org/obo/HP_0009710
+LONG QT SYNDROME 14	http://purl.obolibrary.org/obo/HP_0001695
 Meckel syndrome 8	http://www.orpha.net/ORDO/Orphanet_564
 Xerocytosis	http://www.orpha.net/ORDO/Orphanet_3202
 Distal arthrogryposis type 1B	http://www.orpha.net/ORDO/Orphanet_97120
-FAMILIAL ADENOMATOUS POLYPOSIS 1	http://www.orpha.net/ORDO/Orphanet_733	http://www.orpha.net/ORDO/Orphanet_79665
+FAMILIAL ADENOMATOUS POLYPOSIS 1	http://www.orpha.net/ORDO/Orphanet_733
 Familial partial lipodystrophy 2	http://www.orpha.net/ORDO/Orphanet_98306
-HYPOKALEMIC PERIODIC PARALYSIS	http://www.orpha.net/ORDO/Orphanet_682	http://www.orpha.net/ORDO/Orphanet_681
-NOONAN SYNDROME 7	http://www.orpha.net/ORDO/Orphanet_648	http://www.orpha.net/ORDO/Orphanet_1340
-STICKLER SYNDROME	http://purl.obolibrary.org/obo/HP_0004327	http://purl.obolibrary.org/obo/HP_0012230	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000545
-PARAGANGLIOMAS 4	http://purl.obolibrary.org/obo/HP_0001011	http://purl.obolibrary.org/obo/HP_0003001	http://purl.obolibrary.org/obo/HP_0005584	http://purl.obolibrary.org/obo/HP_0001676	http://purl.obolibrary.org/obo/HP_0000361	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0002640	http://purl.obolibrary.org/obo/HP_0001962	http://purl.obolibrary.org/obo/HP_0001673	http://purl.obolibrary.org/obo/HP_0011281	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0030074	http://purl.obolibrary.org/obo/HP_0000740	http://purl.obolibrary.org/obo/HP_0100723	http://purl.obolibrary.org/obo/HP_0002331	http://purl.obolibrary.org/obo/HP_0002377	http://purl.obolibrary.org/obo/HP_0006748	http://purl.obolibrary.org/obo/HP_0006737	http://purl.obolibrary.org/obo/HP_0003006
-Familial hypertrophic cardiomyopathy 20	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+HYPOKALEMIC PERIODIC PARALYSIS	http://www.orpha.net/ORDO/Orphanet_682
+NOONAN SYNDROME 7	http://www.orpha.net/ORDO/Orphanet_648
+STICKLER SYNDROME	http://purl.obolibrary.org/obo/HP_0004327
+PARAGANGLIOMAS 4	http://purl.obolibrary.org/obo/HP_0001011
+Familial hypertrophic cardiomyopathy 20	http://www.ebi.ac.uk/efo/EFO_0000318
 KALLMANN SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_478
 Erythrokeratodermia with ataxia	http://www.orpha.net/ORDO/Orphanet_1955
-Ataxia	http://www.orpha.net/ORDO/Orphanet_316240	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0010871	http://purl.obolibrary.org/obo/HP_0002403	http://purl.obolibrary.org/obo/HP_0006962	http://www.orpha.net/ORDO/Orphanet_96	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0003409	http://purl.obolibrary.org/obo/HP_0001251
-NEPHRONOPHTHISIS-LIKE NEPHROPATHY 1	http://purl.obolibrary.org/obo/HP_0100702	http://purl.obolibrary.org/obo/HP_0000092	http://purl.obolibrary.org/obo/HP_0003774	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0006280	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000108	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0005583	http://purl.obolibrary.org/obo/HP_0000090	http://purl.obolibrary.org/obo/HP_0001737
+Ataxia	http://www.orpha.net/ORDO/Orphanet_316240
+NEPHRONOPHTHISIS-LIKE NEPHROPATHY 1	http://purl.obolibrary.org/obo/HP_0100702
 Congenital disorder of glycosylation type 2E	http://www.orpha.net/ORDO/Orphanet_79333
-Pseudoexfoliation glaucoma	http://purl.obolibrary.org/obo/HP_0012629	http://purl.obolibrary.org/obo/HP_0001132	http://purl.obolibrary.org/obo/HP_0012633	http://purl.obolibrary.org/obo/HP_0012631	http://purl.obolibrary.org/obo/HP_0012636	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0009916	http://purl.obolibrary.org/obo/HP_0000501
-OSTEOSARCOMA	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_1000292	http://www.ebi.ac.uk/efo/EFO_0000637
+Pseudoexfoliation glaucoma	http://purl.obolibrary.org/obo/HP_0012629
+OSTEOSARCOMA	http://www.ebi.ac.uk/efo/EFO_0000311
 CATARACT 23	http://www.ebi.ac.uk/efo/EFO_0001059
 SPASTIC PARAPLEGIA 13	http://purl.obolibrary.org/obo/HP_0001258
 Attention deficit-hyperactivity disorder 7	http://purl.obolibrary.org/obo/HP_0007018
 Familial hypercholesterolemia	http://www.ebi.ac.uk/efo/EFO_0004911
 ECTOPIA LENTIS	http://www.orpha.net/ORDO/Orphanet_1885
-AUTOIMMUNE LYMPHOPROLIFERATIVE SYNDROME	http://purl.obolibrary.org/obo/HP_0001890	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002716	http://purl.obolibrary.org/obo/HP_0004313	http://purl.obolibrary.org/obo/HP_0001973	http://purl.obolibrary.org/obo/HP_0000964	http://purl.obolibrary.org/obo/HP_0002014	http://www.orpha.net/ORDO/Orphanet_3261	http://purl.obolibrary.org/obo/HP_0002788	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0003765
+AUTOIMMUNE LYMPHOPROLIFERATIVE SYNDROME	http://purl.obolibrary.org/obo/HP_0001890
 Oculocutaneous albinism type 3	http://www.orpha.net/ORDO/Orphanet_79433
-Glycogen storage disease	http://www.orpha.net/ORDO/Orphanet_367	http://www.orpha.net/ORDO/Orphanet_368	http://www.orpha.net/ORDO/Orphanet_365	http://www.orpha.net/ORDO/Orphanet_79201	http://www.orpha.net/ORDO/Orphanet_371
+Glycogen storage disease	http://www.orpha.net/ORDO/Orphanet_367
 PARAMYOTONIA CONGENITA/MYOTONIA CONGENITA	http://www.orpha.net/ORDO/Orphanet_684
-PROOPIOMELANOCORTIN DEFICIENCY	http://purl.obolibrary.org/obo/HP_0011748	http://purl.obolibrary.org/obo/HP_0001396	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002173	http://purl.obolibrary.org/obo/HP_0002297	http://purl.obolibrary.org/obo/HP_0000846	http://purl.obolibrary.org/obo/HP_0001513
+PROOPIOMELANOCORTIN DEFICIENCY	http://purl.obolibrary.org/obo/HP_0011748
 Dilated cardiomyopathy 1GG	http://www.ebi.ac.uk/efo/EFO_0000407
 Severe cerebellar hypoplasia	http://purl.obolibrary.org/obo/HP_0002324
 Primary autosomal recessive microcephaly 7	http://www.orpha.net/ORDO/Orphanet_2512
 Prader-Willi-like syndrome	http://www.orpha.net/ORDO/Orphanet_398073
 Subaortic stenosis	http://purl.obolibrary.org/obo/HP_0001682
 Oculocutaneous albinism type 7	http://www.orpha.net/ORDO/Orphanet_352745
-COMPLEMENT FACTOR B DEFICIENCY	http://purl.obolibrary.org/obo/HP_0005381	http://purl.obolibrary.org/obo/HP_0002586	http://purl.obolibrary.org/obo/HP_0002090	http://purl.obolibrary.org/obo/HP_0005416
+COMPLEMENT FACTOR B DEFICIENCY	http://purl.obolibrary.org/obo/HP_0005381
 Mosaic variegated aneuploidy syndrome	http://www.orpha.net/ORDO/Orphanet_1052
 Factor XII deficiency disease	http://www.orpha.net/ORDO/Orphanet_330
-Basal ganglia disease	http://purl.obolibrary.org/obo/HP_0012179	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0002134	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0001298	http://purl.obolibrary.org/obo/HP_0000737	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0000544	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0001945	http://purl.obolibrary.org/obo/HP_0002062	http://purl.obolibrary.org/obo/HP_0002300	http://purl.obolibrary.org/obo/HP_0002385	http://purl.obolibrary.org/obo/HP_0002540	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001259	http://purl.obolibrary.org/obo/HP_0001289
-FIBULAR HYPOPLASIA AND COMPLEX BRACHYDACTYLY	http://purl.obolibrary.org/obo/HP_0010109	http://purl.obolibrary.org/obo/HP_0009514	http://purl.obolibrary.org/obo/HP_0005048	http://purl.obolibrary.org/obo/HP_0008119	http://purl.obolibrary.org/obo/HP_0003272	http://purl.obolibrary.org/obo/HP_0002997	http://purl.obolibrary.org/obo/HP_0002992	http://purl.obolibrary.org/obo/HP_0002999	http://purl.obolibrary.org/obo/HP_0004097	http://purl.obolibrary.org/obo/HP_0008096	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0010055	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001772	http://purl.obolibrary.org/obo/HP_0009882	http://purl.obolibrary.org/obo/HP_0008368	http://purl.obolibrary.org/obo/HP_0009803	http://purl.obolibrary.org/obo/HP_0009182	http://purl.obolibrary.org/obo/HP_0009161	http://purl.obolibrary.org/obo/HP_0010743	http://purl.obolibrary.org/obo/HP_0009568	http://purl.obolibrary.org/obo/HP_0000446	http://purl.obolibrary.org/obo/HP_0003038	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001822	http://purl.obolibrary.org/obo/HP_0009464	http://purl.obolibrary.org/obo/HP_0004691	http://purl.obolibrary.org/obo/HP_0005930	http://purl.obolibrary.org/obo/HP_0006092	http://purl.obolibrary.org/obo/HP_0009575	http://purl.obolibrary.org/obo/HP_0009467	http://purl.obolibrary.org/obo/HP_0004220	http://purl.obolibrary.org/obo/HP_0010760	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0010049	http://purl.obolibrary.org/obo/HP_0006501	http://purl.obolibrary.org/obo/HP_0008905	http://purl.obolibrary.org/obo/HP_0010624	http://purl.obolibrary.org/obo/HP_0000954	http://purl.obolibrary.org/obo/HP_0001163	http://purl.obolibrary.org/obo/HP_0009536	http://purl.obolibrary.org/obo/HP_0002983	http://purl.obolibrary.org/obo/HP_0001792	http://purl.obolibrary.org/obo/HP_0009204	http://purl.obolibrary.org/obo/HP_0002990	http://purl.obolibrary.org/obo/HP_0001172	http://purl.obolibrary.org/obo/HP_0001376	http://purl.obolibrary.org/obo/HP_0010194
+Basal ganglia disease	http://purl.obolibrary.org/obo/HP_0012179
+FIBULAR HYPOPLASIA AND COMPLEX BRACHYDACTYLY	http://purl.obolibrary.org/obo/HP_0010109
 ELLIPTOCYTOSIS 3	http://purl.obolibrary.org/obo/HP_0004445
 Peripheral schisis	http://purl.obolibrary.org/obo/HP_0011511
-SPASTIC PARAPLEGIA 55	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0003376	http://purl.obolibrary.org/obo/HP_0002355	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000603	http://purl.obolibrary.org/obo/HP_0003383	http://purl.obolibrary.org/obo/HP_0002169	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0003477	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0002936	http://purl.obolibrary.org/obo/HP_0000639
+SPASTIC PARAPLEGIA 55	http://purl.obolibrary.org/obo/HP_0100543
 PREMATURE OVARIAN FAILURE 6	http://www.ebi.ac.uk/efo/EFO_0004266
-Dilated cardiomyopathy 1S	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0002945
+Dilated cardiomyopathy 1S	http://www.ebi.ac.uk/efo/EFO_0000407
 Glycogen storage disease IIIc	http://www.orpha.net/ORDO/Orphanet_79201
 Progressive pseudorheumatoid dysplasia	http://www.orpha.net/ORDO/Orphanet_1159
-Immunodeficiency 26 with or without neurologic abnormalities	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0003429	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0001302	http://purl.obolibrary.org/obo/HP_0011107	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0010557	http://purl.obolibrary.org/obo/HP_0000490	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0000331	http://purl.obolibrary.org/obo/HP_0004430	http://purl.obolibrary.org/obo/HP_0009879	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0002783	http://purl.obolibrary.org/obo/HP_0012444	http://purl.obolibrary.org/obo/HP_0001320
+Immunodeficiency 26 with or without neurologic abnormalities	http://purl.obolibrary.org/obo/HP_0001511
 FRONTONASAL DYSPLASIA 3	http://www.orpha.net/ORDO/Orphanet_250
-RENAL TUBULAR ACIDOSIS	http://purl.obolibrary.org/obo/HP_0008153	http://www.ebi.ac.uk/efo/EFO_0003847	http://purl.obolibrary.org/obo/HP_0002756	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002749	http://purl.obolibrary.org/obo/HP_0002901	http://purl.obolibrary.org/obo/HP_0000121	http://purl.obolibrary.org/obo/HP_0001947	http://www.orpha.net/ORDO/Orphanet_93610	http://www.orpha.net/ORDO/Orphanet_402041	http://www.orpha.net/ORDO/Orphanet_93608	http://purl.obolibrary.org/obo/HP_0003768	http://purl.obolibrary.org/obo/HP_0008897	http://www.orpha.net/ORDO/Orphanet_18
+RENAL TUBULAR ACIDOSIS	http://purl.obolibrary.org/obo/HP_0008153
 Microcephaly-capillary malformation syndrome	http://www.orpha.net/ORDO/Orphanet_294016
-SHORT-RIB THORACIC DYSPLASIA 13 WITH OR WITHOUT POLYDACTYLY	http://purl.obolibrary.org/obo/HP_0002089	http://purl.obolibrary.org/obo/HP_0011315	http://purl.obolibrary.org/obo/HP_0000062	http://purl.obolibrary.org/obo/HP_0001539	http://purl.obolibrary.org/obo/HP_0000089	http://purl.obolibrary.org/obo/HP_0000280	http://purl.obolibrary.org/obo/HP_0000448	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0003180	http://purl.obolibrary.org/obo/HP_0004482	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000695	http://purl.obolibrary.org/obo/HP_0008839	http://purl.obolibrary.org/obo/HP_0000774	http://purl.obolibrary.org/obo/HP_0100258	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0000888	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0001591	http://purl.obolibrary.org/obo/HP_0000308	http://purl.obolibrary.org/obo/HP_0000773	http://purl.obolibrary.org/obo/HP_0000400
+SHORT-RIB THORACIC DYSPLASIA 13 WITH OR WITHOUT POLYDACTYLY	http://purl.obolibrary.org/obo/HP_0002089
 Autism 16	http://www.ebi.ac.uk/efo/EFO_0003758
 Leprosy 5	http://www.ebi.ac.uk/efo/EFO_0001054
 HYPERCALCIURIC HYPERCALCEMIA	http://purl.obolibrary.org/obo/HP_0003072
 AMYOTROPHIC LATERAL SCLEROSIS 18	http://www.ebi.ac.uk/efo/EFO_0000253
-SPINOCEREBELLAR ATAXIA 40	http://purl.obolibrary.org/obo/HP_0002313	http://purl.obolibrary.org/obo/HP_0006879	http://purl.obolibrary.org/obo/HP_0002136	http://purl.obolibrary.org/obo/HP_0002075	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0002317
+SPINOCEREBELLAR ATAXIA 40	http://purl.obolibrary.org/obo/HP_0002313
 Autosomal recessive congenital ichthyosis 3	http://www.orpha.net/ORDO/Orphanet_281097
 TEMPLE-BARAITSER SYNDROME	http://www.orpha.net/ORDO/Orphanet_420561
 Auriculocondylar syndrome 3	http://www.orpha.net/ORDO/Orphanet_137888
-HYPOPHOSPHATEMIC RICKETS	http://www.orpha.net/ORDO/Orphanet_289176	http://www.orpha.net/ORDO/Orphanet_51608
+HYPOPHOSPHATEMIC RICKETS	http://www.orpha.net/ORDO/Orphanet_289176
 FAMILIAL MEDITERRANEAN FEVER	http://www.orpha.net/ORDO/Orphanet_342
-CHONDRODYSPLASIA WITH PLATYSPONDYLY	http://purl.obolibrary.org/obo/HP_0000962	http://purl.obolibrary.org/obo/HP_0007360	http://purl.obolibrary.org/obo/HP_0001423	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0002866	http://purl.obolibrary.org/obo/HP_0100555	http://purl.obolibrary.org/obo/HP_0006402	http://purl.obolibrary.org/obo/HP_0000883	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0006028	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0002644	http://purl.obolibrary.org/obo/HP_0009826	http://purl.obolibrary.org/obo/HP_0001831	http://purl.obolibrary.org/obo/HP_0000322	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0006208	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0000878	http://purl.obolibrary.org/obo/HP_0012789	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0003028	http://purl.obolibrary.org/obo/HP_0004331	http://purl.obolibrary.org/obo/HP_0000457	http://purl.obolibrary.org/obo/HP_0002652	http://purl.obolibrary.org/obo/HP_0008905	http://purl.obolibrary.org/obo/HP_0000926	http://purl.obolibrary.org/obo/HP_0001163	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0000568	http://purl.obolibrary.org/obo/HP_0000256
+CHONDRODYSPLASIA WITH PLATYSPONDYLY	http://purl.obolibrary.org/obo/HP_0000962
 Sulfite oxidase deficiency	http://purl.obolibrary.org/obo/HP_0003643
-MICROCEPHALY	http://purl.obolibrary.org/obo/HP_0002123	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000135	http://purl.obolibrary.org/obo/HP_0000007	http://www.orpha.net/ORDO/Orphanet_391408	http://purl.obolibrary.org/obo/HP_0009879	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000819	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002521	http://purl.obolibrary.org/obo/HP_0012448
+MICROCEPHALY	http://purl.obolibrary.org/obo/HP_0002123
 SINGLETON-MERTEN SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_85191
-familial hyperinsulinism	http://www.orpha.net/ORDO/Orphanet_657	http://www.orpha.net/ORDO/Orphanet_276525
+familial hyperinsulinism	http://www.orpha.net/ORDO/Orphanet_657
 DIMETHYLGLYCINE DEHYDROGENASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_243343
 Meier-Gorlin syndrome 5	http://www.orpha.net/ORDO/Orphanet_2554
 Dihydropteridine reductase deficiency	http://www.orpha.net/ORDO/Orphanet_226
 LEFT VENTRICULAR NONCOMPACTION 1	http://www.orpha.net/ORDO/Orphanet_54260
-PEROXISOME BIOGENESIS DISORDER 4B	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001319
-Mitochondrial DNA depletion syndrome 12 (cardiomyopathic type)	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0001513	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0003546	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0003326
+PEROXISOME BIOGENESIS DISORDER 4B	http://purl.obolibrary.org/obo/HP_0001263
+Mitochondrial DNA depletion syndrome 12 (cardiomyopathic type)	http://purl.obolibrary.org/obo/HP_0100543
 Deficiency of 3-hydroxyacyl-CoA dehydrogenase	http://www.orpha.net/ORDO/Orphanet_309127
-Striatal necrosis	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002355	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0001254	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0001271	http://purl.obolibrary.org/obo/HP_0003470	http://purl.obolibrary.org/obo/HP_0003477	http://purl.obolibrary.org/obo/HP_0005750	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0002490
+Striatal necrosis	http://purl.obolibrary.org/obo/HP_0000007
 Pretibial epidermolysis bullosa	http://purl.obolibrary.org/obo/HP_0012221
 FOCAL SEGMENTAL GLOMERULOSCLEROSIS 1	http://www.ebi.ac.uk/efo/EFO_0004236
-MACULAR DYSTROPHY WITH CENTRAL CONE INVOLVEMENT	http://purl.obolibrary.org/obo/HP_0007754	http://purl.obolibrary.org/obo/HP_0002123	http://purl.obolibrary.org/obo/HP_0000543	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0002180	http://purl.obolibrary.org/obo/HP_0000572	http://purl.obolibrary.org/obo/HP_0003678	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000580	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001268	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002360	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000488	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0011504	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0002059
+MACULAR DYSTROPHY WITH CENTRAL CONE INVOLVEMENT	http://purl.obolibrary.org/obo/HP_0007754
 SPERMATOGENIC FAILURE 10	http://www.orpha.net/ORDO/Orphanet_276234
 ATRICHIA WITH PAPULAR LESIONS	http://www.orpha.net/ORDO/Orphanet_86819
 Hereditary hemorrhagic telangiectasia type 2	http://www.orpha.net/ORDO/Orphanet_774
-HEMOLYTIC ANEMIA	http://www.ebi.ac.uk/efo/EFO_0005558	http://www.orpha.net/ORDO/Orphanet_712
-SPASTIC PARAPLEGIA 28	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0002355	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0003477	http://purl.obolibrary.org/obo/HP_0002936	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0002061	http://purl.obolibrary.org/obo/HP_0007340	http://purl.obolibrary.org/obo/HP_0001761
+HEMOLYTIC ANEMIA	http://www.ebi.ac.uk/efo/EFO_0005558
+SPASTIC PARAPLEGIA 28	http://purl.obolibrary.org/obo/HP_0001347
 X-linked agammaglobulinemia	http://www.orpha.net/ORDO/Orphanet_47
-Hypogonadotropic hypogonadism 20 with or without anosmia	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0000823	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0000135
+Hypogonadotropic hypogonadism 20 with or without anosmia	http://purl.obolibrary.org/obo/HP_0000939
 INFLAMMATORY BOWEL DISEASE 28	http://www.orpha.net/ORDO/Orphanet_238569
 Deficiency of UDPglucose-hexose-1-phosphate uridylyltransferase	http://www.orpha.net/ORDO/Orphanet_79239
 PUSTULAR PSORIASIS	http://www.ebi.ac.uk/efo/EFO_0000676
 XERODERMA PIGMENTOSUM GROUP G/COCKAYNE SYNDROME	http://www.orpha.net/ORDO/Orphanet_132271
 Deafness with labyrinthine aplasia microtia and microdontia (LAMM)	http://www.ebi.ac.uk/efo/EFO_0001063
-Absent or delayed speech development	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0000341	http://purl.obolibrary.org/obo/HP_0011344	http://purl.obolibrary.org/obo/HP_0001531	http://purl.obolibrary.org/obo/HP_0002373	http://purl.obolibrary.org/obo/HP_0000490	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001822	http://purl.obolibrary.org/obo/HP_0000717	http://purl.obolibrary.org/obo/HP_0001249
+Absent or delayed speech development	http://purl.obolibrary.org/obo/HP_0000252
 Hydrocephalus	http://purl.obolibrary.org/obo/HP_0000238
 Spastic paraplegia 39	http://purl.obolibrary.org/obo/HP_0001258
-SPASTIC PARAPLEGIA 52	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0006957	http://purl.obolibrary.org/obo/HP_0000448	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0000414	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0010864	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0100021	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0000280
+SPASTIC PARAPLEGIA 52	http://purl.obolibrary.org/obo/HP_0001371
 DERMATOPATHIA PIGMENTOSA RETICULARIS	http://www.orpha.net/ORDO/Orphanet_86920
-DENT DISEASE 2	http://www.orpha.net/ORDO/Orphanet_534	http://www.orpha.net/ORDO/Orphanet_93623
-WOOLLY HAIR	http://purl.obolibrary.org/obo/HP_0011359	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002224	http://purl.obolibrary.org/obo/HP_0002208
-CHRONIC ATRIAL AND INTESTINAL DYSRHYTHMIA	http://purl.obolibrary.org/obo/HP_0001647	http://purl.obolibrary.org/obo/HP_0001653	http://purl.obolibrary.org/obo/HP_0005110	http://purl.obolibrary.org/obo/HP_0004749	http://purl.obolibrary.org/obo/HP_0001642	http://purl.obolibrary.org/obo/HP_0001662	http://purl.obolibrary.org/obo/HP_0011704	http://purl.obolibrary.org/obo/HP_0001508
-SPONDYLOCARPOTARSAL SYNOSTOSIS SYNDROME	http://purl.obolibrary.org/obo/HP_0005048	http://purl.obolibrary.org/obo/HP_0007961	http://purl.obolibrary.org/obo/HP_0010306	http://purl.obolibrary.org/obo/HP_0002948	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000384	http://purl.obolibrary.org/obo/HP_0008368	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0002644	http://purl.obolibrary.org/obo/HP_0008456	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0000455	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0003312	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0002656	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0006297	http://purl.obolibrary.org/obo/HP_0000410	http://purl.obolibrary.org/obo/HP_0009702	http://purl.obolibrary.org/obo/HP_0003311	http://purl.obolibrary.org/obo/HP_0000113	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0003521	http://purl.obolibrary.org/obo/HP_0001376	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0000107	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0003305	http://purl.obolibrary.org/obo/HP_0003307	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0002091	http://purl.obolibrary.org/obo/HP_0003422	http://purl.obolibrary.org/obo/HP_0000283
-Polymicrogyria	http://purl.obolibrary.org/obo/HP_0002463	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0012650	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001249
-Myopia 6	http://www.orpha.net/ORDO/Orphanet_98619	http://www.orpha.net/ORDO/Orphanet_1561
+DENT DISEASE 2	http://www.orpha.net/ORDO/Orphanet_534
+WOOLLY HAIR	http://purl.obolibrary.org/obo/HP_0011359
+CHRONIC ATRIAL AND INTESTINAL DYSRHYTHMIA	http://purl.obolibrary.org/obo/HP_0001647
+SPONDYLOCARPOTARSAL SYNOSTOSIS SYNDROME	http://purl.obolibrary.org/obo/HP_0005048
+Polymicrogyria	http://purl.obolibrary.org/obo/HP_0002463
+Myopia 6	http://www.orpha.net/ORDO/Orphanet_98619
 Multiple exostoses type 2	http://purl.obolibrary.org/obo/HP_0002762
 Glycogen storage disease IIIb	http://www.orpha.net/ORDO/Orphanet_79201
 RETINITIS PIGMENTOSA 37	http://www.orpha.net/ORDO/Orphanet_791
-Hereditary pyropoikilocytosis	http://purl.obolibrary.org/obo/HP_0004445	http://purl.obolibrary.org/obo/HP_0004839
+Hereditary pyropoikilocytosis	http://purl.obolibrary.org/obo/HP_0004445
 Oculocutaneous albinism type 1	http://www.orpha.net/ORDO/Orphanet_352731
-IMMUNODEFICIENCY 39	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002721
+IMMUNODEFICIENCY 39	http://purl.obolibrary.org/obo/HP_0000007
 Macroglobulinemia	http://www.ebi.ac.uk/efo/EFO_0002616
 Pseudo-Hurler polydystrophy	http://www.orpha.net/ORDO/Orphanet_577
 Retinitis Pigmentosa 28	http://www.orpha.net/ORDO/Orphanet_791
-Heterotopia	http://purl.obolibrary.org/obo/HP_0002273	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0007165	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000817	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002521	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002282	http://purl.obolibrary.org/obo/HP_0001508
-Papillon-Lefevre syndrome	http://www.orpha.net/ORDO/Orphanet_678	http://www.orpha.net/ORDO/Orphanet_2342
-ATRIAL STANDSTILL 1	http://www.orpha.net/ORDO/Orphanet_768	http://www.orpha.net/ORDO/Orphanet_1344	http://www.orpha.net/ORDO/Orphanet_130
-Corneal intraepithelial dyskeratosis and ectodermal dysplasia	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0008404	http://purl.obolibrary.org/obo/HP_0000968	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0011496	http://purl.obolibrary.org/obo/HP_0000982	http://purl.obolibrary.org/obo/HP_0001036	http://purl.obolibrary.org/obo/HP_0006094
+Heterotopia	http://purl.obolibrary.org/obo/HP_0002273
+Papillon-Lefevre syndrome	http://www.orpha.net/ORDO/Orphanet_678
+ATRIAL STANDSTILL 1	http://www.orpha.net/ORDO/Orphanet_768
+Corneal intraepithelial dyskeratosis and ectodermal dysplasia	http://purl.obolibrary.org/obo/HP_0000470
 ASPARTYLGLUCOSAMINURIA	http://www.orpha.net/ORDO/Orphanet_93
 VITREORETINOPATHY WITH PHALANGEAL EPIPHYSEAL DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_98668
 Congenital disorder of glycosylation type 1z	http://www.orpha.net/ORDO/Orphanet_137
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 9	http://purl.obolibrary.org/obo/HP_0003348	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0002094	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001639
-Congenital muscular dystrophy-dystroglycanopathy with brain and eye anomalies	http://www.orpha.net/ORDO/Orphanet_371024	http://www.orpha.net/ORDO/Orphanet_588	http://www.orpha.net/ORDO/Orphanet_97242	http://www.orpha.net/ORDO/Orphanet_263
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 9	http://purl.obolibrary.org/obo/HP_0003348
+Congenital muscular dystrophy-dystroglycanopathy with brain and eye anomalies	http://www.orpha.net/ORDO/Orphanet_371024
 Amyotrophic lateral sclerosis type 6	http://www.ebi.ac.uk/efo/EFO_0000253
 Norum disease	http://www.orpha.net/ORDO/Orphanet_79293
 D-2-hydroxyglutaric aciduria	http://www.orpha.net/ORDO/Orphanet_79315
@@ -1902,12 +1902,12 @@ UV-sensitive syndrome	http://www.orpha.net/ORDO/Orphanet_178338
 Multiple epiphyseal dysplasia 1	http://www.orpha.net/ORDO/Orphanet_93308
 SCHNECKENBECKEN DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_3144
 PSYCHOMOTOR RETARDATION	http://www.ebi.ac.uk/efo/EFO_0000474
-Distal spinal muscular atrophy	http://www.orpha.net/ORDO/Orphanet_166	http://www.orpha.net/ORDO/Orphanet_206713
+Distal spinal muscular atrophy	http://www.orpha.net/ORDO/Orphanet_166
 Premature ovarian failure 9	http://www.ebi.ac.uk/efo/EFO_0004266
-CORTISONE REDUCTASE DEFICIENCY 1	http://purl.obolibrary.org/obo/HP_0000789	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001007	http://purl.obolibrary.org/obo/HP_0001061	http://purl.obolibrary.org/obo/HP_0000876	http://purl.obolibrary.org/obo/HP_0001513
+CORTISONE REDUCTASE DEFICIENCY 1	http://purl.obolibrary.org/obo/HP_0000789
 Congenital disorder of glycosylation type 1C	http://www.orpha.net/ORDO/Orphanet_79320
-Sick sinus syndrome	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001688	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0005155	http://purl.obolibrary.org/obo/HP_0001657	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0011704	http://purl.obolibrary.org/obo/HP_0001678
-NEURAL TUBE DEFECTS	http://www.orpha.net/ORDO/Orphanet_268357	http://www.orpha.net/ORDO/Orphanet_823
+Sick sinus syndrome	http://purl.obolibrary.org/obo/HP_0000007
+NEURAL TUBE DEFECTS	http://www.orpha.net/ORDO/Orphanet_268357
 Intermediate maple syrup urine disease type 2	http://www.orpha.net/ORDO/Orphanet_268162
 WEISSENBACHER-ZWEYMULLER SYNDROME	http://www.orpha.net/ORDO/Orphanet_3450
 PERRAULT SYNDROME 5	http://www.orpha.net/ORDO/Orphanet_2855
@@ -1915,174 +1915,174 @@ HERMANSKY-PUDLAK SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_79430
 Focal epilepsy	http://www.ebi.ac.uk/efo/EFO_0004263
 Czech dysplasia	http://www.orpha.net/ORDO/Orphanet_137678
 Left ventricular noncompaction 10	http://www.orpha.net/ORDO/Orphanet_54260
-MITOCHONDRIAL DNA DEPLETION SYNDROME 1 (MNGIE TYPE)	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0002254	http://purl.obolibrary.org/obo/HP_0002578	http://purl.obolibrary.org/obo/HP_0003200	http://purl.obolibrary.org/obo/HP_0002352	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003688	http://purl.obolibrary.org/obo/HP_0004395	http://purl.obolibrary.org/obo/HP_0003548	http://purl.obolibrary.org/obo/HP_0002027	http://purl.obolibrary.org/obo/HP_0007103	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0003693	http://purl.obolibrary.org/obo/HP_0002579	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0000590	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0003737	http://purl.obolibrary.org/obo/HP_0004326	http://purl.obolibrary.org/obo/HP_0003689	http://purl.obolibrary.org/obo/HP_0002024	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0002460	http://purl.obolibrary.org/obo/HP_0002936	http://purl.obolibrary.org/obo/HP_0100613
+MITOCHONDRIAL DNA DEPLETION SYNDROME 1 (MNGIE TYPE)	http://purl.obolibrary.org/obo/HP_0000508
 HYPERAPOBETALIPOPROTEINEMIA	http://purl.obolibrary.org/obo/HP_0008158
 RETINITIS PIGMENTOSA 41	http://www.orpha.net/ORDO/Orphanet_791
 AURICULOCONDYLAR SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_137888
-KLIPPEL-FEIL SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_98938	http://www.orpha.net/ORDO/Orphanet_2345
-Bullous ichthyosiform erythroderma	http://purl.obolibrary.org/obo/HP_0000972	http://purl.obolibrary.org/obo/HP_0001019	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0008066	http://purl.obolibrary.org/obo/HP_0040189
-CAMPTODACTYLY	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000098	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0006417	http://purl.obolibrary.org/obo/HP_0001166	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0004570	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0100490	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0009473	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0030431	http://purl.obolibrary.org/obo/HP_0001836
+KLIPPEL-FEIL SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_98938
+Bullous ichthyosiform erythroderma	http://purl.obolibrary.org/obo/HP_0000972
+CAMPTODACTYLY	http://purl.obolibrary.org/obo/HP_0002650
 Hereditary factor VIII deficiency disease	http://www.orpha.net/ORDO/Orphanet_98878
 Reynolds syndrome	http://www.orpha.net/ORDO/Orphanet_779
 Wiedemann-Steiner syndrome	http://www.orpha.net/ORDO/Orphanet_319182
 Spheroid body myopathy	http://www.orpha.net/ORDO/Orphanet_268129
 BARDET-BIEDL SYNDROME 13	http://www.orpha.net/ORDO/Orphanet_110
-Familial hypertrophic cardiomyopathy 10	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+Familial hypertrophic cardiomyopathy 10	http://www.ebi.ac.uk/efo/EFO_0000318
 ACHROMATOPSIA 7	http://www.orpha.net/ORDO/Orphanet_49382
 Aspergillosis	http://www.ebi.ac.uk/efo/EFO_0007157
 METAPHYSEAL ANADYSPLASIA 2	http://www.orpha.net/ORDO/Orphanet_1040
-RAPADILINO SYNDROME	http://www.orpha.net/ORDO/Orphanet_3021	http://www.orpha.net/ORDO/Orphanet_1225	http://www.orpha.net/ORDO/Orphanet_2909
+RAPADILINO SYNDROME	http://www.orpha.net/ORDO/Orphanet_3021
 Orofacial-digital syndrome IV	http://www.orpha.net/ORDO/Orphanet_2753
 Diffuse mesangial sclerosis	http://purl.obolibrary.org/obo/HP_0001967
-Charcot-Marie-Tooth disease	http://purl.obolibrary.org/obo/HP_0003376	http://purl.obolibrary.org/obo/HP_0007182	http://purl.obolibrary.org/obo/HP_0002355	http://purl.obolibrary.org/obo/HP_0001423	http://www.orpha.net/ORDO/Orphanet_166	http://purl.obolibrary.org/obo/HP_0009830	http://purl.obolibrary.org/obo/HP_0003677	http://www.orpha.net/ORDO/Orphanet_101082	http://www.orpha.net/ORDO/Orphanet_101081	http://purl.obolibrary.org/obo/HP_0000007	http://www.orpha.net/ORDO/Orphanet_83330	http://purl.obolibrary.org/obo/HP_0030237	http://purl.obolibrary.org/obo/HP_0003383	http://www.orpha.net/ORDO/Orphanet_101101	http://purl.obolibrary.org/obo/HP_0001765	http://purl.obolibrary.org/obo/HP_0001155	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0003431	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0009027	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001760	http://www.orpha.net/ORDO/Orphanet_300319	http://www.orpha.net/ORDO/Orphanet_640	http://www.orpha.net/ORDO/Orphanet_206713	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0003676	http://www.orpha.net/ORDO/Orphanet_101083	http://purl.obolibrary.org/obo/HP_0003387	http://purl.obolibrary.org/obo/HP_0002378	http://purl.obolibrary.org/obo/HP_0003450	http://www.orpha.net/ORDO/Orphanet_431255	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0002460	http://purl.obolibrary.org/obo/HP_0001265	http://www.orpha.net/ORDO/Orphanet_64748	http://purl.obolibrary.org/obo/HP_0002936
-METHYLMALONIC ACIDURIA	http://purl.obolibrary.org/obo/HP_0001875	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0001987	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0001876	http://purl.obolibrary.org/obo/HP_0002919	http://www.orpha.net/ORDO/Orphanet_171059	http://www.orpha.net/ORDO/Orphanet_289916	http://purl.obolibrary.org/obo/HP_0012120	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003210	http://purl.obolibrary.org/obo/HP_0001946	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001254	http://purl.obolibrary.org/obo/HP_0002912	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0001944	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001942	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002098	http://purl.obolibrary.org/obo/HP_0002154	http://purl.obolibrary.org/obo/HP_0003145	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0003623	http://purl.obolibrary.org/obo/HP_0001259
-Spinocerebellar ataxia	http://purl.obolibrary.org/obo/HP_0000571	http://purl.obolibrary.org/obo/HP_0003680	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0002312	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0000546	http://purl.obolibrary.org/obo/HP_0007338	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0000708	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0008003	http://purl.obolibrary.org/obo/HP_0002174	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0002317	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001107	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0000640	http://purl.obolibrary.org/obo/HP_0000544	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0008046	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0002495	http://purl.obolibrary.org/obo/HP_0002066	http://www.orpha.net/ORDO/Orphanet_64753	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001152	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002078	http://purl.obolibrary.org/obo/HP_0007513	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0007772	http://purl.obolibrary.org/obo/HP_0100275	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0005599	http://purl.obolibrary.org/obo/HP_0011448	http://purl.obolibrary.org/obo/HP_0000651	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0002075	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002024	http://www.orpha.net/ORDO/Orphanet_311398	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001265
-Blood group	http://purl.obolibrary.org/obo/HP_0004445	http://purl.obolibrary.org/obo/HP_0010970
-SPINOCEREBELLAR ATAXIA 15	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0002078	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0007772	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002174	http://purl.obolibrary.org/obo/HP_0002168	http://purl.obolibrary.org/obo/HP_0000641	http://purl.obolibrary.org/obo/HP_0007979	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0002066
+Charcot-Marie-Tooth disease	http://purl.obolibrary.org/obo/HP_0003376
+METHYLMALONIC ACIDURIA	http://purl.obolibrary.org/obo/HP_0001875
+Spinocerebellar ataxia	http://purl.obolibrary.org/obo/HP_0000571
+Blood group	http://purl.obolibrary.org/obo/HP_0004445
+SPINOCEREBELLAR ATAXIA 15	http://purl.obolibrary.org/obo/HP_0001347
 KARAK SYNDROME	http://www.orpha.net/ORDO/Orphanet_35069
 Infantile myofibromatosis 1	http://www.orpha.net/ORDO/Orphanet_2591
-Lethal tight skin contracture syndrome	http://www.orpha.net/ORDO/Orphanet_2670	http://www.orpha.net/ORDO/Orphanet_1662
-SHORT QT SYNDROME 3	http://purl.obolibrary.org/obo/HP_0001962	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0012232	http://purl.obolibrary.org/obo/HP_0001649
+Lethal tight skin contracture syndrome	http://www.orpha.net/ORDO/Orphanet_2670
+SHORT QT SYNDROME 3	http://purl.obolibrary.org/obo/HP_0001962
 HYPERTELORISM	http://www.ebi.ac.uk/efo/EFO_0003847
 Dilated cardiomyopathy 1X	http://www.ebi.ac.uk/efo/EFO_0000318
 ZNF711-Related X-linked Mental Retardation	http://www.ebi.ac.uk/efo/EFO_0003847
 McLeod neuroacanthocytosis syndrome	http://www.orpha.net/ORDO/Orphanet_59306
 Wagner syndrome	http://www.orpha.net/ORDO/Orphanet_898
-GLIOMA SUSCEPTIBILITY 2	http://www.orpha.net/ORDO/Orphanet_182067	http://www.orpha.net/ORDO/Orphanet_2495
+GLIOMA SUSCEPTIBILITY 2	http://www.orpha.net/ORDO/Orphanet_182067
 CANAVAN DISEASE	http://www.orpha.net/ORDO/Orphanet_141
 Methemoglobinemia type 2	http://www.orpha.net/ORDO/Orphanet_139380
 Multiple pterygium syndrome Escobar type	http://www.ebi.ac.uk/efo/EFO_0000678
 Deficiency of malonyl-CoA decarboxylase	http://www.orpha.net/ORDO/Orphanet_943
-Combined oxidative phosphorylation deficiency 17	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001639
-MANDIBULOACRAL DYSPLASIA WITH TYPE A LIPODYSTROPHY	http://www.orpha.net/ORDO/Orphanet_2457	http://www.orpha.net/ORDO/Orphanet_166
+Combined oxidative phosphorylation deficiency 17	http://purl.obolibrary.org/obo/HP_0000007
+MANDIBULOACRAL DYSPLASIA WITH TYPE A LIPODYSTROPHY	http://www.orpha.net/ORDO/Orphanet_2457
 Brain iron accummulation	http://purl.obolibrary.org/obo/HP_0002180
 Mucosa-associated lymphoma	http://www.ebi.ac.uk/efo/EFO_0000574
-TIMOTHY SYNDROME	http://www.orpha.net/ORDO/Orphanet_768	http://www.orpha.net/ORDO/Orphanet_65283
+TIMOTHY SYNDROME	http://www.orpha.net/ORDO/Orphanet_768
 Spondylocostal dysostosis 2	http://www.orpha.net/ORDO/Orphanet_364559
 Pseudoprimary hyperaldosteronism	http://www.orpha.net/ORDO/Orphanet_112
 LISSENCEPHALY 3	http://www.orpha.net/ORDO/Orphanet_48471
-Infantile convulsions and paroxysmal choreoathetosis	http://purl.obolibrary.org/obo/HP_0000733	http://purl.obolibrary.org/obo/HP_0002197	http://purl.obolibrary.org/obo/HP_0002072	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002372	http://purl.obolibrary.org/obo/HP_0007098	http://purl.obolibrary.org/obo/HP_0000271	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0000739	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0002310	http://purl.obolibrary.org/obo/HP_0040168	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002268	http://purl.obolibrary.org/obo/HP_0002353
-BASAL GANGLIA CALCIFICATION	http://purl.obolibrary.org/obo/HP_0002135	http://purl.obolibrary.org/obo/HP_0001300	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0000726	http://purl.obolibrary.org/obo/HP_0002354	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001266	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000639
-Spastic paraplegia 64	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000519	http://purl.obolibrary.org/obo/HP_0002500	http://purl.obolibrary.org/obo/HP_0001249
+Infantile convulsions and paroxysmal choreoathetosis	http://purl.obolibrary.org/obo/HP_0000733
+BASAL GANGLIA CALCIFICATION	http://purl.obolibrary.org/obo/HP_0002135
+Spastic paraplegia 64	http://purl.obolibrary.org/obo/HP_0000007
 Autism 15	http://www.ebi.ac.uk/efo/EFO_0003758
 HEMANGIOMA	http://www.orpha.net/ORDO/Orphanet_91415
 Common variable immunodeficiency 7	http://www.orpha.net/ORDO/Orphanet_1572
 SEVERE COMBINED IMMUNODEFICIENCY WITH MICROCEPHALY	http://www.orpha.net/ORDO/Orphanet_183660
-Bone mineral density quantitative trait locus 15	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000939
+Bone mineral density quantitative trait locus 15	http://purl.obolibrary.org/obo/HP_0000006
 Van Maldergem syndrome 2	http://www.orpha.net/ORDO/Orphanet_314679
 Primary hyperaldosteronism	http://purl.obolibrary.org/obo/HP_0011736
 MACROTHROMBOCYTOPENIA	http://www.orpha.net/ORDO/Orphanet_140957
 Atrial septal defect	http://www.ebi.ac.uk/efo/EFO_1000825
 Visceral heterotaxy 5	http://www.orpha.net/ORDO/Orphanet_450
-ANIRIDIA	http://www.orpha.net/ORDO/Orphanet_77	http://www.ebi.ac.uk/efo/EFO_0003847
+ANIRIDIA	http://www.orpha.net/ORDO/Orphanet_77
 Deficiency of glycerol kinase	http://www.orpha.net/ORDO/Orphanet_408
 Rubinstein-Taybi syndrome	http://www.orpha.net/ORDO/Orphanet_783
 SHORT SLEEPER	http://purl.obolibrary.org/obo/HP_0000006
 FOCAL SEGMENTAL GLOMERULOSCLEROSIS 2	http://www.orpha.net/ORDO/Orphanet_656
 Marked Hypotonia	http://purl.obolibrary.org/obo/HP_0002515
 IMMUNODEFICIENCY 20	http://www.orpha.net/ORDO/Orphanet_437552
-ACID-LABILE SUBUNIT DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001530	http://purl.obolibrary.org/obo/HP_0045046	http://purl.obolibrary.org/obo/HP_0030353	http://purl.obolibrary.org/obo/HP_0000823	http://purl.obolibrary.org/obo/HP_0008189
+ACID-LABILE SUBUNIT DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001530
 Inclusion body myopathy 2	http://www.ebi.ac.uk/efo/EFO_0007323
-Carcinoid tumor of intestine	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0004243	http://www.ebi.ac.uk/efo/EFO_0000239
-CYLINDROMATOSIS	http://purl.obolibrary.org/obo/HP_0100585	http://purl.obolibrary.org/obo/HP_0008069	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003581
+Carcinoid tumor of intestine	http://www.ebi.ac.uk/efo/EFO_0000311
+CYLINDROMATOSIS	http://purl.obolibrary.org/obo/HP_0100585
 Gluthathione synthetase deficiency	http://www.orpha.net/ORDO/Orphanet_32
 KALLMANN SYNDROME 6	http://www.orpha.net/ORDO/Orphanet_478
 Acrocephalosyndactyly type I	http://www.orpha.net/ORDO/Orphanet_87
 DFNA 2 Nonsyndromic Hearing Loss	http://www.orpha.net/ORDO/Orphanet_90635
 Maple syrup urine disease	http://www.orpha.net/ORDO/Orphanet_511
-SPINOCEREBELLAR ATAXIA 13	http://purl.obolibrary.org/obo/HP_0007256	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002062	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002406	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002073	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0000639
+SPINOCEREBELLAR ATAXIA 13	http://purl.obolibrary.org/obo/HP_0007256
 Growth and mental retardation	http://www.orpha.net/ORDO/Orphanet_79113
 PARKINSON DISEASE 17	http://www.ebi.ac.uk/efo/EFO_0002508
 OVARIAN HYPERSTIMULATION SYNDROME	http://www.orpha.net/ORDO/Orphanet_64739
-ADRENOLEUKODYSTROPHY	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0002180	http://purl.obolibrary.org/obo/HP_0001283	http://purl.obolibrary.org/obo/HP_0002607	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0007018	http://purl.obolibrary.org/obo/HP_0000924	http://purl.obolibrary.org/obo/HP_0000953	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0002839	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000802	http://purl.obolibrary.org/obo/HP_0002371	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0008207	http://purl.obolibrary.org/obo/HP_0000020	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0001271	http://purl.obolibrary.org/obo/HP_0002078	http://purl.obolibrary.org/obo/HP_0000572	http://purl.obolibrary.org/obo/HP_0000709	http://purl.obolibrary.org/obo/HP_0000135	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0002385	http://purl.obolibrary.org/obo/HP_0003455	http://purl.obolibrary.org/obo/HP_0000726	http://purl.obolibrary.org/obo/HP_0001350	http://purl.obolibrary.org/obo/HP_0002500
+ADRENOLEUKODYSTROPHY	http://purl.obolibrary.org/obo/HP_0002070
 TARP syndrome	http://www.orpha.net/ORDO/Orphanet_2886
 Spermatogenic failure 13	http://purl.obolibrary.org/obo/HP_0000027
-Cutis laxa with severe pulmonary	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0002089	http://purl.obolibrary.org/obo/HP_0002021	http://purl.obolibrary.org/obo/HP_0004415	http://purl.obolibrary.org/obo/HP_0001852	http://purl.obolibrary.org/obo/HP_0000278	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0001388	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002780	http://purl.obolibrary.org/obo/HP_0000015	http://purl.obolibrary.org/obo/HP_0000973	http://purl.obolibrary.org/obo/HP_0002779	http://purl.obolibrary.org/obo/HP_0002035	http://purl.obolibrary.org/obo/HP_0001601	http://purl.obolibrary.org/obo/HP_0002097	http://purl.obolibrary.org/obo/HP_0002020	http://purl.obolibrary.org/obo/HP_0040199	http://purl.obolibrary.org/obo/HP_0000126	http://purl.obolibrary.org/obo/HP_0001655	http://purl.obolibrary.org/obo/HP_0000340	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0000023
-Multiple mitochondrial dysfunctions syndrome 1	http://purl.obolibrary.org/obo/HP_0002092	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002878	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001254	http://purl.obolibrary.org/obo/HP_0008972	http://purl.obolibrary.org/obo/HP_0002093
-CARDIOFACIOCUTANEOUS SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_98733	http://www.orpha.net/ORDO/Orphanet_1340
+Cutis laxa with severe pulmonary	http://purl.obolibrary.org/obo/HP_0000272
+Multiple mitochondrial dysfunctions syndrome 1	http://purl.obolibrary.org/obo/HP_0002092
+CARDIOFACIOCUTANEOUS SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_98733
 BESTROPHINOPATHY	http://www.orpha.net/ORDO/Orphanet_139455
-PROSTATE CANCER/BRAIN CANCER SUSCEPTIBILITY	http://purl.obolibrary.org/obo/HP_0012125	http://purl.obolibrary.org/obo/HP_0100006
+PROSTATE CANCER/BRAIN CANCER SUSCEPTIBILITY	http://purl.obolibrary.org/obo/HP_0012125
 Primary autosomal recessive microcephaly 10	http://www.orpha.net/ORDO/Orphanet_2512
 KNIEST DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_485
 Pena-Shokeir syndrome type I	http://www.orpha.net/ORDO/Orphanet_1008
-COMBINED SAPOSIN DEFICIENCY	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0000496	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0004343	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0011813	http://purl.obolibrary.org/obo/HP_0002518	http://purl.obolibrary.org/obo/HP_0011169	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0002529	http://purl.obolibrary.org/obo/HP_0002380	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0002487	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0007305	http://purl.obolibrary.org/obo/HP_0001522	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0004305	http://purl.obolibrary.org/obo/HP_0001433	http://purl.obolibrary.org/obo/HP_0004975
+COMBINED SAPOSIN DEFICIENCY	http://purl.obolibrary.org/obo/HP_0003577
 Sinoatrial node dysfunction and deafness	http://www.orpha.net/ORDO/Orphanet_324321
 Age-related macular degeneration 14	http://www.ebi.ac.uk/efo/EFO_0001365
 Ethylmalonic encephalopathy	http://www.orpha.net/ORDO/Orphanet_51188
-Pilocytic astrocytoma	http://www.ebi.ac.uk/efo/EFO_0003060	http://www.ebi.ac.uk/efo/EFO_0000272
-Anemia	http://purl.obolibrary.org/obo/HP_0001924	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001923	http://purl.obolibrary.org/obo/HP_0006579	http://purl.obolibrary.org/obo/HP_0004814	http://purl.obolibrary.org/obo/HP_0008282
-Combined immunodeficiency	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0005387
+Pilocytic astrocytoma	http://www.ebi.ac.uk/efo/EFO_0003060
+Anemia	http://purl.obolibrary.org/obo/HP_0001924
+Combined immunodeficiency	http://purl.obolibrary.org/obo/HP_0002721
 Lynch syndrome II	http://www.orpha.net/ORDO/Orphanet_144
-Hyperchlorhidrosis	http://purl.obolibrary.org/obo/HP_0002902	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001944	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002153	http://purl.obolibrary.org/obo/HP_0001508
+Hyperchlorhidrosis	http://purl.obolibrary.org/obo/HP_0002902
 RETINITIS PIGMENTOSA 17	http://www.orpha.net/ORDO/Orphanet_791
 HYPEREOSINOPHILIC SYNDROME	http://www.orpha.net/ORDO/Orphanet_168956
-PETERS-PLUS SYNDROME	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0000480	http://purl.obolibrary.org/obo/HP_0000003	http://purl.obolibrary.org/obo/HP_0000612	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0000204	http://purl.obolibrary.org/obo/HP_0004325	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0007833	http://purl.obolibrary.org/obo/HP_0000384	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0100627	http://purl.obolibrary.org/obo/HP_0001642	http://purl.obolibrary.org/obo/HP_0000055	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0000690	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001080	http://purl.obolibrary.org/obo/HP_0000581	http://purl.obolibrary.org/obo/HP_0010049	http://purl.obolibrary.org/obo/HP_0000311	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0000013	http://purl.obolibrary.org/obo/HP_0002219	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0002937	http://purl.obolibrary.org/obo/HP_0001363	http://purl.obolibrary.org/obo/HP_0002983	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0000402	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0001540	http://purl.obolibrary.org/obo/HP_0006887	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0001388	http://purl.obolibrary.org/obo/HP_0000475	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0000260	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002263	http://purl.obolibrary.org/obo/HP_0010743	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001773	http://purl.obolibrary.org/obo/HP_0000233	http://purl.obolibrary.org/obo/HP_0008569	http://purl.obolibrary.org/obo/HP_0004414	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0003278	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0000060	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0004467	http://purl.obolibrary.org/obo/HP_0008726	http://purl.obolibrary.org/obo/HP_0000960	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000126	http://purl.obolibrary.org/obo/HP_0001274	http://purl.obolibrary.org/obo/HP_0005608	http://purl.obolibrary.org/obo/HP_0000069	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0002059	http://purl.obolibrary.org/obo/HP_0000582	http://purl.obolibrary.org/obo/HP_0000008	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000501	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007759	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0006610	http://purl.obolibrary.org/obo/HP_0001831	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0004279	http://purl.obolibrary.org/obo/HP_0000659	http://purl.obolibrary.org/obo/HP_0001770	http://purl.obolibrary.org/obo/HP_0000202	http://purl.obolibrary.org/obo/HP_0000073	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0000465	http://purl.obolibrary.org/obo/HP_0009623	http://purl.obolibrary.org/obo/HP_0000830	http://purl.obolibrary.org/obo/HP_0011065	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0003561	http://purl.obolibrary.org/obo/HP_0003298	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0100819	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0004404	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0100589	http://purl.obolibrary.org/obo/HP_0002996	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000059	http://purl.obolibrary.org/obo/HP_0001159	http://purl.obolibrary.org/obo/HP_0001671	http://purl.obolibrary.org/obo/HP_0008905	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000200	http://purl.obolibrary.org/obo/HP_0000954	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0007370	http://purl.obolibrary.org/obo/HP_0000411	http://purl.obolibrary.org/obo/HP_0008678	http://purl.obolibrary.org/obo/HP_0001561	http://purl.obolibrary.org/obo/HP_0001629
-Immunodeficiency	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0004313	http://purl.obolibrary.org/obo/HP_0001581	http://purl.obolibrary.org/obo/HP_0001878	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0006510	http://purl.obolibrary.org/obo/HP_0005425	http://www.ebi.ac.uk/efo/EFO_0000616
-ATAXIA TELANGIECTASIA-LIKE DISORDER	http://purl.obolibrary.org/obo/HP_0000571	http://purl.obolibrary.org/obo/HP_0002072	http://purl.obolibrary.org/obo/HP_0007772	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000657	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0002075	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002359	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0000640	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0002066
+PETERS-PLUS SYNDROME	http://purl.obolibrary.org/obo/HP_0002120
+Immunodeficiency	http://purl.obolibrary.org/obo/HP_0001596
+ATAXIA TELANGIECTASIA-LIKE DISORDER	http://purl.obolibrary.org/obo/HP_0000571
 ORTHOSTATIC INTOLERANCE	http://www.ebi.ac.uk/efo/EFO_1000645
 HYPOINSULINEMIC HYPOGLYCEMIA AND HEMIHYPERTROPHY	http://www.orpha.net/ORDO/Orphanet_293964
-Coronary artery spasm 2	http://www.ebi.ac.uk/efo/EFO_0000378	http://www.ebi.ac.uk/efo/EFO_1000013	http://www.ebi.ac.uk/efo/EFO_0001645
+Coronary artery spasm 2	http://www.ebi.ac.uk/efo/EFO_0000378
 PARATHYROID CARCINOMA	http://www.ebi.ac.uk/efo/EFO_1000456
 Coloboma	http://purl.obolibrary.org/obo/HP_0000589
 Congenital disorder of glycosylation type 1E	http://www.orpha.net/ORDO/Orphanet_79322
 Neurohypophyseal diabetes insipidus	http://purl.obolibrary.org/obo/HP_0000863
 Dilated cardiomyopathy 1JJ	http://www.ebi.ac.uk/efo/EFO_0000407
 ALPHA-PLUS-THALASSEMIA	http://www.orpha.net/ORDO/Orphanet_846
-LYMPHEDEMA	http://purl.obolibrary.org/obo/HP_0001974	http://purl.obolibrary.org/obo/HP_0000388	http://purl.obolibrary.org/obo/HP_0002863	http://purl.obolibrary.org/obo/HP_0001876	http://purl.obolibrary.org/obo/HP_0002321	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0002170	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0002716	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001182	http://purl.obolibrary.org/obo/HP_0100724	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0000601	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0000980	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001874	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0001824	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002488	http://purl.obolibrary.org/obo/HP_0004370	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002017	http://purl.obolibrary.org/obo/HP_0001004	http://purl.obolibrary.org/obo/HP_0000465	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0100658	http://purl.obolibrary.org/obo/HP_0005528
-BETA-THALASSEMIA	http://www.orpha.net/ORDO/Orphanet_231214	http://www.orpha.net/ORDO/Orphanet_848	http://www.orpha.net/ORDO/Orphanet_846
-IFAP syndrome with or without BRESHECK syndrome	http://purl.obolibrary.org/obo/HP_0000110	http://purl.obolibrary.org/obo/HP_0007502	http://purl.obolibrary.org/obo/HP_0003468	http://purl.obolibrary.org/obo/HP_0000958	http://purl.obolibrary.org/obo/HP_0001539	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000003	http://purl.obolibrary.org/obo/HP_0000612	http://purl.obolibrary.org/obo/HP_0000076	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001231	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0007759	http://purl.obolibrary.org/obo/HP_0002223	http://purl.obolibrary.org/obo/HP_0100533	http://purl.obolibrary.org/obo/HP_0001357	http://purl.obolibrary.org/obo/HP_0000122	http://purl.obolibrary.org/obo/HP_0000444	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000966	http://purl.obolibrary.org/obo/HP_0000483	http://purl.obolibrary.org/obo/HP_0001562	http://purl.obolibrary.org/obo/HP_0000926	http://purl.obolibrary.org/obo/HP_0100825	http://purl.obolibrary.org/obo/HP_0001162	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0100490	http://purl.obolibrary.org/obo/HP_0040189	http://purl.obolibrary.org/obo/HP_0008056	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0000453	http://purl.obolibrary.org/obo/HP_0003422	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0000400	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0007360	http://purl.obolibrary.org/obo/HP_0008404	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0000682	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0005254	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0001019	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0002164	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002542	http://purl.obolibrary.org/obo/HP_0000964	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000613	http://purl.obolibrary.org/obo/HP_0001025	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0000495	http://purl.obolibrary.org/obo/HP_0000968	http://purl.obolibrary.org/obo/HP_0000561	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0002251	http://purl.obolibrary.org/obo/HP_0000772	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0001171	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0008678	http://purl.obolibrary.org/obo/HP_0012444	http://purl.obolibrary.org/obo/HP_0000023	http://purl.obolibrary.org/obo/HP_0002827
-Familial hypertrophic cardiomyopathy 23	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+LYMPHEDEMA	http://purl.obolibrary.org/obo/HP_0001974
+BETA-THALASSEMIA	http://www.orpha.net/ORDO/Orphanet_231214
+IFAP syndrome with or without BRESHECK syndrome	http://purl.obolibrary.org/obo/HP_0000110
+Familial hypertrophic cardiomyopathy 23	http://www.ebi.ac.uk/efo/EFO_0000318
 CATSPER-Related Male Infertility	http://www.ebi.ac.uk/efo/EFO_0000545
 RETINITIS PIGMENTOSA 51	http://www.orpha.net/ORDO/Orphanet_791
-ELLIPTOCYTOSIS 1	http://purl.obolibrary.org/obo/HP_0001878	http://purl.obolibrary.org/obo/HP_0004445	http://purl.obolibrary.org/obo/HP_0000006
+ELLIPTOCYTOSIS 1	http://purl.obolibrary.org/obo/HP_0001878
 PIEBALDISM WITH SENSORINEURAL DEAFNESS	http://www.orpha.net/ORDO/Orphanet_2884
-CROUZON SYNDROME WITH ACANTHOSIS NIGRICANS	http://www.orpha.net/ORDO/Orphanet_1531	http://www.orpha.net/ORDO/Orphanet_93262
-Iron accumulation in brain	http://purl.obolibrary.org/obo/HP_0000712	http://purl.obolibrary.org/obo/HP_0002072	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0002180	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002185	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0002067	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0007772	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0000752	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0002075	http://purl.obolibrary.org/obo/HP_0001268	http://purl.obolibrary.org/obo/HP_0000736	http://purl.obolibrary.org/obo/HP_0012675	http://purl.obolibrary.org/obo/HP_0100710	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001884	http://purl.obolibrary.org/obo/HP_0002059
+CROUZON SYNDROME WITH ACANTHOSIS NIGRICANS	http://www.orpha.net/ORDO/Orphanet_1531
+Iron accumulation in brain	http://purl.obolibrary.org/obo/HP_0000712
 JOUBERT SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_220493
 Progressive intrahepatic cholestasis	http://www.orpha.net/ORDO/Orphanet_172
 Heart disease	http://www.ebi.ac.uk/efo/EFO_0003777
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 4	http://purl.obolibrary.org/obo/HP_0002179	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0001987	http://purl.obolibrary.org/obo/HP_0001522	http://purl.obolibrary.org/obo/HP_0002126	http://purl.obolibrary.org/obo/HP_0001942	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0000639
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 4	http://purl.obolibrary.org/obo/HP_0002179
 Autism 9	http://www.ebi.ac.uk/efo/EFO_0003758
-Single upper central incisor	http://www.orpha.net/ORDO/Orphanet_2162	http://www.orpha.net/ORDO/Orphanet_799	http://www.orpha.net/ORDO/Orphanet_2286
+Single upper central incisor	http://www.orpha.net/ORDO/Orphanet_2162
 Atypical hemolytic-uremic syndrome 2	http://www.orpha.net/ORDO/Orphanet_2134
 3-Methylglutaconic aciduria	http://www.orpha.net/ORDO/Orphanet_289902
 Hyperphosphatasemia with bone disease	http://www.ebi.ac.uk/efo/EFO_0004260
-RIGIDITY AND MULTIFOCAL SEIZURE SYNDROME	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0002123	http://purl.obolibrary.org/obo/HP_0002459	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0002104	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002529	http://purl.obolibrary.org/obo/HP_0003739	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002169	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0002171	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0012448	http://purl.obolibrary.org/obo/HP_0001662	http://purl.obolibrary.org/obo/HP_0003487
+RIGIDITY AND MULTIFOCAL SEIZURE SYNDROME	http://purl.obolibrary.org/obo/HP_0001371
 Holoprosencephaly 1	http://www.orpha.net/ORDO/Orphanet_2162
-WOLMAN DISEASE	http://www.orpha.net/ORDO/Orphanet_75233	http://www.orpha.net/ORDO/Orphanet_275761
-CARDIOFACIOCUTANEOUS SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_500	http://www.orpha.net/ORDO/Orphanet_648	http://www.orpha.net/ORDO/Orphanet_1340
+WOLMAN DISEASE	http://www.orpha.net/ORDO/Orphanet_75233
+CARDIOFACIOCUTANEOUS SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_500
 Breast carcinoma	http://www.ebi.ac.uk/efo/EFO_0000305
 NIJMEGEN BREAKAGE SYNDROME-LIKE DISORDER	http://www.orpha.net/ORDO/Orphanet_240760
-GLYCOGEN STORAGE DISEASE OF HEART	http://purl.obolibrary.org/obo/HP_0001541	http://purl.obolibrary.org/obo/HP_0000158	http://purl.obolibrary.org/obo/HP_0100598	http://purl.obolibrary.org/obo/HP_0001640	http://purl.obolibrary.org/obo/HP_0000961	http://purl.obolibrary.org/obo/HP_0002615	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0005165	http://purl.obolibrary.org/obo/HP_0001998	http://purl.obolibrary.org/obo/HP_0200128	http://purl.obolibrary.org/obo/HP_0001250
+GLYCOGEN STORAGE DISEASE OF HEART	http://purl.obolibrary.org/obo/HP_0001541
 Alcohol dependence	http://www.ebi.ac.uk/efo/EFO_0003829
-Gaucher disease type 3C	http://www.orpha.net/ORDO/Orphanet_77261	http://www.orpha.net/ORDO/Orphanet_355	http://www.orpha.net/ORDO/Orphanet_77259	http://www.orpha.net/ORDO/Orphanet_77260	http://www.orpha.net/ORDO/Orphanet_2072	http://www.orpha.net/ORDO/Orphanet_85212
+Gaucher disease type 3C	http://www.orpha.net/ORDO/Orphanet_77261
 Chronic myeloid leukemia	http://www.ebi.ac.uk/efo/EFO_0000339
 L-2-HYDROXYGLUTARIC ACIDURIA	http://www.orpha.net/ORDO/Orphanet_79314
 GRAY PLATELET SYNDROME	http://www.orpha.net/ORDO/Orphanet_721
 Late-onset retinal degeneration	http://www.orpha.net/ORDO/Orphanet_67042
-SCID due to ADA deficiency	http://www.orpha.net/ORDO/Orphanet_183660	http://www.orpha.net/ORDO/Orphanet_277
-SICK SINUS SYNDROME 1	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001688	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0005155	http://purl.obolibrary.org/obo/HP_0001657	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0011704	http://purl.obolibrary.org/obo/HP_0001678
+SCID due to ADA deficiency	http://www.orpha.net/ORDO/Orphanet_183660
+SICK SINUS SYNDROME 1	http://purl.obolibrary.org/obo/HP_0000007
 Addisons disease	http://www.orpha.net/ORDO/Orphanet_85138
-SPINA BIFIDA	http://www.ebi.ac.uk/efo/EFO_0000378	http://www.ebi.ac.uk/efo/EFO_0003105
+SPINA BIFIDA	http://www.ebi.ac.uk/efo/EFO_0000378
 KABUKI SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_2322
-NIGHT BLINDNESS	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007642
-Cystinosis	http://www.orpha.net/ORDO/Orphanet_213	http://www.orpha.net/ORDO/Orphanet_411634
+NIGHT BLINDNESS	http://purl.obolibrary.org/obo/HP_0000007
+Cystinosis	http://www.orpha.net/ORDO/Orphanet_213
 KALLMANN SYNDROME 5	http://www.orpha.net/ORDO/Orphanet_478
 Uterine leiomyoma	http://www.ebi.ac.uk/efo/EFO_0000731
-3-@METHYLCROTONYL-CoA CARBOXYLASE 2 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0003108	http://purl.obolibrary.org/obo/HP_0001992	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001051	http://purl.obolibrary.org/obo/HP_0003353	http://purl.obolibrary.org/obo/HP_0001993	http://purl.obolibrary.org/obo/HP_0003202
+3-@METHYLCROTONYL-CoA CARBOXYLASE 2 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0003108
 Hyper-IgE syndrome	http://www.ebi.ac.uk/efo/EFO_0003775
-Niemann-Pick disease	http://www.orpha.net/ORDO/Orphanet_77293	http://www.orpha.net/ORDO/Orphanet_77292
+Niemann-Pick disease	http://www.orpha.net/ORDO/Orphanet_77293
 Emery-dreifuss muscular dystrophy 5	http://www.orpha.net/ORDO/Orphanet_261
 Age-related macular degeneration 8	http://www.ebi.ac.uk/efo/EFO_0001365
 Familial partial lipodystrophy 5	http://www.orpha.net/ORDO/Orphanet_98306
 Secondary hypothyroidism	http://www.orpha.net/ORDO/Orphanet_226298
-Sex cord-stromal tumor	http://www.ebi.ac.uk/efo/EFO_0007483	http://www.ebi.ac.uk/efo/EFO_1000052	http://www.ebi.ac.uk/efo/EFO_0000232
+Sex cord-stromal tumor	http://www.ebi.ac.uk/efo/EFO_0007483
 Familial hemiplegic migraine type 2	http://www.ebi.ac.uk/efo/EFO_0003821
-GAUCHER DISEASE	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0011813	http://purl.obolibrary.org/obo/HP_0001433	http://purl.obolibrary.org/obo/HP_0004975
+GAUCHER DISEASE	http://purl.obolibrary.org/obo/HP_0000007
 TRIGONOCEPHALY 2	http://www.orpha.net/ORDO/Orphanet_3366
-Hereditary cancer-predisposing syndrome	http://www.ebi.ac.uk/efo/EFO_0005406	http://www.ebi.ac.uk/efo/EFO_0000389	http://www.ebi.ac.uk/efo/EFO_1000560	http://www.ebi.ac.uk/efo/EFO_0000206	http://www.ebi.ac.uk/efo/EFO_1000044	http://www.ebi.ac.uk/efo/EFO_0001663	http://www.ebi.ac.uk/efo/EFO_0002618	http://www.ebi.ac.uk/efo/EFO_0000239	http://www.ebi.ac.uk/efo/EFO_0002918	http://www.ebi.ac.uk/efo/EFO_0000305	http://www.ebi.ac.uk/efo/EFO_0000182	http://www.ebi.ac.uk/efo/EFO_0001075	http://www.ebi.ac.uk/efo/EFO_0000304	http://www.ebi.ac.uk/efo/EFO_0000673	http://www.ebi.ac.uk/efo/EFO_0000249	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0002892	http://www.ebi.ac.uk/efo/EFO_0000637	http://www.ebi.ac.uk/efo/EFO_0006318	http://www.ebi.ac.uk/efo/EFO_0000681	http://www.ebi.ac.uk/efo/EFO_0000691	http://www.ebi.ac.uk/efo/EFO_0000430	http://www.ebi.ac.uk/efo/EFO_0007354	http://www.ebi.ac.uk/efo/EFO_0000205	http://www.ebi.ac.uk/efo/EFO_0005842	http://www.ebi.ac.uk/efo/EFO_0004243	http://www.ebi.ac.uk/efo/EFO_0000365	http://www.ebi.ac.uk/efo/EFO_0000616
+Hereditary cancer-predisposing syndrome	http://www.ebi.ac.uk/efo/EFO_0005406
 Amyotrophic lateral sclerosis type 4	http://www.orpha.net/ORDO/Orphanet_357043
-Hypertrichotic osteochondrodysplasia	http://purl.obolibrary.org/obo/HP_0010109	http://purl.obolibrary.org/obo/HP_0000527	http://purl.obolibrary.org/obo/HP_0005129	http://purl.obolibrary.org/obo/HP_0006101	http://purl.obolibrary.org/obo/HP_0001841	http://purl.obolibrary.org/obo/HP_0001640	http://purl.obolibrary.org/obo/HP_0004349	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0001698	http://purl.obolibrary.org/obo/HP_0001647	http://purl.obolibrary.org/obo/HP_0000336	http://purl.obolibrary.org/obo/HP_0000774	http://purl.obolibrary.org/obo/HP_0002162	http://purl.obolibrary.org/obo/HP_0003043	http://purl.obolibrary.org/obo/HP_0001654	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0005616	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0000998	http://purl.obolibrary.org/obo/HP_0000212	http://purl.obolibrary.org/obo/HP_0003300	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002652	http://purl.obolibrary.org/obo/HP_0010068	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0000926	http://purl.obolibrary.org/obo/HP_0001869	http://purl.obolibrary.org/obo/HP_0001004	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0000280	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0003272	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0007665	http://purl.obolibrary.org/obo/HP_0000215	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0010055	http://purl.obolibrary.org/obo/HP_0004540	http://purl.obolibrary.org/obo/HP_0004634	http://purl.obolibrary.org/obo/HP_0009882	http://purl.obolibrary.org/obo/HP_0001520	http://purl.obolibrary.org/obo/HP_0000944	http://purl.obolibrary.org/obo/HP_0008822	http://purl.obolibrary.org/obo/HP_0002690	http://purl.obolibrary.org/obo/HP_0004975	http://purl.obolibrary.org/obo/HP_0003016	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0000574	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000294	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0000179	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0000772	http://purl.obolibrary.org/obo/HP_0002673	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0005445
+Hypertrichotic osteochondrodysplasia	http://purl.obolibrary.org/obo/HP_0010109
 JOUBERT SYNDROME 18	http://www.orpha.net/ORDO/Orphanet_475
 Brown-Vialetto-Van laere syndrome	http://www.orpha.net/ORDO/Orphanet_97229
 BRUGADA SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_130
@@ -2090,72 +2090,72 @@ OPTIC ATROPHY 7	http://purl.obolibrary.org/obo/HP_0000648
 Paroxysmal choreoathetosis	http://www.orpha.net/ORDO/Orphanet_1431
 FRONTOTEMPORAL DEMENTIA WITH TDP43 INCLUSIONS	http://www.orpha.net/ORDO/Orphanet_275872
 Ochoa syndrome	http://www.orpha.net/ORDO/Orphanet_2704
-TELANGIECTASIA	http://purl.obolibrary.org/obo/HP_0004406	http://www.orpha.net/ORDO/Orphanet_774	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0001409	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001009
-BIRK-BAREL MENTAL RETARDATION DYSMORPHISM SYNDROME	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0011229	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000341	http://purl.obolibrary.org/obo/HP_0000574	http://purl.obolibrary.org/obo/HP_0000322	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0002553	http://purl.obolibrary.org/obo/HP_0011819	http://purl.obolibrary.org/obo/HP_0000960	http://purl.obolibrary.org/obo/HP_0001249
+TELANGIECTASIA	http://purl.obolibrary.org/obo/HP_0004406
+BIRK-BAREL MENTAL RETARDATION DYSMORPHISM SYNDROME	http://purl.obolibrary.org/obo/HP_0008872
 Diabetes mellitus AND insipidus with optic atrophy AND deafness	http://www.orpha.net/ORDO/Orphanet_3463
 congenital neutropenia	http://purl.obolibrary.org/obo/HP_0005549
-MYOPIA	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001132	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0000541	http://purl.obolibrary.org/obo/HP_0200071	http://purl.obolibrary.org/obo/HP_0011003
+MYOPIA	http://purl.obolibrary.org/obo/HP_0000007
 PARKINSON DISEASE 22	http://www.ebi.ac.uk/efo/EFO_0002508
 Abetalipoproteinaemia	http://www.orpha.net/ORDO/Orphanet_14
 Urocanate hydratase deficiency	http://www.orpha.net/ORDO/Orphanet_210128
-Partial hypoxanthine-guanine phosphoribosyltransferase deficiency	http://www.orpha.net/ORDO/Orphanet_510	http://www.orpha.net/ORDO/Orphanet_79233
-TRICHODENTOOSSEOUS SYNDROME	http://purl.obolibrary.org/obo/HP_0011073	http://purl.obolibrary.org/obo/HP_0000682	http://purl.obolibrary.org/obo/HP_0000264	http://purl.obolibrary.org/obo/HP_0002997	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0004493	http://purl.obolibrary.org/obo/HP_0006501	http://purl.obolibrary.org/obo/HP_0000311	http://purl.obolibrary.org/obo/HP_0010620	http://purl.obolibrary.org/obo/HP_0001231	http://purl.obolibrary.org/obo/HP_0000691	http://purl.obolibrary.org/obo/HP_0000687	http://purl.obolibrary.org/obo/HP_0000670	http://purl.obolibrary.org/obo/HP_0000684	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0000679	http://purl.obolibrary.org/obo/HP_0002687	http://purl.obolibrary.org/obo/HP_0002224	http://purl.obolibrary.org/obo/HP_0001808	http://purl.obolibrary.org/obo/HP_0011001	http://purl.obolibrary.org/obo/HP_0000268	http://purl.obolibrary.org/obo/HP_0001595	http://purl.obolibrary.org/obo/HP_0002007
+Partial hypoxanthine-guanine phosphoribosyltransferase deficiency	http://www.orpha.net/ORDO/Orphanet_510
+TRICHODENTOOSSEOUS SYNDROME	http://purl.obolibrary.org/obo/HP_0011073
 LONG QT SYNDROME 11	http://purl.obolibrary.org/obo/HP_0001657
-Colorectal adenoma	http://www.ebi.ac.uk/efo/EFO_0005406	http://www.ebi.ac.uk/efo/EFO_0000311
-HYPOGONADOTROPIC HYPOGONADISM 12 WITH OR WITHOUT ANOSMIA	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000044	http://purl.obolibrary.org/obo/HP_0000458	http://purl.obolibrary.org/obo/HP_0000786	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000823	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0008734
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 25	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000768	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0000824	http://purl.obolibrary.org/obo/HP_0002059
+Colorectal adenoma	http://www.ebi.ac.uk/efo/EFO_0005406
+HYPOGONADOTROPIC HYPOGONADISM 12 WITH OR WITHOUT ANOSMIA	http://purl.obolibrary.org/obo/HP_0000028
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 25	http://purl.obolibrary.org/obo/HP_0001252
 Mental retardation 58	http://www.ebi.ac.uk/efo/EFO_0003847
 Carnevale syndrome	http://www.orpha.net/ORDO/Orphanet_293843
 Premature ovarian failure 7	http://www.ebi.ac.uk/efo/EFO_0004266
-Spastic paraplegia 72	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002839	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002064	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0003552
+Spastic paraplegia 72	http://purl.obolibrary.org/obo/HP_0001347
 Ghosal hematodiaphyseal syndrome	http://www.orpha.net/ORDO/Orphanet_1802
-CATARACT	http://purl.obolibrary.org/obo/HP_0001104	http://purl.obolibrary.org/obo/HP_0000646	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0007780	http://purl.obolibrary.org/obo/HP_0008024	http://purl.obolibrary.org/obo/HP_0000612	http://purl.obolibrary.org/obo/HP_0000541	http://purl.obolibrary.org/obo/HP_0007834	http://purl.obolibrary.org/obo/HP_0000501	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007976	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0007787	http://www.ebi.ac.uk/efo/EFO_0001059	http://purl.obolibrary.org/obo/HP_0000519	http://purl.obolibrary.org/obo/HP_0000613	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0100018
+CATARACT	http://purl.obolibrary.org/obo/HP_0001104
 BURN-MCKEOWN SYNDROME	http://www.orpha.net/ORDO/Orphanet_1200
-Pseudoneonatal adrenoleukodystrophy	http://purl.obolibrary.org/obo/HP_0008763	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000737	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0010864	http://purl.obolibrary.org/obo/HP_0000654	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0011344	http://purl.obolibrary.org/obo/HP_0008619	http://purl.obolibrary.org/obo/HP_0001161	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0000547	http://purl.obolibrary.org/obo/HP_0003186	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0006887	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0002415	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0000649	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000580	http://purl.obolibrary.org/obo/HP_0006555	http://purl.obolibrary.org/obo/HP_0000512	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0002011	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0007305
-OSTEOPATHIA STRIATA WITH CRANIAL SCLEROSIS	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0001539	http://purl.obolibrary.org/obo/HP_0000341	http://purl.obolibrary.org/obo/HP_0000003	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0001611	http://purl.obolibrary.org/obo/HP_0000204	http://purl.obolibrary.org/obo/HP_0002023	http://purl.obolibrary.org/obo/HP_0000678	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0006610	http://purl.obolibrary.org/obo/HP_0000689	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0005464	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0010740	http://purl.obolibrary.org/obo/HP_0001562	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0001555	http://purl.obolibrary.org/obo/HP_0001338	http://purl.obolibrary.org/obo/HP_0000193	http://purl.obolibrary.org/obo/HP_0005950	http://purl.obolibrary.org/obo/HP_0000465	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0000239	http://purl.obolibrary.org/obo/HP_0002315	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0000885	http://purl.obolibrary.org/obo/HP_0001476	http://purl.obolibrary.org/obo/HP_0002694	http://purl.obolibrary.org/obo/HP_0008551	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0001423	http://purl.obolibrary.org/obo/HP_0001679	http://purl.obolibrary.org/obo/HP_0006587	http://purl.obolibrary.org/obo/HP_0012385	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000201	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0003298	http://purl.obolibrary.org/obo/HP_0001166	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0000695	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0100670	http://purl.obolibrary.org/obo/HP_0002644	http://purl.obolibrary.org/obo/HP_0000684	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003038	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0006784	http://purl.obolibrary.org/obo/HP_0005830	http://purl.obolibrary.org/obo/HP_0002684	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0002025	http://purl.obolibrary.org/obo/HP_0002779	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0002514	http://purl.obolibrary.org/obo/HP_0005619	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0002990	http://purl.obolibrary.org/obo/HP_0004493	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0002020	http://purl.obolibrary.org/obo/HP_0000396	http://purl.obolibrary.org/obo/HP_0002104	http://purl.obolibrary.org/obo/HP_0000179	http://purl.obolibrary.org/obo/HP_0002566	http://purl.obolibrary.org/obo/HP_0003307	http://purl.obolibrary.org/obo/HP_0009473	http://purl.obolibrary.org/obo/HP_0010628	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0001561	http://purl.obolibrary.org/obo/HP_0001629
-ROBINOW SYNDROME	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0001852	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000348	http://purl.obolibrary.org/obo/HP_0000696	http://purl.obolibrary.org/obo/HP_0002714	http://purl.obolibrary.org/obo/HP_0001636	http://purl.obolibrary.org/obo/HP_0000003	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0009804	http://purl.obolibrary.org/obo/HP_0001231	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000678	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0000055	http://purl.obolibrary.org/obo/HP_0005914	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0004590	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0000212	http://purl.obolibrary.org/obo/HP_0000637	http://purl.obolibrary.org/obo/HP_0000921	http://purl.obolibrary.org/obo/HP_0009466	http://purl.obolibrary.org/obo/HP_0000768	http://purl.obolibrary.org/obo/HP_0003042	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0002983	http://purl.obolibrary.org/obo/HP_0100490	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0001641	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0000388	http://purl.obolibrary.org/obo/HP_0009602	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0001679	http://purl.obolibrary.org/obo/HP_0004397	http://purl.obolibrary.org/obo/HP_0011304	http://purl.obolibrary.org/obo/HP_0002948	http://purl.obolibrary.org/obo/HP_0003272	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000158	http://purl.obolibrary.org/obo/HP_0009883	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0009882	http://purl.obolibrary.org/obo/HP_0000260	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0002164	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0002263	http://purl.obolibrary.org/obo/HP_0000322	http://purl.obolibrary.org/obo/HP_0011069	http://purl.obolibrary.org/obo/HP_0001702	http://purl.obolibrary.org/obo/HP_0012368	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0000060	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000960	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000126	http://purl.obolibrary.org/obo/HP_0000075	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0010297	http://purl.obolibrary.org/obo/HP_0011001	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0000023	http://purl.obolibrary.org/obo/HP_0010292	http://purl.obolibrary.org/obo/HP_0001853	http://purl.obolibrary.org/obo/HP_0000582	http://purl.obolibrary.org/obo/HP_0000527	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0005048	http://purl.obolibrary.org/obo/HP_0006101	http://purl.obolibrary.org/obo/HP_0001841	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0006482	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0000689	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0000902	http://purl.obolibrary.org/obo/HP_0004279	http://purl.obolibrary.org/obo/HP_0010296	http://purl.obolibrary.org/obo/HP_0004220	http://purl.obolibrary.org/obo/HP_0001705	http://purl.obolibrary.org/obo/HP_0001770	http://purl.obolibrary.org/obo/HP_0000202	http://purl.obolibrary.org/obo/HP_0000207	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0000499	http://purl.obolibrary.org/obo/HP_0003422	http://purl.obolibrary.org/obo/HP_0003027	http://purl.obolibrary.org/obo/HP_0000278	http://purl.obolibrary.org/obo/HP_0200055	http://purl.obolibrary.org/obo/HP_0000270	http://purl.obolibrary.org/obo/HP_0008736	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0010804	http://purl.obolibrary.org/obo/HP_0001837	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0030084	http://purl.obolibrary.org/obo/HP_0002684	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0000059	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0002944	http://purl.obolibrary.org/obo/HP_0008467	http://purl.obolibrary.org/obo/HP_0000954	http://purl.obolibrary.org/obo/HP_0000592	http://purl.obolibrary.org/obo/HP_0000772	http://purl.obolibrary.org/obo/HP_0000174	http://purl.obolibrary.org/obo/HP_0001052	http://purl.obolibrary.org/obo/HP_0001171	http://purl.obolibrary.org/obo/HP_0001629
-JOUBERT SYNDROME 6	http://www.orpha.net/ORDO/Orphanet_475	http://www.orpha.net/ORDO/Orphanet_1454	http://www.orpha.net/ORDO/Orphanet_564
+Pseudoneonatal adrenoleukodystrophy	http://purl.obolibrary.org/obo/HP_0008763
+OSTEOPATHIA STRIATA WITH CRANIAL SCLEROSIS	http://purl.obolibrary.org/obo/HP_0000272
+ROBINOW SYNDROME	http://purl.obolibrary.org/obo/HP_0000272
+JOUBERT SYNDROME 6	http://www.orpha.net/ORDO/Orphanet_475
 HYPERLYSINEMIA	http://www.orpha.net/ORDO/Orphanet_2203
 CRANIOECTODERMAL DYSPLASIA 1	http://www.orpha.net/ORDO/Orphanet_1515
 Atypical hemolytic-uremic syndrome 4	http://www.orpha.net/ORDO/Orphanet_2134
 Leydig cell hypoplasia	http://www.orpha.net/ORDO/Orphanet_755
 Progressive familial intrahepatic cholestasis 2	http://www.orpha.net/ORDO/Orphanet_172
-LARSEN SYNDROME	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0001799	http://purl.obolibrary.org/obo/HP_0006101	http://purl.obolibrary.org/obo/HP_0000204	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0001772	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0006067	http://purl.obolibrary.org/obo/HP_0004976	http://purl.obolibrary.org/obo/HP_0005930	http://purl.obolibrary.org/obo/HP_0004232	http://purl.obolibrary.org/obo/HP_0001382	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0002777	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0000768	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001601	http://purl.obolibrary.org/obo/HP_0003042	http://purl.obolibrary.org/obo/HP_0010049	http://purl.obolibrary.org/obo/HP_0002176	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0001363	http://purl.obolibrary.org/obo/HP_0001222	http://purl.obolibrary.org/obo/HP_0003422	http://purl.obolibrary.org/obo/HP_0009602	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0001388	http://purl.obolibrary.org/obo/HP_0001629	http://purl.obolibrary.org/obo/HP_0003298	http://purl.obolibrary.org/obo/HP_0004568	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0001166	http://purl.obolibrary.org/obo/HP_0002780	http://purl.obolibrary.org/obo/HP_0010743	http://purl.obolibrary.org/obo/HP_0001798	http://purl.obolibrary.org/obo/HP_0001626	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003304	http://purl.obolibrary.org/obo/HP_0000668	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0002779	http://purl.obolibrary.org/obo/HP_0012368	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0002947	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0008127	http://purl.obolibrary.org/obo/HP_0008434	http://purl.obolibrary.org/obo/HP_0003994	http://purl.obolibrary.org/obo/HP_0000586	http://purl.obolibrary.org/obo/HP_0007957	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0003019	http://purl.obolibrary.org/obo/HP_0002827	http://purl.obolibrary.org/obo/HP_0001724
+LARSEN SYNDROME	http://purl.obolibrary.org/obo/HP_0000272
 Orofaciodigital syndrome 5	http://www.orpha.net/ORDO/Orphanet_140997
 MULTIPLE FIBROADENOMAS OF THE BREAST	http://purl.obolibrary.org/obo/HP_0000006
 HEMOPHILIA B(M)	http://www.orpha.net/ORDO/Orphanet_98879
-BETA-THALASSEMIA INTERMEDIA	http://www.orpha.net/ORDO/Orphanet_231222	http://www.orpha.net/ORDO/Orphanet_848
+BETA-THALASSEMIA INTERMEDIA	http://www.orpha.net/ORDO/Orphanet_231222
 Congenital microvillous atrophy	http://www.orpha.net/ORDO/Orphanet_2290
 Pigmentary pallidal degeneration	http://www.orpha.net/ORDO/Orphanet_157850
 MIRROR MOVEMENTS 3	http://purl.obolibrary.org/obo/HP_0001335
-Histiocytic medullary reticulosis	http://www.orpha.net/ORDO/Orphanet_39041	http://www.orpha.net/ORDO/Orphanet_183660
+Histiocytic medullary reticulosis	http://www.orpha.net/ORDO/Orphanet_39041
 Generalized dominant dystrophic epidermolysis bullosa	http://www.orpha.net/ORDO/Orphanet_231568
-CASPASE 8 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002716	http://purl.obolibrary.org/obo/HP_0002090	http://purl.obolibrary.org/obo/HP_0005419	http://purl.obolibrary.org/obo/HP_0005384	http://purl.obolibrary.org/obo/HP_0002028	http://purl.obolibrary.org/obo/HP_0000964	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0002099	http://purl.obolibrary.org/obo/HP_0005425	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001744
+CASPASE 8 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
 GNATHODIAPHYSEAL DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_53697
-Hydroxykynureninuria	http://purl.obolibrary.org/obo/HP_0003011	http://purl.obolibrary.org/obo/HP_0003355	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007030	http://purl.obolibrary.org/obo/HP_0001649	http://purl.obolibrary.org/obo/HP_0002086	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000124	http://purl.obolibrary.org/obo/HP_0001259	http://purl.obolibrary.org/obo/HP_0001942	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0002615
-ACHROMATOPSIA 3	http://www.orpha.net/ORDO/Orphanet_827	http://www.orpha.net/ORDO/Orphanet_49382
+Hydroxykynureninuria	http://purl.obolibrary.org/obo/HP_0003011
+ACHROMATOPSIA 3	http://www.orpha.net/ORDO/Orphanet_827
 INTRINSIC FACTOR DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_332
-Colorectal cancer 10	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0005842
+Colorectal cancer 10	http://www.ebi.ac.uk/efo/EFO_0000311
 PITT-HOPKINS SYNDROME	http://www.orpha.net/ORDO/Orphanet_2896
 RETINITIS PIGMENTOSA 54	http://www.orpha.net/ORDO/Orphanet_791
 Oculofaciocardiodental syndrome	http://www.orpha.net/ORDO/Orphanet_2712
 THROMBOCYTOPENIA	http://www.ebi.ac.uk/efo/EFO_0004272
-Pontocerebellar hypoplasia	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0000527	http://purl.obolibrary.org/obo/HP_0002510	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000817	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0000565	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001298	http://purl.obolibrary.org/obo/HP_0000737	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0002179	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0002169	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000430	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000637	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0100704	http://purl.obolibrary.org/obo/HP_0009879	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002553	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0012448	http://purl.obolibrary.org/obo/HP_0002059
+Pontocerebellar hypoplasia	http://purl.obolibrary.org/obo/HP_0001371
 INFECTIONS	http://purl.obolibrary.org/obo/HP_0002719
-Familial hypertrophic cardiomyopathy 14	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
-BILE ACID SYNTHESIS DEFECT	http://purl.obolibrary.org/obo/HP_0003256	http://purl.obolibrary.org/obo/HP_0001928	http://purl.obolibrary.org/obo/HP_0000662	http://purl.obolibrary.org/obo/HP_0009830	http://purl.obolibrary.org/obo/HP_0003155	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0004349	http://purl.obolibrary.org/obo/HP_0001394	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003146	http://purl.obolibrary.org/obo/HP_0002630	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0100626	http://purl.obolibrary.org/obo/HP_0002239	http://purl.obolibrary.org/obo/HP_0000989	http://purl.obolibrary.org/obo/HP_0001399	http://purl.obolibrary.org/obo/HP_0002570	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0001406	http://purl.obolibrary.org/obo/HP_0000952	http://purl.obolibrary.org/obo/HP_0011985	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0200084	http://purl.obolibrary.org/obo/HP_0002904	http://purl.obolibrary.org/obo/HP_0002024	http://purl.obolibrary.org/obo/HP_0003623	http://purl.obolibrary.org/obo/HP_0006579
+Familial hypertrophic cardiomyopathy 14	http://www.ebi.ac.uk/efo/EFO_0000318
+BILE ACID SYNTHESIS DEFECT	http://purl.obolibrary.org/obo/HP_0003256
 VENTRICULAR SEPTAL DEFECT 1	http://www.orpha.net/ORDO/Orphanet_1480
 Familial X-linked hypophosphatemic vitamin D refractory rickets	http://www.orpha.net/ORDO/Orphanet_89936
-Familial hypertrophic cardiomyopathy 2	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+Familial hypertrophic cardiomyopathy 2	http://www.ebi.ac.uk/efo/EFO_0000407
 POLYCYSTIC LIPOMEMBRANOUS OSTEODYSPLASIA WITH SCLEROSING LEUKOENCEPHALOPATHY;	http://www.orpha.net/ORDO/Orphanet_2770
 HYPERBILIVERDINEMIA	http://www.orpha.net/ORDO/Orphanet_276405
 Deficiency of isobutyryl-CoA dehydrogenase	http://www.orpha.net/ORDO/Orphanet_79159
 Complement component 7 deficiency	http://www.orpha.net/ORDO/Orphanet_169150
 Myoclonus with epilepsy with ragged red fibers	http://www.ebi.ac.uk/efo/EFO_0000474
 CORTICAL DYSPLASIA-FOCAL EPILEPSY SYNDROME	http://www.orpha.net/ORDO/Orphanet_163681
-Encephalopathy	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0007256	http://purl.obolibrary.org/obo/HP_0002273	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000752	http://purl.obolibrary.org/obo/HP_0001298	http://purl.obolibrary.org/obo/HP_0001268	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002155	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0002529	http://purl.obolibrary.org/obo/HP_0001332	http://www.orpha.net/ORDO/Orphanet_409944	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002371	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0002059
+Encephalopathy	http://purl.obolibrary.org/obo/HP_0001347
 Neuroblastoma 1	http://www.ebi.ac.uk/efo/EFO_0000621
-HYPERPHOSPHATASIA WITH MENTAL RETARDATION SYNDROME 3	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0002905	http://purl.obolibrary.org/obo/HP_0010864	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003155	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0002059
+HYPERPHOSPHATASIA WITH MENTAL RETARDATION SYNDROME 3	http://purl.obolibrary.org/obo/HP_0000007
 Leiner disease	http://www.orpha.net/ORDO/Orphanet_314
 Deficiency of transaldolase	http://www.orpha.net/ORDO/Orphanet_101028
 ALAGILLE SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_52
@@ -2163,19 +2163,19 @@ Multiple epiphyseal dysplasia 6	http://www.orpha.net/ORDO/Orphanet_251
 Greenberg dysplasia	http://www.orpha.net/ORDO/Orphanet_1426
 FRONTOMETAPHYSEAL DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_1826
 Pfeiffer syndrome variant	http://www.orpha.net/ORDO/Orphanet_710
-CD8 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0005422	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0004429	http://purl.obolibrary.org/obo/HP_0002110	http://purl.obolibrary.org/obo/HP_0002718
-Drash syndrome	http://www.orpha.net/ORDO/Orphanet_220	http://www.orpha.net/ORDO/Orphanet_347	http://www.orpha.net/ORDO/Orphanet_654
+CD8 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
+Drash syndrome	http://www.orpha.net/ORDO/Orphanet_220
 Gonadotropin-independent familial sexual precocity	http://www.orpha.net/ORDO/Orphanet_3000
 Sepiapterin reductase deficiency	http://www.orpha.net/ORDO/Orphanet_70594
 BIETTI CRYSTALLINE CORNEORETINAL DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_41751
 Schnyder crystalline corneal dystrophy	http://www.orpha.net/ORDO/Orphanet_98967
-Reifenstein syndrome	http://purl.obolibrary.org/obo/HP_0000789	http://purl.obolibrary.org/obo/HP_0000008	http://purl.obolibrary.org/obo/HP_0000771	http://purl.obolibrary.org/obo/HP_0010788	http://purl.obolibrary.org/obo/HP_0000144	http://purl.obolibrary.org/obo/HP_0008736	http://purl.obolibrary.org/obo/HP_0000135	http://purl.obolibrary.org/obo/HP_0012873	http://purl.obolibrary.org/obo/HP_0004349	http://purl.obolibrary.org/obo/HP_0000037	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0010458	http://purl.obolibrary.org/obo/HP_0001547	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0100627	http://purl.obolibrary.org/obo/HP_0000048	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0000027
-Age-related macular degeneration 4	http://www.ebi.ac.uk/efo/EFO_0001365	http://www.ebi.ac.uk/efo/EFO_1001155
-BJORNSTAD SYNDROME WITH MILD MITOCHONDRIAL COMPLEX III DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_68380	http://www.orpha.net/ORDO/Orphanet_123
+Reifenstein syndrome	http://purl.obolibrary.org/obo/HP_0000789
+Age-related macular degeneration 4	http://www.ebi.ac.uk/efo/EFO_0001365
+BJORNSTAD SYNDROME WITH MILD MITOCHONDRIAL COMPLEX III DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_68380
 IMMUNODEFICIENCY 42	http://purl.obolibrary.org/obo/HP_0002721
 spino-cellular carcinoma	http://purl.obolibrary.org/obo/HP_0001596
-POLYMICROGYRIA WITH SEIZURES	http://www.orpha.net/ORDO/Orphanet_268940	http://www.orpha.net/ORDO/Orphanet_208447
-PROTEINURIA	http://purl.obolibrary.org/obo/HP_0000097	http://purl.obolibrary.org/obo/HP_0000114	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0003126	http://purl.obolibrary.org/obo/HP_0000092	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0002148	http://purl.obolibrary.org/obo/HP_0003355	http://purl.obolibrary.org/obo/HP_0002907	http://purl.obolibrary.org/obo/HP_0000121	http://purl.obolibrary.org/obo/HP_0002150	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003076
+POLYMICROGYRIA WITH SEIZURES	http://www.orpha.net/ORDO/Orphanet_268940
+PROTEINURIA	http://purl.obolibrary.org/obo/HP_0000097
 ALPHA/BETA T-CELL LYMPHOPENIA WITH GAMMA/DELTA T-CELL EXPANSION	http://www.orpha.net/ORDO/Orphanet_231154
 LIMB-MAMMARY SYNDROME	http://www.orpha.net/ORDO/Orphanet_69085
 GASTROINTESTINAL STROMAL TUMOR	http://www.orpha.net/ORDO/Orphanet_44890
@@ -2186,30 +2186,30 @@ Osteogenesis imperfecta type 15	http://www.orpha.net/ORDO/Orphanet_666
 NEURODEGENERATION WITH BRAIN IRON ACCUMULATION 1	http://www.orpha.net/ORDO/Orphanet_385
 Allergic rhinitis	http://www.ebi.ac.uk/efo/EFO_0005854
 Glaucoma 3	http://www.ebi.ac.uk/efo/EFO_0000516
-ASPHYXIATING THORACIC DYSTROPHY 4	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000546	http://purl.obolibrary.org/obo/HP_0000774	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003026	http://purl.obolibrary.org/obo/HP_0000773
-CRIGLER-NAJJAR SYNDROME	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000952	http://purl.obolibrary.org/obo/HP_0008282	http://purl.obolibrary.org/obo/HP_0001392
+ASPHYXIATING THORACIC DYSTROPHY 4	http://purl.obolibrary.org/obo/HP_0000007
+CRIGLER-NAJJAR SYNDROME	http://purl.obolibrary.org/obo/HP_0000007
 Congenital disorder of glycosylation type 2L	http://www.orpha.net/ORDO/Orphanet_137
 Cardiac arrest	http://purl.obolibrary.org/obo/HP_0001695
 Hyphidrosis	http://purl.obolibrary.org/obo/HP_0001249
 BRUGADA SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_130
 Progressive familial intrahepatic cholestasis 3	http://www.orpha.net/ORDO/Orphanet_172
-THREE M SYNDROME 1	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0010306	http://purl.obolibrary.org/obo/HP_0002643	http://purl.obolibrary.org/obo/HP_0003298	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0003100	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0001382	http://purl.obolibrary.org/obo/HP_0008734	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0000773	http://purl.obolibrary.org/obo/HP_0000268	http://purl.obolibrary.org/obo/HP_0009237	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0000307	http://purl.obolibrary.org/obo/HP_0000574	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000179	http://purl.obolibrary.org/obo/HP_0004570	http://purl.obolibrary.org/obo/HP_0003691	http://purl.obolibrary.org/obo/HP_0008839	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0003307	http://purl.obolibrary.org/obo/HP_0000325	http://purl.obolibrary.org/obo/HP_0002827
+THREE M SYNDROME 1	http://purl.obolibrary.org/obo/HP_0000272
 Septo-optic dysplasia sequence	http://www.orpha.net/ORDO/Orphanet_3157
 Hereditary nonpolyposis colorectal cancer type 5	http://www.orpha.net/ORDO/Orphanet_144
-ANGELMAN SYNDROME	http://www.orpha.net/ORDO/Orphanet_72	http://www.orpha.net/ORDO/Orphanet_3077	http://www.orpha.net/ORDO/Orphanet_209370	http://www.orpha.net/ORDO/Orphanet_409944	http://www.orpha.net/ORDO/Orphanet_778
-SPONDYLOCHEIRODYSPLASIA	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0010489	http://purl.obolibrary.org/obo/HP_0100864	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0001388	http://purl.obolibrary.org/obo/HP_0004349	http://purl.obolibrary.org/obo/HP_0003301	http://purl.obolibrary.org/obo/HP_0000974	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000963	http://purl.obolibrary.org/obo/HP_0009803	http://purl.obolibrary.org/obo/HP_0000944	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0000684	http://purl.obolibrary.org/obo/HP_0001182	http://purl.obolibrary.org/obo/HP_0003393	http://purl.obolibrary.org/obo/HP_0000689	http://purl.obolibrary.org/obo/HP_0003370	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0005930	http://purl.obolibrary.org/obo/HP_0000668	http://purl.obolibrary.org/obo/HP_0006429	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0003016	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0002652	http://purl.obolibrary.org/obo/HP_0010049	http://purl.obolibrary.org/obo/HP_0000926	http://purl.obolibrary.org/obo/HP_0001073	http://purl.obolibrary.org/obo/HP_0008848	http://purl.obolibrary.org/obo/HP_0000592	http://purl.obolibrary.org/obo/HP_0000193	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0100490	http://purl.obolibrary.org/obo/HP_0002515
-HYPERMETHIONINEMIA DUE TO ADENOSINE KINASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001680	http://purl.obolibrary.org/obo/HP_0001410	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001786	http://purl.obolibrary.org/obo/HP_0001642	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0003235	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0001396	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0006580	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0002465	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0002904	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0001397	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0002059
+ANGELMAN SYNDROME	http://www.orpha.net/ORDO/Orphanet_72
+SPONDYLOCHEIRODYSPLASIA	http://purl.obolibrary.org/obo/HP_0001371
+HYPERMETHIONINEMIA DUE TO ADENOSINE KINASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0003593
 Amyotrophic lateral sclerosis 22 with or without frontotemporal dementia	http://purl.obolibrary.org/obo/HP_0002145
-Familial amyloid nephropathy with urticaria AND deafness	http://www.orpha.net/ORDO/Orphanet_575	http://www.orpha.net/ORDO/Orphanet_47045
+Familial amyloid nephropathy with urticaria AND deafness	http://www.orpha.net/ORDO/Orphanet_575
 Cataract 44	http://www.ebi.ac.uk/efo/EFO_0001059
 Dandy-Walker like malformation with atrioventricular septal defect	http://www.orpha.net/ORDO/Orphanet_98722
 LEBER CONGENITAL AMAUROSIS 9	http://www.orpha.net/ORDO/Orphanet_65
-SPONDYLOMETAPHYSEAL DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_2646	http://www.orpha.net/ORDO/Orphanet_93314	http://www.orpha.net/ORDO/Orphanet_93317
-STRIATONIGRAL DEGENERATION	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0012043	http://purl.obolibrary.org/obo/HP_0001266	http://purl.obolibrary.org/obo/HP_0007281	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0001249
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 5	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0002510	http://purl.obolibrary.org/obo/HP_0000278	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0001560	http://purl.obolibrary.org/obo/HP_0002352	http://purl.obolibrary.org/obo/HP_0000969	http://purl.obolibrary.org/obo/HP_0005989	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000091	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0001541	http://purl.obolibrary.org/obo/HP_0001942	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0012448	http://purl.obolibrary.org/obo/HP_0001522
-CRANIOOSTEOARTHROPATHY	http://www.orpha.net/ORDO/Orphanet_2796	http://www.orpha.net/ORDO/Orphanet_1525
+SPONDYLOMETAPHYSEAL DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_2646
+STRIATONIGRAL DEGENERATION	http://purl.obolibrary.org/obo/HP_0000007
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 5	http://purl.obolibrary.org/obo/HP_0003577
+CRANIOOSTEOARTHROPATHY	http://www.orpha.net/ORDO/Orphanet_2796
 FACTOR X DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_328
-Spastic paraplegia 63	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0002518	http://purl.obolibrary.org/obo/HP_0012407
+Spastic paraplegia 63	http://purl.obolibrary.org/obo/HP_0001347
 RETINOPATHY OF PREMATURITY	http://www.ebi.ac.uk/efo/EFO_1001158
 Immunodeficiency 29	http://purl.obolibrary.org/obo/HP_0002721
 Familial visceral amyloidosis	http://www.orpha.net/ORDO/Orphanet_85450
@@ -2219,65 +2219,65 @@ Congenital disorder of glycosylation type 2C	http://www.orpha.net/ORDO/Orphanet_
 METAPHYSEAL ANADYSPLASIA 1	http://www.orpha.net/ORDO/Orphanet_1040
 Ehlers-Danlos syndrome type 7	http://www.orpha.net/ORDO/Orphanet_98249
 Meningioma	http://www.orpha.net/ORDO/Orphanet_2495
-Kosaki overgrowth syndrome	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000307	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0001030	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0002944	http://purl.obolibrary.org/obo/HP_0000974	http://purl.obolibrary.org/obo/HP_0000963	http://purl.obolibrary.org/obo/HP_0000739	http://purl.obolibrary.org/obo/HP_0001833	http://purl.obolibrary.org/obo/HP_0000336	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0002344	http://purl.obolibrary.org/obo/HP_0001548
-Endometrial carcinoma	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0000206	http://www.ebi.ac.uk/efo/EFO_0000205
+Kosaki overgrowth syndrome	http://purl.obolibrary.org/obo/HP_0000508
+Endometrial carcinoma	http://www.ebi.ac.uk/efo/EFO_0000311
 Symmetrical dyschromatosis of extremities	http://www.orpha.net/ORDO/Orphanet_41
 Intellectual disability syndrome	http://www.ebi.ac.uk/efo/EFO_0003847
-D-2-@HYDROXYGLUTARIC ACIDURIA 1	http://purl.obolibrary.org/obo/HP_0007105	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0005348	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0003150	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001638	http://purl.obolibrary.org/obo/HP_0002416	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0001659	http://purl.obolibrary.org/obo/HP_0012321	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0006956	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0007052	http://purl.obolibrary.org/obo/HP_0002104	http://purl.obolibrary.org/obo/HP_0002188	http://purl.obolibrary.org/obo/HP_0002572	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000256
+D-2-@HYDROXYGLUTARIC ACIDURIA 1	http://purl.obolibrary.org/obo/HP_0007105
 Myelofibrosis with myeloid metaplasia	http://www.orpha.net/ORDO/Orphanet_824
 Familial restrictive cardiomyopathy 3	http://www.orpha.net/ORDO/Orphanet_217635
-Breast adenocarcinoma	http://www.ebi.ac.uk/efo/EFO_0005584	http://www.ebi.ac.uk/efo/EFO_0000182	http://www.ebi.ac.uk/efo/EFO_0000304	http://www.ebi.ac.uk/efo/EFO_0003060	http://www.ebi.ac.uk/efo/EFO_0000365	http://www.ebi.ac.uk/efo/EFO_0000691
-Mandibulofacial dysostosis	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000652	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0005321	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000356
+Breast adenocarcinoma	http://www.ebi.ac.uk/efo/EFO_0005584
+Mandibulofacial dysostosis	http://purl.obolibrary.org/obo/HP_0000272
 WARBURG MICRO SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_2510
-OVARIOLEUKODYSTROPHY	http://www.orpha.net/ORDO/Orphanet_99853	http://www.orpha.net/ORDO/Orphanet_135
-Spastic paraplegia 45	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0006989	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0002064	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0000639
-HYPERCHOLESTEROLEMIA	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003362	http://purl.obolibrary.org/obo/HP_0010874	http://purl.obolibrary.org/obo/HP_0003124	http://purl.obolibrary.org/obo/HP_0002621
+OVARIOLEUKODYSTROPHY	http://www.orpha.net/ORDO/Orphanet_99853
+Spastic paraplegia 45	http://purl.obolibrary.org/obo/HP_0001371
+HYPERCHOLESTEROLEMIA	http://purl.obolibrary.org/obo/HP_0000007
 ERYTHROCYTE AMP DEAMINASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_45
-Split-hand/foot malformation 1	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000377	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0001159	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0001199	http://purl.obolibrary.org/obo/HP_0001839	http://purl.obolibrary.org/obo/HP_0010055	http://purl.obolibrary.org/obo/HP_0001849	http://purl.obolibrary.org/obo/HP_0001171	http://purl.obolibrary.org/obo/HP_0001180	http://purl.obolibrary.org/obo/HP_0030084	http://purl.obolibrary.org/obo/HP_0030680
+Split-hand/foot malformation 1	http://purl.obolibrary.org/obo/HP_0000175
 Spastic paraplegia 35	http://purl.obolibrary.org/obo/HP_0001258
 ALZHEIMER DISEASE	http://www.ebi.ac.uk/efo/EFO_0000249
 Infantile cerebellar-retinal degeneration	http://www.orpha.net/ORDO/Orphanet_313850
 Microcytic anemia	http://purl.obolibrary.org/obo/HP_0001935
-DUCHENNE MUSCULAR DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_98896	http://www.orpha.net/ORDO/Orphanet_98895
+DUCHENNE MUSCULAR DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_98896
 RETINITIS PIGMENTOSA 36	http://www.orpha.net/ORDO/Orphanet_791
 UV-SENSITIVE SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_178338
 cerebellar-facial-dental syndrome	http://www.orpha.net/ORDO/Orphanet_444072
 Arthrogryposis renal dysfunction cholestasis syndrome	http://www.ebi.ac.uk/efo/EFO_0003857
 PULMONARY VENOOCCLUSIVE DISEASE 1	http://www.orpha.net/ORDO/Orphanet_31837
 Spastic paraplegia 7	http://purl.obolibrary.org/obo/HP_0001258
-SPERMATOGENIC FAILURE 11	http://purl.obolibrary.org/obo/HP_0000789	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0012864
+SPERMATOGENIC FAILURE 11	http://purl.obolibrary.org/obo/HP_0000789
 Severe congenital neutropenia 2	http://www.orpha.net/ORDO/Orphanet_42738
 FASTING PLASMA GLUCOSE LEVEL QUANTITATIVE TRAIT LOCUS 5	http://www.ebi.ac.uk/efo/EFO_0004465
 KLIPPEL-FEIL SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_2345
-Cutis laxa	http://purl.obolibrary.org/obo/HP_0001181	http://purl.obolibrary.org/obo/HP_0000729	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0100678	http://purl.obolibrary.org/obo/HP_0000270	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002677	http://purl.obolibrary.org/obo/HP_0002645	http://purl.obolibrary.org/obo/HP_0000973	http://purl.obolibrary.org/obo/HP_0000122	http://purl.obolibrary.org/obo/HP_0000519	http://purl.obolibrary.org/obo/HP_0001348	http://purl.obolibrary.org/obo/HP_0001659	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0000337	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0000411	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0100790	http://purl.obolibrary.org/obo/HP_0007957	http://purl.obolibrary.org/obo/HP_0000325	http://purl.obolibrary.org/obo/HP_0002827
+Cutis laxa	http://purl.obolibrary.org/obo/HP_0001181
 BRUGADA SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_130
 EXUDATIVE VITREORETINOPATHY	http://www.orpha.net/ORDO/Orphanet_98668
-Hearing impairment	http://www.ebi.ac.uk/efo/EFO_0004238	http://www.ebi.ac.uk/efo/EFO_0001063
+Hearing impairment	http://www.ebi.ac.uk/efo/EFO_0004238
 Ataxia-telangiectasia-like disorder 2	http://www.orpha.net/ORDO/Orphanet_251347
 Malignant melanoma of skin	http://www.ebi.ac.uk/efo/EFO_0000389
-TROPICAL CALCIFIC PANCREATITIS	http://www.orpha.net/ORDO/Orphanet_103918	http://www.orpha.net/ORDO/Orphanet_676
+TROPICAL CALCIFIC PANCREATITIS	http://www.orpha.net/ORDO/Orphanet_103918
 NEPHROLITHIASIS	http://www.ebi.ac.uk/efo/EFO_0004253
 Cole disease	http://www.orpha.net/ORDO/Orphanet_324561
-OTOPALATODIGITAL SYNDROME	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0001852	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0001539	http://purl.obolibrary.org/obo/HP_0009804	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0008368	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0100627	http://purl.obolibrary.org/obo/HP_0002878	http://purl.obolibrary.org/obo/HP_0006487	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0002991	http://purl.obolibrary.org/obo/HP_0009467	http://purl.obolibrary.org/obo/HP_0003042	http://purl.obolibrary.org/obo/HP_0010049	http://purl.obolibrary.org/obo/HP_0006381	http://purl.obolibrary.org/obo/HP_0002982	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0100490	http://purl.obolibrary.org/obo/HP_0010047	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0006703	http://purl.obolibrary.org/obo/HP_0002687	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0008089	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0001423	http://purl.obolibrary.org/obo/HP_0008404	http://purl.obolibrary.org/obo/HP_0011304	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0009882	http://purl.obolibrary.org/obo/HP_0000260	http://purl.obolibrary.org/obo/HP_0002164	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0010560	http://purl.obolibrary.org/obo/HP_0002644	http://purl.obolibrary.org/obo/HP_0010743	http://purl.obolibrary.org/obo/HP_0003083	http://purl.obolibrary.org/obo/HP_0000162	http://purl.obolibrary.org/obo/HP_0012368	http://purl.obolibrary.org/obo/HP_0002688	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0003031	http://purl.obolibrary.org/obo/HP_0004493	http://purl.obolibrary.org/obo/HP_0010935	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0002475	http://purl.obolibrary.org/obo/HP_0000126	http://purl.obolibrary.org/obo/HP_0001838	http://purl.obolibrary.org/obo/HP_0002673	http://purl.obolibrary.org/obo/HP_0001592	http://purl.obolibrary.org/obo/HP_0011001	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0010041	http://purl.obolibrary.org/obo/HP_0001376	http://purl.obolibrary.org/obo/HP_0002827	http://purl.obolibrary.org/obo/HP_0010109	http://purl.obolibrary.org/obo/HP_0009642	http://purl.obolibrary.org/obo/HP_0001782	http://purl.obolibrary.org/obo/HP_0002980	http://purl.obolibrary.org/obo/HP_0005048	http://purl.obolibrary.org/obo/HP_0008087	http://purl.obolibrary.org/obo/HP_0009601	http://purl.obolibrary.org/obo/HP_0001841	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0005090	http://purl.obolibrary.org/obo/HP_0000336	http://purl.obolibrary.org/obo/HP_0000774	http://purl.obolibrary.org/obo/HP_0001241	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0010557	http://purl.obolibrary.org/obo/HP_0000946	http://purl.obolibrary.org/obo/HP_0001374	http://purl.obolibrary.org/obo/HP_0004232	http://purl.obolibrary.org/obo/HP_0000773	http://purl.obolibrary.org/obo/HP_0000366	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0001770	http://purl.obolibrary.org/obo/HP_0009778	http://purl.obolibrary.org/obo/HP_0006389	http://purl.obolibrary.org/obo/HP_0000926	http://purl.obolibrary.org/obo/HP_0001162	http://purl.obolibrary.org/obo/HP_0009623	http://purl.obolibrary.org/obo/HP_0001571	http://purl.obolibrary.org/obo/HP_0002737	http://purl.obolibrary.org/obo/HP_0003422	http://purl.obolibrary.org/obo/HP_0002694	http://purl.obolibrary.org/obo/HP_0001476	http://purl.obolibrary.org/obo/HP_0010044	http://purl.obolibrary.org/obo/HP_0007360	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0002084	http://purl.obolibrary.org/obo/HP_0000269	http://purl.obolibrary.org/obo/HP_0010055	http://purl.obolibrary.org/obo/HP_0002986	http://purl.obolibrary.org/obo/HP_0002645	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003304	http://purl.obolibrary.org/obo/HP_0003826	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0001671	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0010559	http://purl.obolibrary.org/obo/HP_0000772	http://purl.obolibrary.org/obo/HP_0006160	http://purl.obolibrary.org/obo/HP_0001377	http://purl.obolibrary.org/obo/HP_0008127	http://purl.obolibrary.org/obo/HP_0000235	http://purl.obolibrary.org/obo/HP_0000283
-PULMONARY FIBROSIS AND/OR BONE MARROW FAILURE	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0002216	http://purl.obolibrary.org/obo/HP_0002206	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001915	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0001909	http://purl.obolibrary.org/obo/HP_0005528	http://purl.obolibrary.org/obo/HP_0001394	http://www.orpha.net/ORDO/Orphanet_88
-Mucopolysaccharidosis type 1	http://www.orpha.net/ORDO/Orphanet_93473	http://www.orpha.net/ORDO/Orphanet_93476	http://www.orpha.net/ORDO/Orphanet_579
+OTOPALATODIGITAL SYNDROME	http://purl.obolibrary.org/obo/HP_0000272
+PULMONARY FIBROSIS AND/OR BONE MARROW FAILURE	http://purl.obolibrary.org/obo/HP_0003829
+Mucopolysaccharidosis type 1	http://www.orpha.net/ORDO/Orphanet_93473
 NEMALINE MYOPATHY 3	http://www.orpha.net/ORDO/Orphanet_607
-Nephrotic syndrome	http://purl.obolibrary.org/obo/HP_0000007	http://www.ebi.ac.uk/efo/EFO_0004255	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000093	http://purl.obolibrary.org/obo/HP_0003774	http://purl.obolibrary.org/obo/HP_0000100	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0000639
-Avellino corneal dystrophy	http://www.orpha.net/ORDO/Orphanet_98963	http://www.orpha.net/ORDO/Orphanet_98961
+Nephrotic syndrome	http://purl.obolibrary.org/obo/HP_0000007
+Avellino corneal dystrophy	http://www.orpha.net/ORDO/Orphanet_98963
 Lattice corneal dystrophy Type III	http://www.orpha.net/ORDO/Orphanet_98957
 Lethal congenital contracture syndrome 6	http://www.orpha.net/ORDO/Orphanet_294965
-Lattice corneal dystrophy Type I	http://www.orpha.net/ORDO/Orphanet_98964	http://www.orpha.net/ORDO/Orphanet_34533
-Bruck syndrome 1	http://www.orpha.net/ORDO/Orphanet_666	http://www.orpha.net/ORDO/Orphanet_2771
+Lattice corneal dystrophy Type I	http://www.orpha.net/ORDO/Orphanet_98964
+Bruck syndrome 1	http://www.orpha.net/ORDO/Orphanet_666
 Benign scapuloperoneal muscular dystrophy with cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0000318
-TESTICULAR ANOMALIES WITH OR WITHOUT CONGENITAL HEART DISEASE	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000062	http://purl.obolibrary.org/obo/HP_0008715	http://purl.obolibrary.org/obo/HP_0030260	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001636	http://purl.obolibrary.org/obo/HP_0000051	http://purl.obolibrary.org/obo/HP_0000054
+TESTICULAR ANOMALIES WITH OR WITHOUT CONGENITAL HEART DISEASE	http://purl.obolibrary.org/obo/HP_0000028
 Autosomal dominant progressive external ophthalmoplegia with mitochondrial DNA deletions 1	http://www.ebi.ac.uk/efo/EFO_0002509
 Distichiasis-lymphedema syndrome	http://www.orpha.net/ORDO/Orphanet_33001
-ZUNICH NEUROECTODERMAL SYNDROME	http://purl.obolibrary.org/obo/HP_0000582	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0000480	http://purl.obolibrary.org/obo/HP_0001636	http://purl.obolibrary.org/obo/HP_0009804	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000687	http://purl.obolibrary.org/obo/HP_0007759	http://purl.obolibrary.org/obo/HP_0002562	http://purl.obolibrary.org/obo/HP_0001831	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0005930	http://purl.obolibrary.org/obo/HP_0200042	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0002136	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0008760	http://purl.obolibrary.org/obo/HP_0000567	http://purl.obolibrary.org/obo/HP_0008572	http://purl.obolibrary.org/obo/HP_0002488	http://purl.obolibrary.org/obo/HP_0002648	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0001833	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0000465	http://purl.obolibrary.org/obo/HP_0001641	http://purl.obolibrary.org/obo/HP_0008070	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0007477	http://purl.obolibrary.org/obo/HP_0000717	http://purl.obolibrary.org/obo/HP_0001669	http://purl.obolibrary.org/obo/HP_0000962	http://purl.obolibrary.org/obo/HP_0100760	http://purl.obolibrary.org/obo/HP_0003272	http://purl.obolibrary.org/obo/HP_0002557	http://purl.obolibrary.org/obo/HP_0000074	http://purl.obolibrary.org/obo/HP_0001629	http://purl.obolibrary.org/obo/HP_0000081	http://purl.obolibrary.org/obo/HP_0002213	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0001520	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0009776	http://purl.obolibrary.org/obo/HP_0000889	http://purl.obolibrary.org/obo/HP_0000322	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0006709	http://purl.obolibrary.org/obo/HP_0011069	http://purl.obolibrary.org/obo/HP_0000972	http://purl.obolibrary.org/obo/HP_0000098	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000077	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0001176	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0000457	http://purl.obolibrary.org/obo/HP_0011362	http://purl.obolibrary.org/obo/HP_0004969	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000179	http://purl.obolibrary.org/obo/HP_0000396	http://purl.obolibrary.org/obo/HP_0000691	http://purl.obolibrary.org/obo/HP_0000126	http://purl.obolibrary.org/obo/HP_0009473	http://purl.obolibrary.org/obo/HP_0002797	http://purl.obolibrary.org/obo/HP_0006721	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0002059
-Limb-girdle muscular dystrophy	http://www.orpha.net/ORDO/Orphanet_399096	http://purl.obolibrary.org/obo/HP_0003236	http://www.orpha.net/ORDO/Orphanet_97238	http://www.orpha.net/ORDO/Orphanet_45448	http://purl.obolibrary.org/obo/HP_0006203	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0006785	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0003547	http://purl.obolibrary.org/obo/HP_0008116	http://purl.obolibrary.org/obo/HP_0008956	http://purl.obolibrary.org/obo/HP_0003749	http://purl.obolibrary.org/obo/HP_0008948	http://www.orpha.net/ORDO/Orphanet_267	http://purl.obolibrary.org/obo/HP_0000518	http://www.orpha.net/ORDO/Orphanet_263	http://purl.obolibrary.org/obo/HP_0003805	http://purl.obolibrary.org/obo/HP_0003198
+ZUNICH NEUROECTODERMAL SYNDROME	http://purl.obolibrary.org/obo/HP_0000582
+Limb-girdle muscular dystrophy	http://www.orpha.net/ORDO/Orphanet_399096
 Glucocorticoid resistance	http://www.orpha.net/ORDO/Orphanet_786
-PIGMENTED NODULAR ADRENOCORTICAL DISEASE	http://purl.obolibrary.org/obo/HP_0000712	http://purl.obolibrary.org/obo/HP_0000713	http://purl.obolibrary.org/obo/HP_0001575	http://purl.obolibrary.org/obo/HP_0003674	http://purl.obolibrary.org/obo/HP_0000716	http://purl.obolibrary.org/obo/HP_0003118	http://purl.obolibrary.org/obo/HP_0001030	http://purl.obolibrary.org/obo/HP_0002920	http://purl.obolibrary.org/obo/HP_0000963	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0001065	http://purl.obolibrary.org/obo/HP_0001578	http://purl.obolibrary.org/obo/HP_0001580	http://purl.obolibrary.org/obo/HP_0001956	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003701	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0000709	http://purl.obolibrary.org/obo/HP_0000311	http://purl.obolibrary.org/obo/HP_0004324	http://purl.obolibrary.org/obo/HP_0008221	http://purl.obolibrary.org/obo/HP_0001268	http://purl.obolibrary.org/obo/HP_0001007	http://purl.obolibrary.org/obo/HP_0000739	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0001061	http://purl.obolibrary.org/obo/HP_0000819	http://purl.obolibrary.org/obo/HP_0001579	http://purl.obolibrary.org/obo/HP_0003466	http://purl.obolibrary.org/obo/HP_0002808
+PIGMENTED NODULAR ADRENOCORTICAL DISEASE	http://purl.obolibrary.org/obo/HP_0000712
 Neonatal adrenoleucodystrophy	http://www.orpha.net/ORDO/Orphanet_44
-HYPOTRICHOSIS 3	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0004782
+HYPOTRICHOSIS 3	http://purl.obolibrary.org/obo/HP_0000006
 Primary pulmonary hypertension 4	http://www.ebi.ac.uk/efo/EFO_0001361
 SPONDYLO-MEGAEPIPHYSEAL-METAPHYSEAL DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_228387
 Hirschsprung disease ganglioneuroblastoma	http://www.orpha.net/ORDO/Orphanet_388
@@ -2286,24 +2286,24 @@ APPARENT MINERALOCORTICOID EXCESS	http://www.orpha.net/ORDO/Orphanet_320
 MICROPENIS	http://purl.obolibrary.org/obo/HP_0000054
 Isolated 17	http://www.orpha.net/ORDO/Orphanet_90796
 L-FERRITIN DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_440731
-CROUZON SYNDROME	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0010535	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0007360	http://purl.obolibrary.org/obo/HP_0000348	http://purl.obolibrary.org/obo/HP_0004440	http://purl.obolibrary.org/obo/HP_0000612	http://purl.obolibrary.org/obo/HP_0000509	http://purl.obolibrary.org/obo/HP_0004443	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0001053	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0000678	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001739	http://purl.obolibrary.org/obo/HP_0000956	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0003319	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0002516	http://purl.obolibrary.org/obo/HP_0000444	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0004442	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002308	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0000413	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0004439	http://purl.obolibrary.org/obo/HP_0000174	http://purl.obolibrary.org/obo/HP_0001363	http://purl.obolibrary.org/obo/HP_0000327	http://purl.obolibrary.org/obo/HP_0000586	http://purl.obolibrary.org/obo/HP_0005107	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0000995	http://purl.obolibrary.org/obo/HP_0000453
+CROUZON SYNDROME	http://purl.obolibrary.org/obo/HP_0000303
 Mulibrey nanism syndrome	http://www.orpha.net/ORDO/Orphanet_2576
-Ciliary dyskinesia	http://purl.obolibrary.org/obo/HP_0000789	http://purl.obolibrary.org/obo/HP_0011109	http://purl.obolibrary.org/obo/HP_0012384	http://purl.obolibrary.org/obo/HP_0000388	http://purl.obolibrary.org/obo/HP_0001696	http://purl.obolibrary.org/obo/HP_0012207	http://purl.obolibrary.org/obo/HP_0000246	http://purl.obolibrary.org/obo/HP_0012262	http://purl.obolibrary.org/obo/HP_0004469	http://purl.obolibrary.org/obo/HP_0012257	http://purl.obolibrary.org/obo/HP_0000403	http://purl.obolibrary.org/obo/HP_0001748	http://www.ebi.ac.uk/efo/EFO_0003900	http://purl.obolibrary.org/obo/HP_0012258	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0100582	http://purl.obolibrary.org/obo/HP_0002110	http://purl.obolibrary.org/obo/HP_0200073	http://purl.obolibrary.org/obo/HP_0002099	http://purl.obolibrary.org/obo/HP_0012735	http://purl.obolibrary.org/obo/HP_0012265
-Primary familial hypertrophic cardiomyopathy	http://www.orpha.net/ORDO/Orphanet_648	http://www.orpha.net/ORDO/Orphanet_130	http://www.orpha.net/ORDO/Orphanet_217635	http://www.orpha.net/ORDO/Orphanet_99739
+Ciliary dyskinesia	http://purl.obolibrary.org/obo/HP_0000789
+Primary familial hypertrophic cardiomyopathy	http://www.orpha.net/ORDO/Orphanet_648
 SICK SINUS SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_166282
 WHITE SPONGE NEVUS 2	http://www.orpha.net/ORDO/Orphanet_171723
 COMPLEMENT COMPONENT 2 DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_169147
 LEBER CONGENITAL AMAUROSIS 5	http://www.orpha.net/ORDO/Orphanet_65
 Congenital adrenal hypoplasia	http://www.orpha.net/ORDO/Orphanet_95702
 ACAMPOMELIC CAMPOMELIC DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_140
-Lynch syndrome I	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003003
+Lynch syndrome I	http://purl.obolibrary.org/obo/HP_0000006
 FRONTONASAL DYSPLASIA 1	http://www.orpha.net/ORDO/Orphanet_391474
 Noonan syndrome-like disorder with or without juvenile myelomonocytic leukemia	http://www.ebi.ac.uk/efo/EFO_0000565
 Hyperphosphatasia with mental retardation syndrome 5	http://www.orpha.net/ORDO/Orphanet_247262
-MUCOLIPIDOSIS III GAMMA	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0001650	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007759	http://purl.obolibrary.org/obo/HP_0003370	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001547	http://purl.obolibrary.org/obo/HP_0001155	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0003333	http://purl.obolibrary.org/obo/HP_0001659	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0000768	http://purl.obolibrary.org/obo/HP_0001387	http://purl.obolibrary.org/obo/HP_0002829	http://purl.obolibrary.org/obo/HP_0003307	http://purl.obolibrary.org/obo/HP_0002869	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0002857	http://purl.obolibrary.org/obo/HP_0000943	http://purl.obolibrary.org/obo/HP_0000280
-LEIGH SYNDROME	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0002789	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0003074	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0002171	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0011096	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0006565	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001414	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0000294	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0001943	http://purl.obolibrary.org/obo/HP_0001007	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0002553	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0002490	http://purl.obolibrary.org/obo/HP_0007305
+MUCOLIPIDOSIS III GAMMA	http://purl.obolibrary.org/obo/HP_0001256
+LEIGH SYNDROME	http://purl.obolibrary.org/obo/HP_0000272
 ALCOHOL DEPENDENCE	http://www.ebi.ac.uk/efo/EFO_0003829
-SCAPULOPERONEAL SYNDROME	http://purl.obolibrary.org/obo/HP_0009049	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003704	http://purl.obolibrary.org/obo/HP_0003724	http://purl.obolibrary.org/obo/HP_0009027	http://purl.obolibrary.org/obo/HP_0001762
+SCAPULOPERONEAL SYNDROME	http://purl.obolibrary.org/obo/HP_0009049
 Amyotrophic lateral sclerosis type 5	http://www.ebi.ac.uk/efo/EFO_0000253
 Hereditary neutrophilia	http://www.orpha.net/ORDO/Orphanet_279943
 BOSLEY-SALIH-ALORAINY SYNDROME	http://www.orpha.net/ORDO/Orphanet_69737
@@ -2311,100 +2311,100 @@ Andermann syndrome	http://www.orpha.net/ORDO/Orphanet_1496
 ACROMESOMELIC DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_40
 VATER ASSOCIATION WITH MACROCEPHALY AND VENTRICULOMEGALY	http://www.orpha.net/ORDO/Orphanet_887
 Coronary heart disease 5	http://www.ebi.ac.uk/efo/EFO_0001645
-BRACHYDACTYLY	http://purl.obolibrary.org/obo/HP_0010554	http://purl.obolibrary.org/obo/HP_0010109	http://purl.obolibrary.org/obo/HP_0009514	http://purl.obolibrary.org/obo/HP_0006152	http://purl.obolibrary.org/obo/HP_0009587	http://purl.obolibrary.org/obo/HP_0009516	http://purl.obolibrary.org/obo/HP_0009835	http://purl.obolibrary.org/obo/HP_0005048	http://purl.obolibrary.org/obo/HP_0008386	http://purl.obolibrary.org/obo/HP_0000696	http://purl.obolibrary.org/obo/HP_0010259	http://purl.obolibrary.org/obo/HP_0006101	http://purl.obolibrary.org/obo/HP_0010621	http://purl.obolibrary.org/obo/HP_0001841	http://purl.obolibrary.org/obo/HP_0006206	http://purl.obolibrary.org/obo/HP_0001231	http://purl.obolibrary.org/obo/HP_0010034	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0001772	http://purl.obolibrary.org/obo/HP_0009461	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0008368	http://purl.obolibrary.org/obo/HP_0009843	http://purl.obolibrary.org/obo/HP_0009765	http://purl.obolibrary.org/obo/HP_0001831	http://purl.obolibrary.org/obo/HP_0001822	http://purl.obolibrary.org/obo/HP_0009464	http://purl.obolibrary.org/obo/HP_0005831	http://purl.obolibrary.org/obo/HP_0004691	http://purl.obolibrary.org/obo/HP_0003026	http://purl.obolibrary.org/obo/HP_0000054	http://www.orpha.net/ORDO/Orphanet_294937	http://purl.obolibrary.org/obo/HP_0001883	http://purl.obolibrary.org/obo/HP_0004590	http://purl.obolibrary.org/obo/HP_0009467	http://purl.obolibrary.org/obo/HP_0005819	http://purl.obolibrary.org/obo/HP_0004220	http://purl.obolibrary.org/obo/HP_0000540	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001770	http://purl.obolibrary.org/obo/HP_0009702	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0009495	http://purl.obolibrary.org/obo/HP_0009356	http://purl.obolibrary.org/obo/HP_0001163	http://purl.obolibrary.org/obo/HP_0009456	http://purl.obolibrary.org/obo/HP_0000466	http://purl.obolibrary.org/obo/HP_0002937	http://purl.obolibrary.org/obo/HP_0009536	http://purl.obolibrary.org/obo/HP_0009204	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0009623	http://purl.obolibrary.org/obo/HP_0002949	http://purl.obolibrary.org/obo/HP_0009177	http://purl.obolibrary.org/obo/HP_0009436	http://purl.obolibrary.org/obo/HP_0009602	http://purl.obolibrary.org/obo/HP_0003189	http://purl.obolibrary.org/obo/HP_0009463	http://purl.obolibrary.org/obo/HP_0010442	http://purl.obolibrary.org/obo/HP_0010185	http://purl.obolibrary.org/obo/HP_0011304	http://purl.obolibrary.org/obo/HP_0002948	http://purl.obolibrary.org/obo/HP_0012385	http://purl.obolibrary.org/obo/HP_0000270	http://purl.obolibrary.org/obo/HP_0007943	http://purl.obolibrary.org/obo/HP_0008096	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0010055	http://purl.obolibrary.org/obo/HP_0009882	http://purl.obolibrary.org/obo/HP_0000260	http://purl.obolibrary.org/obo/HP_0009182	http://purl.obolibrary.org/obo/HP_0000684	http://purl.obolibrary.org/obo/HP_0009161	http://purl.obolibrary.org/obo/HP_0009349	http://purl.obolibrary.org/obo/HP_0009568	http://purl.obolibrary.org/obo/HP_0009465	http://purl.obolibrary.org/obo/HP_0001798	http://purl.obolibrary.org/obo/HP_0009527	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000430	http://purl.obolibrary.org/obo/HP_0001204	http://purl.obolibrary.org/obo/HP_0006109	http://purl.obolibrary.org/obo/HP_0009575	http://purl.obolibrary.org/obo/HP_0009331	http://purl.obolibrary.org/obo/HP_0009523	http://purl.obolibrary.org/obo/HP_0010579	http://purl.obolibrary.org/obo/HP_0001159	http://purl.obolibrary.org/obo/HP_0001760	http://purl.obolibrary.org/obo/HP_0002944	http://purl.obolibrary.org/obo/HP_0000381	http://purl.obolibrary.org/obo/HP_0009773	http://purl.obolibrary.org/obo/HP_0009417	http://purl.obolibrary.org/obo/HP_0003067	http://purl.obolibrary.org/obo/HP_0009534	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0009370	http://purl.obolibrary.org/obo/HP_0009473	http://purl.obolibrary.org/obo/HP_0009324	http://purl.obolibrary.org/obo/HP_0011929	http://purl.obolibrary.org/obo/HP_0010048	http://purl.obolibrary.org/obo/HP_0001629	http://purl.obolibrary.org/obo/HP_0010194
-AMYOTROPHIC LATERAL SCLEROSIS 16	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007354	http://purl.obolibrary.org/obo/HP_0002366	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0002127
+BRACHYDACTYLY	http://purl.obolibrary.org/obo/HP_0010554
+AMYOTROPHIC LATERAL SCLEROSIS 16	http://purl.obolibrary.org/obo/HP_0001347
 FOCAL SEGMENTAL GLOMERULOSCLEROSIS 9	http://www.ebi.ac.uk/efo/EFO_0004236
-MAY-HEGGLIN ANOMALY	http://purl.obolibrary.org/obo/HP_0000421	http://purl.obolibrary.org/obo/HP_0000132	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001892	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0008264	http://purl.obolibrary.org/obo/HP_0001977	http://purl.obolibrary.org/obo/HP_0001658	http://purl.obolibrary.org/obo/HP_0001902	http://purl.obolibrary.org/obo/HP_0003010
+MAY-HEGGLIN ANOMALY	http://purl.obolibrary.org/obo/HP_0000421
 CORTICOSTEROID-BINDING GLOBULIN DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_199247
 Acrocapitofemoral dysplasia	http://www.orpha.net/ORDO/Orphanet_63446
 Progressive familial intrahepatic cholestasis 4	http://www.orpha.net/ORDO/Orphanet_172
-Polyneuropathy	http://purl.obolibrary.org/obo/HP_0007141	http://purl.obolibrary.org/obo/HP_0003674	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000762	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000523	http://purl.obolibrary.org/obo/HP_0003693	http://purl.obolibrary.org/obo/HP_0001271	http://purl.obolibrary.org/obo/HP_0001771	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0002936
+Polyneuropathy	http://purl.obolibrary.org/obo/HP_0007141
 History of neonatal hypotonia	http://purl.obolibrary.org/obo/HP_0000508
 DIHYDROPYRIMIDINE DEHYDROGENASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_1675
-Trichomegaly	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000527	http://purl.obolibrary.org/obo/HP_0000518
+Trichomegaly	http://purl.obolibrary.org/obo/HP_0000006
 King Denborough syndrome	http://www.orpha.net/ORDO/Orphanet_99741
 Hypogonadotropic hypogonadism 10 with or without anosmia	http://www.orpha.net/ORDO/Orphanet_432
 Common variable immunodeficiency 8	http://www.orpha.net/ORDO/Orphanet_1572
 Encephalocraniocutaneous lipomatosis	http://www.orpha.net/ORDO/Orphanet_2396
-CARNITINE PALMITOYLTRANSFERASE I DEFICIENCY	http://purl.obolibrary.org/obo/HP_0004372	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0001987	http://purl.obolibrary.org/obo/HP_0003119	http://purl.obolibrary.org/obo/HP_0000708	http://purl.obolibrary.org/obo/HP_0001640	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0007335	http://purl.obolibrary.org/obo/HP_0001254	http://purl.obolibrary.org/obo/HP_0000091	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001645	http://purl.obolibrary.org/obo/HP_0004374	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0002686	http://purl.obolibrary.org/obo/HP_0001399	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0001943	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0001985	http://purl.obolibrary.org/obo/HP_0011675	http://purl.obolibrary.org/obo/HP_0001947	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0001315	http://purl.obolibrary.org/obo/HP_0001259	http://purl.obolibrary.org/obo/HP_0008279	http://purl.obolibrary.org/obo/HP_0001397
+CARNITINE PALMITOYLTRANSFERASE I DEFICIENCY	http://purl.obolibrary.org/obo/HP_0004372
 Abnormal cortical gyration	http://purl.obolibrary.org/obo/HP_0002536
 Severe congenital neutropenia 3	http://www.orpha.net/ORDO/Orphanet_42738
 Syndactyly type 5	http://www.orpha.net/ORDO/Orphanet_93406
 Benign hereditary chorea	http://www.orpha.net/ORDO/Orphanet_1429
 Stiff skin syndrome	http://www.orpha.net/ORDO/Orphanet_2833
-Dystonia 23	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0011675	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0002530	http://purl.obolibrary.org/obo/HP_0000473	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002451	http://purl.obolibrary.org/obo/HP_0001618	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002346	http://purl.obolibrary.org/obo/HP_0002356
-MYOPATHY	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0009743	http://purl.obolibrary.org/obo/HP_0003281	http://purl.obolibrary.org/obo/HP_0002304	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002359	http://purl.obolibrary.org/obo/HP_0002747	http://purl.obolibrary.org/obo/HP_0003557	http://purl.obolibrary.org/obo/HP_0003688	http://www.ebi.ac.uk/efo/EFO_0000311	http://purl.obolibrary.org/obo/HP_0010557	http://purl.obolibrary.org/obo/HP_0001935	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0008180	http://purl.obolibrary.org/obo/HP_0003323	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0001417	http://www.orpha.net/ORDO/Orphanet_59135	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0000980	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0003693	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003701	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0008944	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0002240	http://www.orpha.net/ORDO/Orphanet_330054	http://purl.obolibrary.org/obo/HP_0001931	http://purl.obolibrary.org/obo/HP_0001430	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0002033	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0001522	http://purl.obolibrary.org/obo/HP_0001924	http://purl.obolibrary.org/obo/HP_0003700	http://purl.obolibrary.org/obo/HP_0001423	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0012385	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0003678	http://purl.obolibrary.org/obo/HP_0001166	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0003546	http://purl.obolibrary.org/obo/HP_0009055	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001989	http://purl.obolibrary.org/obo/HP_0003198	http://purl.obolibrary.org/obo/HP_0000268	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0012132	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0000300	http://www.ebi.ac.uk/efo/EFO_0004145	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0003306	http://purl.obolibrary.org/obo/HP_0007149	http://www.orpha.net/ORDO/Orphanet_169189	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0003307	http://purl.obolibrary.org/obo/HP_0009473	http://purl.obolibrary.org/obo/HP_0002460	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0000823	http://purl.obolibrary.org/obo/HP_0001561
-PROSTATE CANCER	http://purl.obolibrary.org/obo/HP_0012125	http://www.ebi.ac.uk/efo/EFO_0000311	http://purl.obolibrary.org/obo/HP_0002664	http://www.ebi.ac.uk/efo/EFO_0001663	http://purl.obolibrary.org/obo/HP_0000006	http://www.orpha.net/ORDO/Orphanet_1331	http://www.ebi.ac.uk/efo/EFO_0000673	http://www.ebi.ac.uk/efo/EFO_0005842
-Generalized arterial calcification of infancy 2	http://www.orpha.net/ORDO/Orphanet_758	http://www.orpha.net/ORDO/Orphanet_51608
+Dystonia 23	http://purl.obolibrary.org/obo/HP_0001336
+MYOPATHY	http://purl.obolibrary.org/obo/HP_0001371
+PROSTATE CANCER	http://purl.obolibrary.org/obo/HP_0012125
+Generalized arterial calcification of infancy 2	http://www.orpha.net/ORDO/Orphanet_758
 HYPERCALCIURIA	http://purl.obolibrary.org/obo/HP_0003072
 Congenital disorder of glycosylation type 1G	http://www.orpha.net/ORDO/Orphanet_79324
 EPISODIC ATAXIA TYPE 2	http://www.orpha.net/ORDO/Orphanet_97
 VENOUS THROMBOSIS	http://purl.obolibrary.org/obo/HP_0004936
-Cerebellar ataxia infantile with progressive external ophthalmoplegia	http://www.ebi.ac.uk/efo/EFO_0002509	http://www.ebi.ac.uk/efo/EFO_0000474
+Cerebellar ataxia infantile with progressive external ophthalmoplegia	http://www.ebi.ac.uk/efo/EFO_0002509
 Mutilating keratoderma	http://www.orpha.net/ORDO/Orphanet_494
-Oculoectodermal syndrome	http://www.orpha.net/ORDO/Orphanet_65	http://www.orpha.net/ORDO/Orphanet_3339
+Oculoectodermal syndrome	http://www.orpha.net/ORDO/Orphanet_65
 Lipodystrophy	http://www.ebi.ac.uk/efo/EFO_1000727
-IMMUNODEFICIENCY 18	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0003593	http://www.orpha.net/ORDO/Orphanet_183660	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0000403	http://purl.obolibrary.org/obo/HP_0001888
+IMMUNODEFICIENCY 18	http://purl.obolibrary.org/obo/HP_0000007
 DOWLING-DEGOS DISEASE 1	http://www.orpha.net/ORDO/Orphanet_79145
-VON WILLEBRAND DISEASE	http://www.orpha.net/ORDO/Orphanet_166084	http://www.orpha.net/ORDO/Orphanet_166093	http://www.orpha.net/ORDO/Orphanet_166087	http://www.orpha.net/ORDO/Orphanet_166090	http://www.orpha.net/ORDO/Orphanet_903	http://www.orpha.net/ORDO/Orphanet_120487
-Alport syndrome	http://purl.obolibrary.org/obo/HP_0000093	http://purl.obolibrary.org/obo/HP_0000099	http://purl.obolibrary.org/obo/HP_0001134	http://www.orpha.net/ORDO/Orphanet_247676	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003774	http://purl.obolibrary.org/obo/HP_0002148	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0002157	http://purl.obolibrary.org/obo/HP_0001142	http://purl.obolibrary.org/obo/HP_0000100	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0000790	http://purl.obolibrary.org/obo/HP_0000121	http://purl.obolibrary.org/obo/HP_0004722	http://purl.obolibrary.org/obo/HP_0030034	http://purl.obolibrary.org/obo/HP_0000407
+VON WILLEBRAND DISEASE	http://www.orpha.net/ORDO/Orphanet_166084
+Alport syndrome	http://purl.obolibrary.org/obo/HP_0000093
 Lewy body dementia	http://www.ebi.ac.uk/efo/EFO_0006792
 Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome	http://www.orpha.net/ORDO/Orphanet_415
 Exudative retinopathy	http://purl.obolibrary.org/obo/HP_0007898
 INFLAMMATORY BOWEL DISEASE 19	http://www.ebi.ac.uk/efo/EFO_0003767
 Primary autosomal recessive microcephaly 6	http://www.orpha.net/ORDO/Orphanet_2512
 Primary erythromelalgia	http://www.orpha.net/ORDO/Orphanet_1956
-Hypercholesterolemia	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001677	http://purl.obolibrary.org/obo/HP_0003124	http://purl.obolibrary.org/obo/HP_0001084	http://purl.obolibrary.org/obo/HP_0001114
-Hirschsprung disease 1	http://www.orpha.net/ORDO/Orphanet_1675	http://www.orpha.net/ORDO/Orphanet_388
+Hypercholesterolemia	http://purl.obolibrary.org/obo/HP_0000006
+Hirschsprung disease 1	http://www.orpha.net/ORDO/Orphanet_1675
 Primary pulmonary hypertension 3	http://www.ebi.ac.uk/efo/EFO_0001361
 PYRUVATE DEHYDROGENASE E3-BINDING PROTEIN DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_255182
-THROMBOCYTOPENIA 2	http://www.orpha.net/ORDO/Orphanet_268322	http://www.orpha.net/ORDO/Orphanet_168629
-PITUITARY HORMONE DEFICIENCY COMBINED 3	http://www.orpha.net/ORDO/Orphanet_95494	http://www.orpha.net/ORDO/Orphanet_467
-Spinocerebellar ataxia 41	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002317
-COACH syndrome	http://www.orpha.net/ORDO/Orphanet_475	http://www.orpha.net/ORDO/Orphanet_220497	http://www.orpha.net/ORDO/Orphanet_1454	http://www.orpha.net/ORDO/Orphanet_564
+THROMBOCYTOPENIA 2	http://www.orpha.net/ORDO/Orphanet_268322
+PITUITARY HORMONE DEFICIENCY COMBINED 3	http://www.orpha.net/ORDO/Orphanet_95494
+Spinocerebellar ataxia 41	http://purl.obolibrary.org/obo/HP_0001272
+COACH syndrome	http://www.orpha.net/ORDO/Orphanet_475
 JOUBERT SYNDROME 20	http://www.orpha.net/ORDO/Orphanet_475
-GLUCOCORTICOID DEFICIENCY 4	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001943
+GLUCOCORTICOID DEFICIENCY 4	http://purl.obolibrary.org/obo/HP_0000007
 Vitamin D-dependent rickets	http://www.ebi.ac.uk/efo/EFO_0005583
-INSULIN RESISTANCE	http://www.ebi.ac.uk/efo/EFO_0000400	http://www.ebi.ac.uk/efo/EFO_0000378	http://www.ebi.ac.uk/efo/EFO_0001645	http://www.ebi.ac.uk/efo/EFO_0002614
+INSULIN RESISTANCE	http://www.ebi.ac.uk/efo/EFO_0000400
 UROFACIAL SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_2704
 DUBIN-JOHNSON SYNDROME	http://www.orpha.net/ORDO/Orphanet_234
 Leukemia	http://www.ebi.ac.uk/efo/EFO_0000565
-FEBRILE SEIZURES	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002069	http://purl.obolibrary.org/obo/HP_0002373
+FEBRILE SEIZURES	http://purl.obolibrary.org/obo/HP_0000007
 SICK SINUS SYNDROME 3	http://purl.obolibrary.org/obo/HP_0011704
 JOUBERT SYNDROME 10	http://www.orpha.net/ORDO/Orphanet_475
-PFEIFFER SYNDROME	http://www.orpha.net/ORDO/Orphanet_710	http://www.orpha.net/ORDO/Orphanet_1540
-AMINOACYLASE 1 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0006846	http://purl.obolibrary.org/obo/HP_0000752	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002188	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0002059
+PFEIFFER SYNDROME	http://www.orpha.net/ORDO/Orphanet_710
+AMINOACYLASE 1 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001252
 Dilated cardiomyopathy 1LL	http://www.ebi.ac.uk/efo/EFO_0000407
-Charcot-Marie-Tooth disease type 2C	http://www.orpha.net/ORDO/Orphanet_166	http://www.orpha.net/ORDO/Orphanet_206713
+Charcot-Marie-Tooth disease type 2C	http://www.orpha.net/ORDO/Orphanet_166
 Medium Chain Acyl-Coenzyme A Dehydrogenase Deficiency	http://www.orpha.net/ORDO/Orphanet_42
 Fibrochondrogenesis	http://www.orpha.net/ORDO/Orphanet_2021
-SHORT-RIB THORACIC DYSPLASIA 10 WITH OR WITHOUT POLYDACTYLY	http://purl.obolibrary.org/obo/HP_0000546	http://purl.obolibrary.org/obo/HP_0001320	http://purl.obolibrary.org/obo/HP_0000662	http://purl.obolibrary.org/obo/HP_0000657	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0001395	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000833	http://purl.obolibrary.org/obo/HP_0001591	http://purl.obolibrary.org/obo/HP_0000090	http://purl.obolibrary.org/obo/HP_0003026	http://purl.obolibrary.org/obo/HP_0000773	http://purl.obolibrary.org/obo/HP_0001396	http://purl.obolibrary.org/obo/HP_0001513	http://purl.obolibrary.org/obo/HP_0012622	http://purl.obolibrary.org/obo/HP_0000202	http://purl.obolibrary.org/obo/HP_0001399	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0001162	http://purl.obolibrary.org/obo/HP_0005257	http://purl.obolibrary.org/obo/HP_0010230	http://purl.obolibrary.org/obo/HP_0006644	http://purl.obolibrary.org/obo/HP_0002857	http://purl.obolibrary.org/obo/HP_0001629
+SHORT-RIB THORACIC DYSPLASIA 10 WITH OR WITHOUT POLYDACTYLY	http://purl.obolibrary.org/obo/HP_0000546
 Thyroid adenoma	http://www.ebi.ac.uk/efo/EFO_0000499
-ZELLWEGER SYNDROME	http://www.orpha.net/ORDO/Orphanet_65	http://www.orpha.net/ORDO/Orphanet_178826	http://www.orpha.net/ORDO/Orphanet_118174	http://www.orpha.net/ORDO/Orphanet_3220	http://www.orpha.net/ORDO/Orphanet_912
+ZELLWEGER SYNDROME	http://www.orpha.net/ORDO/Orphanet_65
 Benign familial neonatal seizures 2	http://www.orpha.net/ORDO/Orphanet_1949
 CYSTINURIA	http://www.orpha.net/ORDO/Orphanet_214
 Aminoglycoside-induced deafness	http://www.ebi.ac.uk/efo/EFO_0001063
 4-Hydroxyphenylpyruvate dioxygenase deficiency	http://www.orpha.net/ORDO/Orphanet_69723
-Primary open angle glaucoma	http://purl.obolibrary.org/obo/HP_0012108	http://purl.obolibrary.org/obo/HP_0000589
-Chondroectodermal dysplasia	http://www.orpha.net/ORDO/Orphanet_289	http://www.orpha.net/ORDO/Orphanet_952
+Primary open angle glaucoma	http://purl.obolibrary.org/obo/HP_0012108
+Chondroectodermal dysplasia	http://www.orpha.net/ORDO/Orphanet_289
 DUANE-RADIAL RAY SYNDROME	http://www.orpha.net/ORDO/Orphanet_93293
-PONTOCEREBELLAR HYPOPLASIA	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0002803	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0000341	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000737	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0002179	http://purl.obolibrary.org/obo/HP_0003819	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002187	http://purl.obolibrary.org/obo/HP_0002509	http://purl.obolibrary.org/obo/HP_0002171	http://purl.obolibrary.org/obo/HP_0003121	http://purl.obolibrary.org/obo/HP_0002878	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0000711	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0000998	http://purl.obolibrary.org/obo/HP_0000540	http://purl.obolibrary.org/obo/HP_0002350	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0011344	http://purl.obolibrary.org/obo/HP_0007772	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0000189	http://purl.obolibrary.org/obo/HP_0002518	http://purl.obolibrary.org/obo/HP_0000483	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0007269	http://purl.obolibrary.org/obo/HP_0100704	http://purl.obolibrary.org/obo/HP_0002421	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0000340	http://purl.obolibrary.org/obo/HP_0002827	http://purl.obolibrary.org/obo/HP_0002033	http://purl.obolibrary.org/obo/HP_0001522	http://purl.obolibrary.org/obo/HP_0002490	http://purl.obolibrary.org/obo/HP_0012110	http://purl.obolibrary.org/obo/HP_0007308	http://purl.obolibrary.org/obo/HP_0001320	http://purl.obolibrary.org/obo/HP_0001285	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0007105	http://purl.obolibrary.org/obo/HP_0002510	http://purl.obolibrary.org/obo/HP_0004684	http://purl.obolibrary.org/obo/HP_0002072	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0000565	http://purl.obolibrary.org/obo/HP_0002804	http://purl.obolibrary.org/obo/HP_0000657	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002169	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001308	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000490	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0000253	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0100307	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0000426	http://purl.obolibrary.org/obo/HP_0001760	http://purl.obolibrary.org/obo/HP_0002061	http://purl.obolibrary.org/obo/HP_0002020	http://purl.obolibrary.org/obo/HP_0002104	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0007001	http://purl.obolibrary.org/obo/HP_0002360	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0000556	http://purl.obolibrary.org/obo/HP_0002465	http://purl.obolibrary.org/obo/HP_0009879	http://purl.obolibrary.org/obo/HP_0005484	http://purl.obolibrary.org/obo/HP_0002365	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0012448	http://purl.obolibrary.org/obo/HP_0012473	http://purl.obolibrary.org/obo/HP_0006986	http://purl.obolibrary.org/obo/HP_0001561	http://purl.obolibrary.org/obo/HP_0002059
+PONTOCEREBELLAR HYPOPLASIA	http://purl.obolibrary.org/obo/HP_0001371
 DOPAMINE RECEPTOR D2	http://www.orpha.net/ORDO/Orphanet_121177
 PALLISTER-HALL SYNDROME	http://www.orpha.net/ORDO/Orphanet_672
-HOYERAAL-HREIDARSSON SYNDROME	http://www.orpha.net/ORDO/Orphanet_1775	http://www.orpha.net/ORDO/Orphanet_3322
+HOYERAAL-HREIDARSSON SYNDROME	http://www.orpha.net/ORDO/Orphanet_1775
 Congenital order of glycosylation type 1r	http://www.orpha.net/ORDO/Orphanet_300536
-RETINITIS PIGMENTOSA 4	http://www.orpha.net/ORDO/Orphanet_52427	http://www.orpha.net/ORDO/Orphanet_791
-ENTEROKINASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0007609	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0003075
+RETINITIS PIGMENTOSA 4	http://www.orpha.net/ORDO/Orphanet_52427
+ENTEROKINASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
 Stuve-Wiedemann syndrome	http://www.orpha.net/ORDO/Orphanet_3206
-Transient neonatal diabetes mellitus 2	http://www.orpha.net/ORDO/Orphanet_224	http://www.orpha.net/ORDO/Orphanet_99886
+Transient neonatal diabetes mellitus 2	http://www.orpha.net/ORDO/Orphanet_224
 Familial multiple polyposis syndrome	http://www.orpha.net/ORDO/Orphanet_733
 LEBER CONGENITAL AMAUROSIS 1	http://www.orpha.net/ORDO/Orphanet_65
 Deficiency of galactokinase	http://www.orpha.net/ORDO/Orphanet_79237
-BASEL-VANAGAITE-SMIRIN-YOSEF SYNDROME	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000232	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001671	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000126	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0010804	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000322	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0008070	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0000316
+BASEL-VANAGAITE-SMIRIN-YOSEF SYNDROME	http://purl.obolibrary.org/obo/HP_0002650
 CEREBRAL PALSY	http://www.orpha.net/ORDO/Orphanet_210141
 Medulloblastoma with extensive nodularity	http://www.orpha.net/ORDO/Orphanet_251858
 KENNY-CAFFEY SYNDROME	http://www.orpha.net/ORDO/Orphanet_2333
-ECTODERMAL DYSPLASIA 9	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001598	http://purl.obolibrary.org/obo/HP_0008404	http://purl.obolibrary.org/obo/HP_0000968	http://purl.obolibrary.org/obo/HP_0001006
+ECTODERMAL DYSPLASIA 9	http://purl.obolibrary.org/obo/HP_0000007
 TRIOSEPHOSPHATE ISOMERASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_868
 CORONARY ARTERY SPASM 3	http://www.ebi.ac.uk/efo/EFO_1000013
 Spastic paraplegia 12	http://purl.obolibrary.org/obo/HP_0001258
@@ -2412,49 +2412,49 @@ GRACILE BONE DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_2763
 Short rib polydactyly syndrome 5	http://www.orpha.net/ORDO/Orphanet_2913
 Craniofacial dysmorphism	http://www.ebi.ac.uk/efo/EFO_0003847
 LIG4 SYNDROME	http://www.orpha.net/ORDO/Orphanet_99812
-Deafness	http://purl.obolibrary.org/obo/HP_0003390	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0008619	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0005101	http://purl.obolibrary.org/obo/HP_0012715	http://www.ebi.ac.uk/efo/EFO_0004238	http://www.ebi.ac.uk/efo/EFO_0001063	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0001963	http://www.orpha.net/ORDO/Orphanet_90641	http://purl.obolibrary.org/obo/HP_0000399	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0004454	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0001751	http://www.orpha.net/ORDO/Orphanet_90636	http://purl.obolibrary.org/obo/HP_0002936	http://purl.obolibrary.org/obo/HP_0001730	http://www.orpha.net/ORDO/Orphanet_99739
+Deafness	http://purl.obolibrary.org/obo/HP_0003390
 Pyridoxine-dependent epilepsy	http://www.orpha.net/ORDO/Orphanet_3006
 Spondylocostal dysostosis 5	http://www.orpha.net/ORDO/Orphanet_364559
-HYPOMAGNESEMIA 6	http://purl.obolibrary.org/obo/HP_0002321	http://purl.obolibrary.org/obo/HP_0002315	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002917
+HYPOMAGNESEMIA 6	http://purl.obolibrary.org/obo/HP_0002321
 PROSTATE CANCER SUSCEPTIBILITY	http://www.ebi.ac.uk/efo/EFO_0001663
-Complement 1s deficiency	http://www.orpha.net/ORDO/Orphanet_308400	http://www.orpha.net/ORDO/Orphanet_308393	http://www.orpha.net/ORDO/Orphanet_308386
+Complement 1s deficiency	http://www.orpha.net/ORDO/Orphanet_308400
 Spastic paraplegia 15	http://purl.obolibrary.org/obo/HP_0001258
-BARRETT ESOPHAGUS/ESOPHAGEAL ADENOCARCINOMA	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0000280
+BARRETT ESOPHAGUS/ESOPHAGEAL ADENOCARCINOMA	http://www.ebi.ac.uk/efo/EFO_0000311
 Diffuse palmoplantar keratoderma	http://www.orpha.net/ORDO/Orphanet_307141
 NATIVE AMERICAN MYOPATHY	http://www.orpha.net/ORDO/Orphanet_168572
-HARTSFIELD SYNDROME	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0005466	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0000445	http://purl.obolibrary.org/obo/HP_0001360	http://purl.obolibrary.org/obo/HP_0002084	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000204	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0100335	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0000601	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0000873	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0000506	http://purl.obolibrary.org/obo/HP_0001159	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0008213	http://purl.obolibrary.org/obo/HP_0006501	http://purl.obolibrary.org/obo/HP_0003228	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0100596	http://purl.obolibrary.org/obo/HP_0001274	http://purl.obolibrary.org/obo/HP_0007370	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0001363	http://purl.obolibrary.org/obo/HP_0001171	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0008056	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0100257	http://purl.obolibrary.org/obo/HP_0006870	http://purl.obolibrary.org/obo/HP_0004408
+HARTSFIELD SYNDROME	http://purl.obolibrary.org/obo/HP_0000508
 Acrokeratosis verruciformis of Hopf	http://www.ebi.ac.uk/efo/EFO_1000666
 Autosomal recessive woolly hair 1	http://www.orpha.net/ORDO/Orphanet_170
-Parkinson disease 19	http://purl.obolibrary.org/obo/HP_0000571	http://purl.obolibrary.org/obo/HP_0007256	http://purl.obolibrary.org/obo/HP_0002067	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0003678	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002172	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001300	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002362
+Parkinson disease 19	http://purl.obolibrary.org/obo/HP_0000571
 Joubert syndrome 12/15	http://www.orpha.net/ORDO/Orphanet_475
-POSTERIOR COLUMN ATAXIA WITH RETINITIS PIGMENTOSA	http://purl.obolibrary.org/obo/HP_0012385	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0011463	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0010871	http://purl.obolibrary.org/obo/HP_0000575	http://purl.obolibrary.org/obo/HP_0003448	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0000020	http://purl.obolibrary.org/obo/HP_0002136	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0000550	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0000010	http://purl.obolibrary.org/obo/HP_0002166	http://purl.obolibrary.org/obo/HP_0002403	http://purl.obolibrary.org/obo/HP_0007737	http://purl.obolibrary.org/obo/HP_0002571	http://purl.obolibrary.org/obo/HP_0009473	http://purl.obolibrary.org/obo/HP_0002460
-CORNEA PLANA 2	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000540	http://purl.obolibrary.org/obo/HP_0100689	http://purl.obolibrary.org/obo/HP_0001084	http://purl.obolibrary.org/obo/HP_0007720
+POSTERIOR COLUMN ATAXIA WITH RETINITIS PIGMENTOSA	http://purl.obolibrary.org/obo/HP_0012385
+CORNEA PLANA 2	http://purl.obolibrary.org/obo/HP_0000007
 Amyotrophic lateral sclerosis 19	http://www.ebi.ac.uk/efo/EFO_0000253
 SPONDYLOEPIPHYSEAL DYSPLASIA TARDA	http://www.orpha.net/ORDO/Orphanet_93284
-DIAMOND-BLACKFAN ANEMIA 7	http://purl.obolibrary.org/obo/HP_0010487	http://purl.obolibrary.org/obo/HP_0005518	http://purl.obolibrary.org/obo/HP_0001636	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000076	http://purl.obolibrary.org/obo/HP_0001972	http://purl.obolibrary.org/obo/HP_0000085	http://purl.obolibrary.org/obo/HP_0001199
+DIAMOND-BLACKFAN ANEMIA 7	http://purl.obolibrary.org/obo/HP_0010487
 ADAMS-OLIVER SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_974
 FOCAL DERMAL HYPOPLASIA	http://www.orpha.net/ORDO/Orphanet_2092
 PELGER-HUET ANOMALY	http://www.ebi.ac.uk/efo/EFO_1001093
 Moyamoya disease 5	http://www.orpha.net/ORDO/Orphanet_2573
-Fetal hemoglobin quantitative trait locus 2	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001871
+Fetal hemoglobin quantitative trait locus 2	http://purl.obolibrary.org/obo/HP_0000006
 CEREBRAL CAVERNOUS MALFORMATIONS 1	http://www.orpha.net/ORDO/Orphanet_221061
-LEBER CONGENITAL AMAUROSIS 8	http://www.orpha.net/ORDO/Orphanet_65	http://www.orpha.net/ORDO/Orphanet_791
+LEBER CONGENITAL AMAUROSIS 8	http://www.orpha.net/ORDO/Orphanet_65
 Hypogonadotropic hypogonadism 7 with or without anosmia	http://www.orpha.net/ORDO/Orphanet_432
 Foveal hypoplasia and anterior segment dysgenesis	http://www.ebi.ac.uk/efo/EFO_0001059
-Macrocephaly	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0000455	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0000337	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0000256
-Neuropathy	http://purl.obolibrary.org/obo/HP_0009830	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0002445	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003701	http://purl.obolibrary.org/obo/HP_0003077	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0002398	http://purl.obolibrary.org/obo/HP_0002380	http://purl.obolibrary.org/obo/HP_0002378	http://purl.obolibrary.org/obo/HP_0003380	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0002171	http://purl.obolibrary.org/obo/HP_0007126	http://purl.obolibrary.org/obo/HP_0002936	http://purl.obolibrary.org/obo/HP_0008180
+Macrocephaly	http://purl.obolibrary.org/obo/HP_0000494
+Neuropathy	http://purl.obolibrary.org/obo/HP_0009830
 ERYTHROCYTE LACTATE TRANSPORTER DEFECT	http://www.orpha.net/ORDO/Orphanet_171690
-POLYCYSTIC KIDNEY DISEASE 2	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0000113
+POLYCYSTIC KIDNEY DISEASE 2	http://purl.obolibrary.org/obo/HP_0000006
 Severe congenital neutropenia 4	http://www.orpha.net/ORDO/Orphanet_42738
 Seizure disorder	http://www.ebi.ac.uk/efo/EFO_0000474
 APOE4(+)	http://www.ebi.ac.uk/efo/EFO_0000249
-ABCD SYNDROME	http://purl.obolibrary.org/obo/HP_0006958	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001520	http://purl.obolibrary.org/obo/HP_0002251	http://purl.obolibrary.org/obo/HP_0008513	http://purl.obolibrary.org/obo/HP_0001022	http://purl.obolibrary.org/obo/HP_0007894	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0008619
+ABCD SYNDROME	http://purl.obolibrary.org/obo/HP_0006958
 Dyschromatosis universalis hereditaria 3	http://www.orpha.net/ORDO/Orphanet_241
 Heart failure	http://www.ebi.ac.uk/efo/EFO_0003144
 Arrhythmia	http://www.ebi.ac.uk/efo/EFO_0004269
 UNIPOLAR DEPRESSION	http://www.ebi.ac.uk/efo/EFO_0003761
 NARCOLEPSY 1	http://www.ebi.ac.uk/efo/EFO_0000614
-CEREBRAL AMYLOID ANGIOPATHY	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0004372	http://purl.obolibrary.org/obo/HP_0004938	http://purl.obolibrary.org/obo/HP_0002514	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000708	http://purl.obolibrary.org/obo/HP_0003401	http://purl.obolibrary.org/obo/HP_0011970	http://purl.obolibrary.org/obo/HP_0004968	http://purl.obolibrary.org/obo/HP_0002170	http://purl.obolibrary.org/obo/HP_0002076	http://www.ebi.ac.uk/efo/EFO_0006790	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0001297	http://purl.obolibrary.org/obo/HP_0000726	http://purl.obolibrary.org/obo/HP_0011695	http://purl.obolibrary.org/obo/HP_0002637	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002354	http://purl.obolibrary.org/obo/HP_0004305	http://purl.obolibrary.org/obo/HP_0002376
+CEREBRAL AMYLOID ANGIOPATHY	http://purl.obolibrary.org/obo/HP_0008872
 OKT4 EPITOPE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0002843
 Weaver syndrome	http://www.orpha.net/ORDO/Orphanet_3447
 AFIBRINOGENEMIA	http://www.orpha.net/ORDO/Orphanet_98880
@@ -2465,19 +2465,19 @@ Duane syndrome type 2	http://www.orpha.net/ORDO/Orphanet_233
 Nanophthalmos 4	http://www.ebi.ac.uk/efo/EFO_0005569
 Peroxisome biogenesis disorder 11A	http://www.orpha.net/ORDO/Orphanet_79189
 Familial juvenile gout	http://www.ebi.ac.uk/efo/EFO_0004274
-PSEUDOXANTHOMA ELASTICUM	http://www.orpha.net/ORDO/Orphanet_758	http://www.orpha.net/ORDO/Orphanet_51608
+PSEUDOXANTHOMA ELASTICUM	http://www.orpha.net/ORDO/Orphanet_758
 BARDET-BIEDL SYNDROME 6/10	http://www.orpha.net/ORDO/Orphanet_110
 Nephronophthisis 16	http://www.orpha.net/ORDO/Orphanet_655
-CORNEAL DYSTROPHY AND PERCEPTIVE DEAFNESS	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001131	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0007759	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0000639
-Dementia	http://purl.obolibrary.org/obo/HP_0001115	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0000726	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0011970	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000709	http://purl.obolibrary.org/obo/HP_0002185
+CORNEAL DYSTROPHY AND PERCEPTIVE DEAFNESS	http://purl.obolibrary.org/obo/HP_0000007
+Dementia	http://purl.obolibrary.org/obo/HP_0001115
 HUNTINGTON DISEASE-LIKE 2	http://www.orpha.net/ORDO/Orphanet_98934
-Breast-ovarian cancer	http://www.orpha.net/ORDO/Orphanet_145	http://www.orpha.net/ORDO/Orphanet_319462	http://www.orpha.net/ORDO/Orphanet_227535
+Breast-ovarian cancer	http://www.orpha.net/ORDO/Orphanet_145
 Finnish congenital nephrotic syndrome	http://www.orpha.net/ORDO/Orphanet_839
 Corticosterone methyloxidase type 2 deficiency	http://www.orpha.net/ORDO/Orphanet_99763
 Scaphocephaly	http://www.orpha.net/ORDO/Orphanet_168624
 RETINITIS PIGMENTOSA 42	http://www.orpha.net/ORDO/Orphanet_791
 Levy-Hollister syndrome	http://www.orpha.net/ORDO/Orphanet_2363
-MUCOPOLYSACCHARIDOSIS	http://www.orpha.net/ORDO/Orphanet_584	http://www.orpha.net/ORDO/Orphanet_580	http://www.orpha.net/ORDO/Orphanet_217085	http://www.orpha.net/ORDO/Orphanet_79213
+MUCOPOLYSACCHARIDOSIS	http://www.orpha.net/ORDO/Orphanet_584
 Hypotrichosis simplex	http://www.orpha.net/ORDO/Orphanet_55654
 POLYGLUCOSAN BODY MYOPATHY 2	http://www.orpha.net/ORDO/Orphanet_397937
 LETHAL CONGENITAL CONTRACTURE SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_294965
@@ -2486,43 +2486,43 @@ Otospondylomegaepiphyseal dysplasia	http://www.orpha.net/ORDO/Orphanet_1427
 Emery-Dreifuss muscular dystrophy	http://www.orpha.net/ORDO/Orphanet_261
 Maple Syrup Urine Disease	http://www.orpha.net/ORDO/Orphanet_511
 Keratosis palmoplantaris striata 1	http://www.orpha.net/ORDO/Orphanet_50942
-Cone-rod dystrophy	http://purl.obolibrary.org/obo/HP_0000551	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0007994	http://purl.obolibrary.org/obo/HP_0000662	http://purl.obolibrary.org/obo/HP_0000533	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000548	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0001133
+Cone-rod dystrophy	http://purl.obolibrary.org/obo/HP_0000551
 WERNER SYNDROME	http://www.orpha.net/ORDO/Orphanet_902
-SPINOCEREBELLAR ATAXIA 5	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000317	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0007772	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0002075	http://purl.obolibrary.org/obo/HP_0000640	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0002495	http://purl.obolibrary.org/obo/HP_0002066
+SPINOCEREBELLAR ATAXIA 5	http://purl.obolibrary.org/obo/HP_0001347
 COWDEN SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_201
 RHIZOMELIC CHONDRODYSPLASIA PUNCTATA	http://www.orpha.net/ORDO/Orphanet_177
-MENTAL RETARDATION	http://www.ebi.ac.uk/efo/EFO_0003847	http://purl.obolibrary.org/obo/HP_0002021	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0000696	http://purl.obolibrary.org/obo/HP_0002714	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000708	http://purl.obolibrary.org/obo/HP_0000612	http://purl.obolibrary.org/obo/HP_0000219	http://www.orpha.net/ORDO/Orphanet_178469	http://purl.obolibrary.org/obo/HP_0000204	http://purl.obolibrary.org/obo/HP_0001640	http://purl.obolibrary.org/obo/HP_0002317	http://purl.obolibrary.org/obo/HP_0004325	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0000678	http://purl.obolibrary.org/obo/HP_0001419	http://www.orpha.net/ORDO/Orphanet_88616	http://purl.obolibrary.org/obo/HP_0000738	http://purl.obolibrary.org/obo/HP_0009062	http://purl.obolibrary.org/obo/HP_0001822	http://purl.obolibrary.org/obo/HP_0003477	http://purl.obolibrary.org/obo/HP_0000455	http://www.orpha.net/ORDO/Orphanet_3077	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0002173	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0000540	http://purl.obolibrary.org/obo/HP_0002373	http://purl.obolibrary.org/obo/HP_0011344	http://purl.obolibrary.org/obo/HP_0000581	http://purl.obolibrary.org/obo/HP_0000768	http://purl.obolibrary.org/obo/HP_0000189	http://purl.obolibrary.org/obo/HP_0002580	http://purl.obolibrary.org/obo/HP_0000709	http://purl.obolibrary.org/obo/HP_0000752	http://purl.obolibrary.org/obo/HP_0000331	http://purl.obolibrary.org/obo/HP_0100022	http://purl.obolibrary.org/obo/HP_0007359	http://purl.obolibrary.org/obo/HP_0000414	http://purl.obolibrary.org/obo/HP_0000739	http://purl.obolibrary.org/obo/HP_0001290	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0010721	http://purl.obolibrary.org/obo/HP_0001363	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0002194	http://purl.obolibrary.org/obo/HP_0100021	http://purl.obolibrary.org/obo/HP_0000275	http://purl.obolibrary.org/obo/HP_0007328	http://purl.obolibrary.org/obo/HP_0000717	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0000729	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0000664	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0001423	http://purl.obolibrary.org/obo/HP_0002510	http://purl.obolibrary.org/obo/HP_0002028	http://purl.obolibrary.org/obo/HP_0000646	http://purl.obolibrary.org/obo/HP_0001360	http://purl.obolibrary.org/obo/HP_0002209	http://purl.obolibrary.org/obo/HP_0002804	http://purl.obolibrary.org/obo/HP_0001298	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0001166	http://purl.obolibrary.org/obo/HP_0007018	http://purl.obolibrary.org/obo/HP_0100660	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0200134	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0001182	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000322	http://purl.obolibrary.org/obo/HP_0000964	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0002334	http://purl.obolibrary.org/obo/HP_0000232	http://purl.obolibrary.org/obo/HP_0005781	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0011220	http://www.orpha.net/ORDO/Orphanet_778	http://purl.obolibrary.org/obo/HP_0000324	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0000356	http://purl.obolibrary.org/obo/HP_0000649	http://purl.obolibrary.org/obo/HP_0001760	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0002389	http://purl.obolibrary.org/obo/HP_0005988	http://purl.obolibrary.org/obo/HP_0000179	http://purl.obolibrary.org/obo/HP_0002020	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0012745	http://purl.obolibrary.org/obo/HP_0000448	http://purl.obolibrary.org/obo/HP_0000378	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0002540	http://purl.obolibrary.org/obo/HP_0002098	http://purl.obolibrary.org/obo/HP_0006184	http://purl.obolibrary.org/obo/HP_0005484	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0012448	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0001195	http://purl.obolibrary.org/obo/HP_0001273	http://purl.obolibrary.org/obo/HP_0000308	http://purl.obolibrary.org/obo/HP_0002059	http://purl.obolibrary.org/obo/HP_0007758	http://purl.obolibrary.org/obo/HP_0000582	http://purl.obolibrary.org/obo/HP_0000527	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0000826	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0000341	http://purl.obolibrary.org/obo/HP_0011098	http://purl.obolibrary.org/obo/HP_0005274	http://purl.obolibrary.org/obo/HP_0001302	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000276	http://purl.obolibrary.org/obo/HP_0200105	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0005487	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002187	http://purl.obolibrary.org/obo/HP_0001519	http://purl.obolibrary.org/obo/HP_0010864	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0002521	http://purl.obolibrary.org/obo/HP_0006610	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0001357	http://purl.obolibrary.org/obo/HP_0000286	http://www.orpha.net/ORDO/Orphanet_1465	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001374	http://purl.obolibrary.org/obo/HP_0002069	http://purl.obolibrary.org/obo/HP_0001382	http://purl.obolibrary.org/obo/HP_0009183	http://purl.obolibrary.org/obo/HP_0002136	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0001417	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001956	http://purl.obolibrary.org/obo/HP_0000307	http://purl.obolibrary.org/obo/HP_0008619	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000748	http://purl.obolibrary.org/obo/HP_0001771	http://purl.obolibrary.org/obo/HP_0000742	http://purl.obolibrary.org/obo/HP_0001943	http://purl.obolibrary.org/obo/HP_0001833	http://purl.obolibrary.org/obo/HP_0001007	http://purl.obolibrary.org/obo/HP_0000053	http://purl.obolibrary.org/obo/HP_0100704	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0008070	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0000718	http://purl.obolibrary.org/obo/HP_0000280	http://www.orpha.net/ORDO/Orphanet_777	http://purl.obolibrary.org/obo/HP_0000400	http://purl.obolibrary.org/obo/HP_0000733	http://purl.obolibrary.org/obo/HP_0000713	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0200055	http://purl.obolibrary.org/obo/HP_0001531	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0004749	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0001266	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0002938	http://purl.obolibrary.org/obo/HP_0010055	http://purl.obolibrary.org/obo/HP_0000164	http://purl.obolibrary.org/obo/HP_0010804	http://purl.obolibrary.org/obo/HP_0000473	http://purl.obolibrary.org/obo/HP_0000490	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0000601	http://purl.obolibrary.org/obo/HP_0000430	http://purl.obolibrary.org/obo/HP_0000268	http://purl.obolibrary.org/obo/HP_0001264	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0200065	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0000319	http://purl.obolibrary.org/obo/HP_0000574	http://purl.obolibrary.org/obo/HP_0000294	http://purl.obolibrary.org/obo/HP_0000506	http://purl.obolibrary.org/obo/HP_0000426	http://purl.obolibrary.org/obo/HP_0200104	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000194	http://purl.obolibrary.org/obo/HP_0002719	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0000512	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0002360	http://purl.obolibrary.org/obo/HP_0002751	http://purl.obolibrary.org/obo/HP_0002365	http://purl.obolibrary.org/obo/HP_0000411	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001377	http://purl.obolibrary.org/obo/HP_0009179	http://purl.obolibrary.org/obo/HP_0002463	http://purl.obolibrary.org/obo/HP_0030260	http://purl.obolibrary.org/obo/HP_0002553	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0001629
-Charcot-Marie-Tooth disease type 2E	http://www.orpha.net/ORDO/Orphanet_640	http://www.orpha.net/ORDO/Orphanet_166	http://www.orpha.net/ORDO/Orphanet_101081
+MENTAL RETARDATION	http://www.ebi.ac.uk/efo/EFO_0003847
+Charcot-Marie-Tooth disease type 2E	http://www.orpha.net/ORDO/Orphanet_640
 Orofacial clefting	http://www.orpha.net/ORDO/Orphanet_139039
-KERATOSIS LINEARIS WITH ICHTHYOSIS CONGENITA AND SCLEROSING KERATODERMA	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007490	http://purl.obolibrary.org/obo/HP_0007479	http://purl.obolibrary.org/obo/HP_0001367	http://purl.obolibrary.org/obo/HP_0007465	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0008404	http://purl.obolibrary.org/obo/HP_0000982	http://purl.obolibrary.org/obo/HP_0001795	http://purl.obolibrary.org/obo/HP_0009775	http://purl.obolibrary.org/obo/HP_0001036
+KERATOSIS LINEARIS WITH ICHTHYOSIS CONGENITA AND SCLEROSING KERATODERMA	http://purl.obolibrary.org/obo/HP_0000007
 Glutaryl-CoA oxidase deficiency	http://www.orpha.net/ORDO/Orphanet_35706
-VITREORETINOPATHY	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0000512	http://purl.obolibrary.org/obo/HP_0007658	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0007902	http://purl.obolibrary.org/obo/HP_0000541	http://purl.obolibrary.org/obo/HP_0007778	http://purl.obolibrary.org/obo/HP_0000554
+VITREORETINOPATHY	http://purl.obolibrary.org/obo/HP_0000618
 KALLMANN SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_478
-Benign recurrent intrahepatic cholestasis 1	http://www.orpha.net/ORDO/Orphanet_172	http://www.orpha.net/ORDO/Orphanet_65682
-CONE-ROD DYSTROPHY 11	http://purl.obolibrary.org/obo/HP_0007924	http://purl.obolibrary.org/obo/HP_0000608	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000548	http://purl.obolibrary.org/obo/HP_0000613	http://purl.obolibrary.org/obo/HP_0011504	http://purl.obolibrary.org/obo/HP_0007401
-ERYTHRODERMA	http://purl.obolibrary.org/obo/HP_0000972	http://purl.obolibrary.org/obo/HP_0001019	http://purl.obolibrary.org/obo/HP_0000998	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001217
+Benign recurrent intrahepatic cholestasis 1	http://www.orpha.net/ORDO/Orphanet_172
+CONE-ROD DYSTROPHY 11	http://purl.obolibrary.org/obo/HP_0007924
+ERYTHRODERMA	http://purl.obolibrary.org/obo/HP_0000972
 Fragile X syndrome	http://www.orpha.net/ORDO/Orphanet_908
 LYMPHOMA	http://www.ebi.ac.uk/efo/EFO_0000574
-MITOCHONDRIAL COMPLEX III DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000582	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0002305	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000738	http://purl.obolibrary.org/obo/HP_0001618	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0002878	http://purl.obolibrary.org/obo/HP_0100259	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0002067	http://purl.obolibrary.org/obo/HP_0001903	http://www.orpha.net/ORDO/Orphanet_68380	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0040078	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0000709	http://purl.obolibrary.org/obo/HP_0000752	http://purl.obolibrary.org/obo/HP_0001942	http://purl.obolibrary.org/obo/HP_0001943	http://purl.obolibrary.org/obo/HP_0000739	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0000718	http://purl.obolibrary.org/obo/HP_0001285	http://purl.obolibrary.org/obo/HP_0002049	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0000664	http://purl.obolibrary.org/obo/HP_0001987	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0002180	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0002542	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0001254	http://purl.obolibrary.org/obo/HP_0003542	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0006554	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0002313	http://purl.obolibrary.org/obo/HP_0002075	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0002186	http://purl.obolibrary.org/obo/HP_0002465	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0000722	http://purl.obolibrary.org/obo/HP_0002071	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001993	http://purl.obolibrary.org/obo/HP_0002059
+MITOCHONDRIAL COMPLEX III DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000582
 Early infantile epileptic encephalopathy 13	http://www.orpha.net/ORDO/Orphanet_1934
 ACHROMATOPSIA 4	http://www.orpha.net/ORDO/Orphanet_49382
-SPERMATOGENIC FAILURE 12	http://purl.obolibrary.org/obo/HP_0000789	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000027
+SPERMATOGENIC FAILURE 12	http://purl.obolibrary.org/obo/HP_0000789
 Hereditary sensory and autonomic neuropathy type IIA	http://www.orpha.net/ORDO/Orphanet_140471
 Autosomal recessive congenital ichthyosis 4A	http://www.orpha.net/ORDO/Orphanet_281097
 HYDATIDIFORM MOLE	http://purl.obolibrary.org/obo/HP_0000007
-POLYMICROGYRIA	http://purl.obolibrary.org/obo/HP_0002136	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0002078	http://purl.obolibrary.org/obo/HP_0000565	http://purl.obolibrary.org/obo/HP_0011448	http://purl.obolibrary.org/obo/HP_0001249	http://www.orpha.net/ORDO/Orphanet_35981	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000577	http://www.orpha.net/ORDO/Orphanet_98889	http://purl.obolibrary.org/obo/HP_0006821	http://purl.obolibrary.org/obo/HP_0002365	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0007095	http://purl.obolibrary.org/obo/HP_0007266	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0000639
-INFLAMMATORY SKIN AND BOWEL DISEASE	http://purl.obolibrary.org/obo/HP_0100501	http://purl.obolibrary.org/obo/HP_0006532	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0200039	http://purl.obolibrary.org/obo/HP_0200034	http://purl.obolibrary.org/obo/HP_0000822
+POLYMICROGYRIA	http://purl.obolibrary.org/obo/HP_0002136
+INFLAMMATORY SKIN AND BOWEL DISEASE	http://purl.obolibrary.org/obo/HP_0100501
 NOONAN SYNDROME 10	http://www.orpha.net/ORDO/Orphanet_648
 BARDET-BIEDL SYNDROME 10	http://www.orpha.net/ORDO/Orphanet_110
-PHOSPHOGLYCERATE KINASE 1 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000712	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0000572	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0008305	http://purl.obolibrary.org/obo/HP_0003546	http://purl.obolibrary.org/obo/HP_0000556	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0001923	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001878	http://purl.obolibrary.org/obo/HP_0003201	http://purl.obolibrary.org/obo/HP_0003198	http://purl.obolibrary.org/obo/HP_0003710
+PHOSPHOGLYCERATE KINASE 1 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000712
 GLAUCOMA	http://www.ebi.ac.uk/efo/EFO_0000516
-AICARDI-GOUTIERES SYNDROME 6	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0002514	http://purl.obolibrary.org/obo/HP_0006957	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002415	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001878	http://purl.obolibrary.org/obo/HP_0002371	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0000639
-Immunodeficiency 8	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0000752	http://purl.obolibrary.org/obo/HP_0001888
+AICARDI-GOUTIERES SYNDROME 6	http://purl.obolibrary.org/obo/HP_0001337
+Immunodeficiency 8	http://purl.obolibrary.org/obo/HP_0000007
 Ataxia-telangiectasia syndrome	http://www.orpha.net/ORDO/Orphanet_100
-Aspartylglycosaminuria	http://purl.obolibrary.org/obo/HP_0001875	http://purl.obolibrary.org/obo/HP_0001369	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0002756	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001609	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0000670	http://purl.obolibrary.org/obo/HP_0002738	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0012068	http://purl.obolibrary.org/obo/HP_0002167	http://purl.obolibrary.org/obo/HP_0000157	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000212	http://purl.obolibrary.org/obo/HP_0001653	http://purl.obolibrary.org/obo/HP_0000768	http://purl.obolibrary.org/obo/HP_0100729	http://purl.obolibrary.org/obo/HP_0000926	http://purl.obolibrary.org/obo/HP_0100022	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0000053	http://purl.obolibrary.org/obo/HP_0001061	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0100790	http://purl.obolibrary.org/obo/HP_0001071	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0000943	http://purl.obolibrary.org/obo/HP_0000280	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0000388	http://purl.obolibrary.org/obo/HP_0002997	http://purl.obolibrary.org/obo/HP_0001388	http://purl.obolibrary.org/obo/HP_0000158	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0004568	http://purl.obolibrary.org/obo/HP_0001922	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0003302	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0002684	http://purl.obolibrary.org/obo/HP_0003304	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0000356	http://purl.obolibrary.org/obo/HP_0004493	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000179	http://purl.obolibrary.org/obo/HP_0002360	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0003103	http://purl.obolibrary.org/obo/HP_0002024	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0001376	http://purl.obolibrary.org/obo/HP_0002059	http://purl.obolibrary.org/obo/HP_0000283
+Aspartylglycosaminuria	http://purl.obolibrary.org/obo/HP_0001875
 Congenital disorder of glycosylation type 2B	http://www.orpha.net/ORDO/Orphanet_79330
 Worth disease	http://www.orpha.net/ORDO/Orphanet_2790
-DIARRHEA 7	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0003073	http://purl.obolibrary.org/obo/HP_0002243	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0003077
+DIARRHEA 7	http://purl.obolibrary.org/obo/HP_0002013
 Hypocalciuric hypercalcemia	http://www.orpha.net/ORDO/Orphanet_93372
 Transposition of great arteries	http://www.orpha.net/ORDO/Orphanet_216675
 Adenoma	http://www.ebi.ac.uk/efo/EFO_0000232
@@ -2530,17 +2530,17 @@ MEND syndrome	http://www.orpha.net/ORDO/Orphanet_401973
 ALLAN-HERNDON-DUDLEY SYNDROME	http://www.orpha.net/ORDO/Orphanet_59
 Hereditary angioedema type 1	http://www.orpha.net/ORDO/Orphanet_100050
 Osteogenesis imperfecta type 10	http://www.orpha.net/ORDO/Orphanet_666
-STEATOCYSTOMA MULTIPLEX	http://www.orpha.net/ORDO/Orphanet_2309	http://www.orpha.net/ORDO/Orphanet_841
-BETA-PLUS-THALASSEMIA	http://www.orpha.net/ORDO/Orphanet_231222	http://www.orpha.net/ORDO/Orphanet_231214	http://www.orpha.net/ORDO/Orphanet_848	http://www.orpha.net/ORDO/Orphanet_846
-Acute neuronopathic Gauchers disease	http://www.orpha.net/ORDO/Orphanet_77261	http://www.orpha.net/ORDO/Orphanet_77259	http://www.orpha.net/ORDO/Orphanet_355	http://www.orpha.net/ORDO/Orphanet_77260
+STEATOCYSTOMA MULTIPLEX	http://www.orpha.net/ORDO/Orphanet_2309
+BETA-PLUS-THALASSEMIA	http://www.orpha.net/ORDO/Orphanet_231222
+Acute neuronopathic Gauchers disease	http://www.orpha.net/ORDO/Orphanet_77261
 Hereditary diffuse gastric cancer	http://www.orpha.net/ORDO/Orphanet_26106
 RETINITIS PIGMENTOSA 49	http://www.orpha.net/ORDO/Orphanet_791
-Pigmentary retinal dystrophy	http://www.orpha.net/ORDO/Orphanet_52427	http://www.orpha.net/ORDO/Orphanet_71862
+Pigmentary retinal dystrophy	http://www.orpha.net/ORDO/Orphanet_52427
 IMMUNODEFICIENCY 44	http://purl.obolibrary.org/obo/HP_0002721
 Skeletal myopathy	http://purl.obolibrary.org/obo/HP_0003756
-GLYCOGEN STORAGE DISEASE XV	http://purl.obolibrary.org/obo/HP_0004308	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0011712	http://purl.obolibrary.org/obo/HP_0001324
-DYSTONIA 25	http://purl.obolibrary.org/obo/HP_0000473	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002451	http://purl.obolibrary.org/obo/HP_0012049
-OROFACIAL CLEFT 5	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000204
+GLYCOGEN STORAGE DISEASE XV	http://purl.obolibrary.org/obo/HP_0004308
+DYSTONIA 25	http://purl.obolibrary.org/obo/HP_0000473
+OROFACIAL CLEFT 5	http://purl.obolibrary.org/obo/HP_0000006
 Combined deficiency of factor V and factor VIII	http://www.orpha.net/ORDO/Orphanet_35909
 Tay-Sachs disease	http://www.orpha.net/ORDO/Orphanet_845
 Pseudohypoaldosteronism type 1 autosomal dominant	http://www.orpha.net/ORDO/Orphanet_756
@@ -2548,127 +2548,127 @@ Cerebral folate deficiency	http://www.ebi.ac.uk/efo/EFO_0001070
 ELLIPTOCYTOSIS 2	http://www.orpha.net/ORDO/Orphanet_288
 TUBEROUS SCLEROSIS 2	http://www.orpha.net/ORDO/Orphanet_805
 Hereditary acrodermatitis enteropathica	http://www.orpha.net/ORDO/Orphanet_37
-FETAL HEMOGLOBIN QUANTITATIVE TRAIT LOCUS 5	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001871
-Hereditary pancreatitis	http://www.orpha.net/ORDO/Orphanet_586	http://www.orpha.net/ORDO/Orphanet_48	http://www.orpha.net/ORDO/Orphanet_676
-Frontotemporal dementia and/or amyotrophic lateral sclerosis 3	http://www.orpha.net/ORDO/Orphanet_803	http://www.orpha.net/ORDO/Orphanet_275872	http://www.orpha.net/ORDO/Orphanet_275864
+FETAL HEMOGLOBIN QUANTITATIVE TRAIT LOCUS 5	http://purl.obolibrary.org/obo/HP_0000006
+Hereditary pancreatitis	http://www.orpha.net/ORDO/Orphanet_586
+Frontotemporal dementia and/or amyotrophic lateral sclerosis 3	http://www.orpha.net/ORDO/Orphanet_803
 BOWEN-CONRADI SYNDROME	http://www.orpha.net/ORDO/Orphanet_1270
-Arthrogryposis	http://purl.obolibrary.org/obo/HP_0002804	http://purl.obolibrary.org/obo/HP_0001339	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002611	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001385	http://purl.obolibrary.org/obo/HP_0000112	http://purl.obolibrary.org/obo/HP_0002908	http://purl.obolibrary.org/obo/HP_0001942	http://purl.obolibrary.org/obo/HP_0000121	http://purl.obolibrary.org/obo/HP_0000952	http://purl.obolibrary.org/obo/HP_0001947	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0200084	http://purl.obolibrary.org/obo/HP_0000340	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001884	http://purl.obolibrary.org/obo/HP_0009806	http://purl.obolibrary.org/obo/HP_0001629
+Arthrogryposis	http://purl.obolibrary.org/obo/HP_0002804
 Early infantile epileptic encephalopathy 10	http://www.orpha.net/ORDO/Orphanet_1934
 Arterial calcification of infancy	http://www.orpha.net/ORDO/Orphanet_51608
-FANCONI RENOTUBULAR SYNDROME 3	http://purl.obolibrary.org/obo/HP_0002748	http://purl.obolibrary.org/obo/HP_0003355	http://purl.obolibrary.org/obo/HP_0003109	http://purl.obolibrary.org/obo/HP_0000093	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0002979	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001942	http://purl.obolibrary.org/obo/HP_0003076
+FANCONI RENOTUBULAR SYNDROME 3	http://purl.obolibrary.org/obo/HP_0002748
 PROGRESSIVE EXTERNAL OPHTHALMOPLEGIA WITH MITOCHONDRIAL DNA DELETIONS	http://www.ebi.ac.uk/efo/EFO_0002509
 Progeria syndrome	http://purl.obolibrary.org/obo/HP_0011663
 Iron deposition in globus pallidus	http://purl.obolibrary.org/obo/HP_0001252
 BRAIN SMALL VESSEL DISEASE WITH HEMORRHAGE	http://www.orpha.net/ORDO/Orphanet_36383
-CONE-ROD DYSTROPHY 6	http://www.orpha.net/ORDO/Orphanet_1872	http://www.orpha.net/ORDO/Orphanet_65
-FUMARASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_523	http://www.orpha.net/ORDO/Orphanet_24
+CONE-ROD DYSTROPHY 6	http://www.orpha.net/ORDO/Orphanet_1872
+FUMARASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_523
 Pityriasis rubra pilaris	http://www.orpha.net/ORDO/Orphanet_2897
 Segawa syndrome	http://www.orpha.net/ORDO/Orphanet_101150
 Congenital stationary night blindness	http://www.orpha.net/ORDO/Orphanet_215
 Prune belly syndrome	http://www.orpha.net/ORDO/Orphanet_2970
 PREMATURE OVARIAN FAILURE 3	http://www.ebi.ac.uk/efo/EFO_0004266
-ATHEROSCLEROSIS	http://www.ebi.ac.uk/efo/EFO_0003914	http://www.ebi.ac.uk/efo/EFO_0000249
+ATHEROSCLEROSIS	http://www.ebi.ac.uk/efo/EFO_0003914
 SMITH-MCCORT DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_178355
 Glaucoma	http://www.ebi.ac.uk/efo/EFO_0000516
-HEPATOCELLULAR CARCINOMA	http://www.ebi.ac.uk/efo/EFO_0000182	http://www.ebi.ac.uk/efo/EFO_0001061	http://www.ebi.ac.uk/efo/EFO_0000365
+HEPATOCELLULAR CARCINOMA	http://www.ebi.ac.uk/efo/EFO_0000182
 Autosomal recessive hypophosphatemic vitamin D refractory rickets	http://www.orpha.net/ORDO/Orphanet_289176
-Dermodistortive urticaria	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001025	http://purl.obolibrary.org/obo/HP_0001041
-Globozoospermia	http://purl.obolibrary.org/obo/HP_0000789	http://purl.obolibrary.org/obo/HP_0012205
-HETEROTAXY	http://purl.obolibrary.org/obo/HP_0001669	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0011599	http://www.orpha.net/ORDO/Orphanet_450	http://purl.obolibrary.org/obo/HP_0011537	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0006695	http://purl.obolibrary.org/obo/HP_0003363
-Osteopetrosis autosomal dominant type 2	http://www.orpha.net/ORDO/Orphanet_2781	http://www.orpha.net/ORDO/Orphanet_53
+Dermodistortive urticaria	http://purl.obolibrary.org/obo/HP_0000006
+Globozoospermia	http://purl.obolibrary.org/obo/HP_0000789
+HETEROTAXY	http://purl.obolibrary.org/obo/HP_0001669
+Osteopetrosis autosomal dominant type 2	http://www.orpha.net/ORDO/Orphanet_2781
 MEGALENCEPHALIC LEUKOENCEPHALOPATHY WITH SUBCORTICAL CYSTS 1	http://www.orpha.net/ORDO/Orphanet_2478
 Brain malformation	http://purl.obolibrary.org/obo/HP_0001263
 Infantile nephronophthisis	http://www.orpha.net/ORDO/Orphanet_93591
-Chondrodysplasia	http://purl.obolibrary.org/obo/HP_0002789	http://purl.obolibrary.org/obo/HP_0008551	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0008786	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0004565	http://purl.obolibrary.org/obo/HP_0003177	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000311	http://purl.obolibrary.org/obo/HP_0001640	http://purl.obolibrary.org/obo/HP_0002092	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002002	http://purl.obolibrary.org/obo/HP_0000774	http://purl.obolibrary.org/obo/HP_0003021	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0002983	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0002645	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003175	http://purl.obolibrary.org/obo/HP_0000239	http://purl.obolibrary.org/obo/HP_0001591	http://purl.obolibrary.org/obo/HP_0003026	http://purl.obolibrary.org/obo/HP_0000773	http://purl.obolibrary.org/obo/HP_0002007
+Chondrodysplasia	http://purl.obolibrary.org/obo/HP_0002789
 HYPOCHONDROGENESIS	http://www.orpha.net/ORDO/Orphanet_93297
 Transient neonatal diabetes mellitus 1	http://www.orpha.net/ORDO/Orphanet_99886
-Merosin deficient congenital muscular dystrophy	http://www.orpha.net/ORDO/Orphanet_258	http://www.orpha.net/ORDO/Orphanet_97242
-Spinocerebellar ataxia 19	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0007944	http://purl.obolibrary.org/obo/HP_0002078	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002174	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0002396	http://purl.obolibrary.org/obo/HP_0007979	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002073	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0002066
-Epileptic encephalopathy Lennox-Gastaut type	http://purl.obolibrary.org/obo/HP_0006887	http://purl.obolibrary.org/obo/HP_0002280	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000348	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0011463	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000164	http://purl.obolibrary.org/obo/HP_0010804	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0006892	http://purl.obolibrary.org/obo/HP_0010864	http://purl.obolibrary.org/obo/HP_0002069	http://purl.obolibrary.org/obo/HP_0010819	http://purl.obolibrary.org/obo/HP_0002123	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0000212	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0002373	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002518	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0002121	http://purl.obolibrary.org/obo/HP_0002020	http://purl.obolibrary.org/obo/HP_0010818	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0006813	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000256
-IMMUNODEFICIENCY 23	http://purl.obolibrary.org/obo/HP_0001875	http://purl.obolibrary.org/obo/HP_0000793	http://purl.obolibrary.org/obo/HP_0040148	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0001888	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0000964	http://purl.obolibrary.org/obo/HP_0001878	http://purl.obolibrary.org/obo/HP_0002110	http://purl.obolibrary.org/obo/HP_0002099	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0200029	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003474	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0003193	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000407
+Merosin deficient congenital muscular dystrophy	http://www.orpha.net/ORDO/Orphanet_258
+Spinocerebellar ataxia 19	http://purl.obolibrary.org/obo/HP_0100543
+Epileptic encephalopathy Lennox-Gastaut type	http://purl.obolibrary.org/obo/HP_0006887
+IMMUNODEFICIENCY 23	http://purl.obolibrary.org/obo/HP_0001875
 Dyserythropoietic anemia with thrombocytopenia	http://www.ebi.ac.uk/efo/EFO_0004272
 Adams-Oliver syndrome 5	http://www.orpha.net/ORDO/Orphanet_974
 White sponge nevus of cannon	http://www.orpha.net/ORDO/Orphanet_171723
-Thyroid cancer	http://www.ebi.ac.uk/efo/EFO_0000501	http://www.ebi.ac.uk/efo/EFO_0003060	http://www.ebi.ac.uk/efo/EFO_0000365
+Thyroid cancer	http://www.ebi.ac.uk/efo/EFO_0000501
 PAROXYSMAL NOCTURNAL HEMOGLOBINURIA 1	http://www.orpha.net/ORDO/Orphanet_447
-Congenital cataract	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0000646	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0008024	http://purl.obolibrary.org/obo/HP_0000519	http://purl.obolibrary.org/obo/HP_0000613	http://purl.obolibrary.org/obo/HP_0000501	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0100018
-MICROPHTHALMIA	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000044	http://purl.obolibrary.org/obo/HP_0000662	http://purl.obolibrary.org/obo/HP_0011505	http://purl.obolibrary.org/obo/HP_0000348	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0000612	http://purl.obolibrary.org/obo/HP_0000204	http://purl.obolibrary.org/obo/HP_0001231	http://www.orpha.net/ORDO/Orphanet_98938	http://purl.obolibrary.org/obo/HP_0000171	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0100627	http://purl.obolibrary.org/obo/HP_0010469	http://purl.obolibrary.org/obo/HP_0000821	http://purl.obolibrary.org/obo/HP_0100259	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0012426	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0009600	http://purl.obolibrary.org/obo/HP_0005819	http://purl.obolibrary.org/obo/HP_0000540	http://purl.obolibrary.org/obo/HP_0012152	http://purl.obolibrary.org/obo/HP_0000921	http://purl.obolibrary.org/obo/HP_0001328	http://purl.obolibrary.org/obo/HP_0002342	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0002937	http://purl.obolibrary.org/obo/HP_0000193	http://purl.obolibrary.org/obo/HP_0009755	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0008323	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0002510	http://purl.obolibrary.org/obo/HP_0002948	http://purl.obolibrary.org/obo/HP_0001360	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0010627	http://purl.obolibrary.org/obo/HP_0004443	http://purl.obolibrary.org/obo/HP_0008050	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0000589	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0003316	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0003312	http://purl.obolibrary.org/obo/HP_0001000	http://purl.obolibrary.org/obo/HP_0000324	http://purl.obolibrary.org/obo/HP_0000835	http://purl.obolibrary.org/obo/HP_0006829	http://purl.obolibrary.org/obo/HP_0000541	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0001177	http://purl.obolibrary.org/obo/HP_0001274	http://purl.obolibrary.org/obo/HP_0000556	http://purl.obolibrary.org/obo/HP_0008417	http://purl.obolibrary.org/obo/HP_0002444	http://purl.obolibrary.org/obo/HP_0007737	http://purl.obolibrary.org/obo/HP_0007722	http://purl.obolibrary.org/obo/HP_0001263	http://www.ebi.ac.uk/efo/EFO_0005569	http://purl.obolibrary.org/obo/HP_0000826	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0006101	http://purl.obolibrary.org/obo/HP_0001144	http://purl.obolibrary.org/obo/HP_0000089	http://purl.obolibrary.org/obo/HP_0000134	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000864	http://purl.obolibrary.org/obo/HP_0007068	http://purl.obolibrary.org/obo/HP_0000609	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0011510	http://purl.obolibrary.org/obo/HP_0001357	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0030276	http://purl.obolibrary.org/obo/HP_0000902	http://purl.obolibrary.org/obo/HP_0000567	http://purl.obolibrary.org/obo/HP_0008572	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001770	http://purl.obolibrary.org/obo/HP_0002032	http://www.orpha.net/ORDO/Orphanet_65	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0005815	http://purl.obolibrary.org/obo/HP_0000493	http://purl.obolibrary.org/obo/HP_0002188	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0009623	http://purl.obolibrary.org/obo/HP_0008056	http://purl.obolibrary.org/obo/HP_0000830	http://purl.obolibrary.org/obo/HP_0000568	http://purl.obolibrary.org/obo/HP_0000400	http://purl.obolibrary.org/obo/HP_0007360	http://purl.obolibrary.org/obo/HP_0000278	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0008736	http://purl.obolibrary.org/obo/HP_0010999	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0000613	http://purl.obolibrary.org/obo/HP_0003319	http://purl.obolibrary.org/obo/HP_0000528	http://purl.obolibrary.org/obo/HP_0001264	http://purl.obolibrary.org/obo/HP_0010538	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0001830	http://purl.obolibrary.org/obo/HP_0008905	http://purl.obolibrary.org/obo/HP_0012687	http://purl.obolibrary.org/obo/HP_0000954	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0009909	http://purl.obolibrary.org/obo/HP_0007370	http://purl.obolibrary.org/obo/HP_0000772	http://purl.obolibrary.org/obo/HP_0000411	http://purl.obolibrary.org/obo/HP_0002575	http://purl.obolibrary.org/obo/HP_0000174	http://purl.obolibrary.org/obo/HP_0000591	http://purl.obolibrary.org/obo/HP_0000647	http://purl.obolibrary.org/obo/HP_0000048	http://purl.obolibrary.org/obo/HP_0001629
-PHOSPHOSERINE AMINOTRANSFERASE DEFICIENCY_x000B_	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0005484	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0012277	http://purl.obolibrary.org/obo/HP_0012279	http://purl.obolibrary.org/obo/HP_0001320
-Oligosynaptic infertility	http://purl.obolibrary.org/obo/HP_0000789	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001939
-Autism Spectrum Disorders	http://www.ebi.ac.uk/efo/EFO_0003756	http://www.ebi.ac.uk/efo/EFO_0000311
-Medulloblastoma	http://www.ebi.ac.uk/efo/EFO_0002939	http://www.ebi.ac.uk/efo/EFO_0000311
-Dejerine-Sottas disease	http://www.orpha.net/ORDO/Orphanet_64748	http://www.orpha.net/ORDO/Orphanet_166
+Congenital cataract	http://purl.obolibrary.org/obo/HP_0000007
+MICROPHTHALMIA	http://purl.obolibrary.org/obo/HP_0000272
+PHOSPHOSERINE AMINOTRANSFERASE DEFICIENCY_x000B_	http://purl.obolibrary.org/obo/HP_0000007
+Oligosynaptic infertility	http://purl.obolibrary.org/obo/HP_0000789
+Autism Spectrum Disorders	http://www.ebi.ac.uk/efo/EFO_0003756
+Medulloblastoma	http://www.ebi.ac.uk/efo/EFO_0002939
+Dejerine-Sottas disease	http://www.orpha.net/ORDO/Orphanet_64748
 Posterior polar cataract type 2	http://www.ebi.ac.uk/efo/EFO_0001059
-HYPOMAGNESEMIA 2	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0005567	http://purl.obolibrary.org/obo/HP_0002917
-Arrhythmogenic right ventricular dysplasia	http://purl.obolibrary.org/obo/HP_0004756	http://purl.obolibrary.org/obo/HP_0000006	http://www.orpha.net/ORDO/Orphanet_247	http://purl.obolibrary.org/obo/HP_0011710
+HYPOMAGNESEMIA 2	http://purl.obolibrary.org/obo/HP_0001250
+Arrhythmogenic right ventricular dysplasia	http://purl.obolibrary.org/obo/HP_0004756
 Homocysteinemia due to MTHFR deficiency	http://www.orpha.net/ORDO/Orphanet_395
 HYPOGONADOTROPIC HYPOGONADISM 20 WITHOUT ANOSMIA	http://www.orpha.net/ORDO/Orphanet_174590
 Lysosomal acid lipase deficiency	http://www.orpha.net/ORDO/Orphanet_275761
 Familial amyloid polyneuropathy	http://www.orpha.net/ORDO/Orphanet_85447
-CEROID LIPOFUSCINOSIS	http://purl.obolibrary.org/obo/HP_0003205	http://purl.obolibrary.org/obo/HP_0002312	http://purl.obolibrary.org/obo/HP_0001337	http://www.orpha.net/ORDO/Orphanet_228363	http://purl.obolibrary.org/obo/HP_0003208	http://purl.obolibrary.org/obo/HP_0000716	http://purl.obolibrary.org/obo/HP_0000543	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000648	http://www.orpha.net/ORDO/Orphanet_77292	http://purl.obolibrary.org/obo/HP_0000737	http://purl.obolibrary.org/obo/HP_0002074	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002133	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0010864	http://purl.obolibrary.org/obo/HP_0002878	http://purl.obolibrary.org/obo/HP_0001105	http://purl.obolibrary.org/obo/HP_0000618	http://purl.obolibrary.org/obo/HP_0002069	http://purl.obolibrary.org/obo/HP_0000711	http://purl.obolibrary.org/obo/HP_0007754	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0008765	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0000340	http://www.orpha.net/ORDO/Orphanet_228354	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0003226	http://purl.obolibrary.org/obo/HP_0000712	http://purl.obolibrary.org/obo/HP_0006887	http://purl.obolibrary.org/obo/HP_0003577	http://www.orpha.net/ORDO/Orphanet_79264	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0002180	http://purl.obolibrary.org/obo/HP_0002506	http://purl.obolibrary.org/obo/HP_0003678	http://purl.obolibrary.org/obo/HP_0001260	http://www.orpha.net/ORDO/Orphanet_168491	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0001300	http://purl.obolibrary.org/obo/HP_0002529	http://purl.obolibrary.org/obo/HP_0000252	http://www.orpha.net/ORDO/Orphanet_216	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003621	http://purl.obolibrary.org/obo/HP_0003657	http://www.orpha.net/ORDO/Orphanet_228360	http://purl.obolibrary.org/obo/HP_0002123	http://purl.obolibrary.org/obo/HP_0002367	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0000572	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000580	http://purl.obolibrary.org/obo/HP_0002384	http://purl.obolibrary.org/obo/HP_0002104	http://purl.obolibrary.org/obo/HP_0005458	http://purl.obolibrary.org/obo/HP_0001268	http://purl.obolibrary.org/obo/HP_0002360	http://www.orpha.net/ORDO/Orphanet_228329	http://purl.obolibrary.org/obo/HP_0000488	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0000726	http://purl.obolibrary.org/obo/HP_0002071	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0011504	http://www.orpha.net/ORDO/Orphanet_228349	http://purl.obolibrary.org/obo/HP_0002059
-Tetraamelia	http://purl.obolibrary.org/obo/HP_0002089	http://purl.obolibrary.org/obo/HP_0008697	http://purl.obolibrary.org/obo/HP_0000775	http://purl.obolibrary.org/obo/HP_0000104	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000003	http://purl.obolibrary.org/obo/HP_0000612	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000204	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000148	http://purl.obolibrary.org/obo/HP_0000068	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0005316	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0002023	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0002101	http://purl.obolibrary.org/obo/HP_0011743	http://purl.obolibrary.org/obo/HP_0006709	http://purl.obolibrary.org/obo/HP_0001746	http://purl.obolibrary.org/obo/HP_0000042	http://purl.obolibrary.org/obo/HP_0100589	http://purl.obolibrary.org/obo/HP_0002777	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0009827	http://purl.obolibrary.org/obo/HP_0001543	http://purl.obolibrary.org/obo/HP_0000453	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0009932	http://purl.obolibrary.org/obo/HP_0000356	http://purl.obolibrary.org/obo/HP_0100842	http://purl.obolibrary.org/obo/HP_0000202	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0100569	http://purl.obolibrary.org/obo/HP_0008839	http://purl.obolibrary.org/obo/HP_0000772	http://purl.obolibrary.org/obo/HP_0007370	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0009924	http://purl.obolibrary.org/obo/HP_0006703	http://purl.obolibrary.org/obo/HP_0000568	http://purl.obolibrary.org/obo/HP_0003057	http://purl.obolibrary.org/obo/HP_0001425	http://purl.obolibrary.org/obo/HP_0001195	http://purl.obolibrary.org/obo/HP_0001600	http://purl.obolibrary.org/obo/HP_0001561	http://purl.obolibrary.org/obo/HP_0004408
+CEROID LIPOFUSCINOSIS	http://purl.obolibrary.org/obo/HP_0003205
+Tetraamelia	http://purl.obolibrary.org/obo/HP_0002089
 Thrombocytosis	http://www.orpha.net/ORDO/Orphanet_71493
 Osteogenesis imperfecta type 7	http://www.orpha.net/ORDO/Orphanet_666
-NASOPHARYNGEAL CARCINOMA	http://www.ebi.ac.uk/efo/EFO_0004252	http://www.ebi.ac.uk/efo/EFO_1000058
+NASOPHARYNGEAL CARCINOMA	http://www.ebi.ac.uk/efo/EFO_0004252
 Proteinuria	http://purl.obolibrary.org/obo/HP_0000093
-IMMUNODEFICIENCY 31A	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002721
+IMMUNODEFICIENCY 31A	http://purl.obolibrary.org/obo/HP_0000006
 Combined deficiency of sialidase AND beta galactosidase	http://www.orpha.net/ORDO/Orphanet_351
 Wolfram syndrome	http://www.orpha.net/ORDO/Orphanet_3463
 3-Methylglutaconic aciduria type 2	http://www.orpha.net/ORDO/Orphanet_111
-MACULAR CORNEAL DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_34533	http://www.orpha.net/ORDO/Orphanet_98969
+MACULAR CORNEAL DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_34533
 Hereditary factor IX deficiency disease	http://www.orpha.net/ORDO/Orphanet_98879
-SPINOCEREBELLAR ATAXIA 28	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002395	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0000641	http://purl.obolibrary.org/obo/HP_0001300	http://purl.obolibrary.org/obo/HP_0000640	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0000514	http://purl.obolibrary.org/obo/HP_0000597
+SPINOCEREBELLAR ATAXIA 28	http://purl.obolibrary.org/obo/HP_0002070
 Progressive myositis ossificans	http://www.orpha.net/ORDO/Orphanet_337
-SPASTIC PARAPLEGIA 54	http://purl.obolibrary.org/obo/HP_0000020	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000506	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0002518	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000609	http://purl.obolibrary.org/obo/HP_0002607	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0007340
-Cleft palate	http://purl.obolibrary.org/obo/HP_0002187	http://purl.obolibrary.org/obo/HP_0000212	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0100335	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0011094	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0009102	http://purl.obolibrary.org/obo/HP_0200049
-KERATOSIS PALMOPLANTARIS STRIATA II	http://purl.obolibrary.org/obo/HP_0000982	http://purl.obolibrary.org/obo/HP_0000006
+SPASTIC PARAPLEGIA 54	http://purl.obolibrary.org/obo/HP_0000020
+Cleft palate	http://purl.obolibrary.org/obo/HP_0002187
+KERATOSIS PALMOPLANTARIS STRIATA II	http://purl.obolibrary.org/obo/HP_0000982
 Lumbar disc degeneration	http://www.ebi.ac.uk/efo/EFO_0004994
-ESTROGEN RESISTANCE	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0000786
+ESTROGEN RESISTANCE	http://purl.obolibrary.org/obo/HP_0000007
 Very long chain acyl-CoA dehydrogenase deficiency	http://www.orpha.net/ORDO/Orphanet_26793
 Complete combined 17-alpha-hydroxylase/17	http://www.orpha.net/ORDO/Orphanet_90793
-FANCONI ANEMIA	http://purl.obolibrary.org/obo/HP_0001875	http://purl.obolibrary.org/obo/HP_0000086	http://purl.obolibrary.org/obo/HP_0003974	http://www.orpha.net/ORDO/Orphanet_84	http://purl.obolibrary.org/obo/HP_0001876	http://purl.obolibrary.org/obo/HP_0000089	http://purl.obolibrary.org/obo/HP_0003214	http://purl.obolibrary.org/obo/HP_0002667	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0012210	http://purl.obolibrary.org/obo/HP_0002023	http://purl.obolibrary.org/obo/HP_0001896	http://purl.obolibrary.org/obo/HP_0009777	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0001915	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0003006	http://purl.obolibrary.org/obo/HP_0000085	http://purl.obolibrary.org/obo/HP_0002564	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0003241	http://purl.obolibrary.org/obo/HP_0009778	http://purl.obolibrary.org/obo/HP_0002885	http://purl.obolibrary.org/obo/HP_0002032	http://purl.obolibrary.org/obo/HP_0003213	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0000107	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0001172	http://purl.obolibrary.org/obo/HP_0000568	http://purl.obolibrary.org/obo/HP_0008551	http://purl.obolibrary.org/obo/HP_0000104	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0002863	http://purl.obolibrary.org/obo/HP_0003774	http://purl.obolibrary.org/obo/HP_0001909	http://purl.obolibrary.org/obo/HP_0000081	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0001017	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000815	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003220	http://purl.obolibrary.org/obo/HP_0030680	http://purl.obolibrary.org/obo/HP_0003221	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001000	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0009943	http://purl.obolibrary.org/obo/HP_0000957	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000126	http://purl.obolibrary.org/obo/HP_0002984	http://purl.obolibrary.org/obo/HP_0007565	http://purl.obolibrary.org/obo/HP_0002575	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0009942	http://purl.obolibrary.org/obo/HP_0005528	http://purl.obolibrary.org/obo/HP_0001629
+FANCONI ANEMIA	http://purl.obolibrary.org/obo/HP_0001875
 Gamma-aminobutyric acid transaminase deficiency	http://www.orpha.net/ORDO/Orphanet_2066
-OBESITY	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0011344	http://purl.obolibrary.org/obo/HP_0002591	http://www.ebi.ac.uk/efo/EFO_0001360	http://www.ebi.ac.uk/efo/EFO_0002614	http://www.ebi.ac.uk/efo/EFO_0000692	http://purl.obolibrary.org/obo/HP_0001513	http://www.ebi.ac.uk/efo/EFO_0001073	http://www.ebi.ac.uk/efo/EFO_0000195
-MACROCEPHALY	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0004325	http://purl.obolibrary.org/obo/HP_0000974	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001596	http://purl.obolibrary.org/obo/HP_0000815	http://purl.obolibrary.org/obo/HP_0000766	http://purl.obolibrary.org/obo/HP_0002110	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000973	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0040079	http://purl.obolibrary.org/obo/HP_0001382	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000212	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0008661	http://purl.obolibrary.org/obo/HP_0000280	http://purl.obolibrary.org/obo/HP_0000179	http://purl.obolibrary.org/obo/HP_0000954	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0000535	http://purl.obolibrary.org/obo/HP_0100540	http://purl.obolibrary.org/obo/HP_0008070	http://purl.obolibrary.org/obo/HP_0001620	http://purl.obolibrary.org/obo/HP_0003010
+OBESITY	http://purl.obolibrary.org/obo/HP_0000006
+MACROCEPHALY	http://purl.obolibrary.org/obo/HP_0000494
 Severe dystonia	http://purl.obolibrary.org/obo/HP_0001263
 Hyperphenylalaninemia due to tetrahydrobiopterin deficiency	http://www.orpha.net/ORDO/Orphanet_238583
 PEROXISOMAL BIOGENESIS DISORDER 3B	http://www.orpha.net/ORDO/Orphanet_79189
-Dilated cardiomyopathy 1DD	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318
+Dilated cardiomyopathy 1DD	http://www.ebi.ac.uk/efo/EFO_0000407
 Inflammatory skin and bowel disease	http://www.orpha.net/ORDO/Orphanet_294023
 HERMANSKY-PUDLAK SYNDROME 8	http://www.orpha.net/ORDO/Orphanet_79430
 Small cell lung cancer	http://www.ebi.ac.uk/efo/EFO_0000702
-INVASIVE PNEUMOCOCCAL DISEASE	http://purl.obolibrary.org/obo/HP_0005366	http://purl.obolibrary.org/obo/HP_0000668	http://purl.obolibrary.org/obo/HP_0000958	http://purl.obolibrary.org/obo/HP_0011065	http://purl.obolibrary.org/obo/HP_0002007
+INVASIVE PNEUMOCOCCAL DISEASE	http://purl.obolibrary.org/obo/HP_0005366
 SPINOCEREBELLAR ATAXIA 21	http://www.orpha.net/ORDO/Orphanet_98773
 Essential thrombocythemia	http://www.ebi.ac.uk/efo/EFO_0000479
-PEROXISOME BIOGENESIS DISORDER 5B	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0010571	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000657	http://purl.obolibrary.org/obo/HP_0002317	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0008167	http://purl.obolibrary.org/obo/HP_0001410	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0009046	http://purl.obolibrary.org/obo/HP_0000514	http://purl.obolibrary.org/obo/HP_0000639
+PEROXISOME BIOGENESIS DISORDER 5B	http://purl.obolibrary.org/obo/HP_0001337
 Troyer syndrome	http://www.orpha.net/ORDO/Orphanet_101000
-LONG QT SYNDROME 9	http://www.orpha.net/ORDO/Orphanet_768	http://purl.obolibrary.org/obo/HP_0001657
+LONG QT SYNDROME 9	http://www.orpha.net/ORDO/Orphanet_768
 Atrial septal defect 9	http://www.ebi.ac.uk/efo/EFO_1000825
-Dilated cardiomyopathy 1N	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000538
+Dilated cardiomyopathy 1N	http://www.ebi.ac.uk/efo/EFO_0000407
 Atrioventricular septal defect 2	http://www.orpha.net/ORDO/Orphanet_98722
 Hyperammonemia	http://purl.obolibrary.org/obo/HP_0001987
-Hypogonadotropic hypogonadism 8 with or without anosmia	http://www.orpha.net/ORDO/Orphanet_478	http://www.orpha.net/ORDO/Orphanet_432
+Hypogonadotropic hypogonadism 8 with or without anosmia	http://www.orpha.net/ORDO/Orphanet_478
 MANDIBULOFACIAL DYSOSTOSIS WITH ALOPECIA	http://www.orpha.net/ORDO/Orphanet_443995
 TRICHOHEPATOENTERIC SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_84064
 RETINITIS PIGMENTOSA WITHOUT SITUS INVERSUS	http://www.orpha.net/ORDO/Orphanet_791
-EHLERS-DANLOS-LIKE SYNDROME DUE TO TENASCIN-X DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001633	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0009830	http://purl.obolibrary.org/obo/HP_0002036	http://purl.obolibrary.org/obo/HP_0000076	http://purl.obolibrary.org/obo/HP_0003298	http://purl.obolibrary.org/obo/HP_0000974	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000963	http://purl.obolibrary.org/obo/HP_0001373	http://purl.obolibrary.org/obo/HP_0001578	http://purl.obolibrary.org/obo/HP_0009025	http://purl.obolibrary.org/obo/HP_0000061	http://purl.obolibrary.org/obo/HP_0003326	http://purl.obolibrary.org/obo/HP_0001382	http://purl.obolibrary.org/obo/HP_0000977	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003555	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0002829	http://purl.obolibrary.org/obo/HP_0003701	http://purl.obolibrary.org/obo/HP_0000813	http://purl.obolibrary.org/obo/HP_0002239	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0011675	http://purl.obolibrary.org/obo/HP_0002637	http://purl.obolibrary.org/obo/HP_0007126	http://purl.obolibrary.org/obo/HP_0001634	http://purl.obolibrary.org/obo/HP_0002621
+EHLERS-DANLOS-LIKE SYNDROME DUE TO TENASCIN-X DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001633
 MYOCLONIC EPILEPSY	http://www.ebi.ac.uk/efo/EFO_0000474
 Ichthyosis histrix	http://www.orpha.net/ORDO/Orphanet_79354
 Hajdu-Cheney syndrome	http://www.orpha.net/ORDO/Orphanet_955
-CD59 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0004818	http://purl.obolibrary.org/obo/HP_0001878	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0002922	http://purl.obolibrary.org/obo/HP_0003690
+CD59 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
 Renal dysplasia	http://www.orpha.net/ORDO/Orphanet_93108
 Lamellar ichthyosis	http://www.orpha.net/ORDO/Orphanet_313
 CHUDLEY-MCCULLOUGH SYNDROME	http://www.orpha.net/ORDO/Orphanet_314597
 DYSPROTHROMBINEMIA PROTHROMBIN HIMI-II	http://www.orpha.net/ORDO/Orphanet_325
 Bardet-Biedl syndrome 12	http://www.orpha.net/ORDO/Orphanet_110
-Ventricular fibrillation	http://www.ebi.ac.uk/efo/EFO_0004269	http://www.ebi.ac.uk/efo/EFO_0004287
-HOLOPROSENCEPHALY 3	http://www.orpha.net/ORDO/Orphanet_2286	http://www.orpha.net/ORDO/Orphanet_799	http://www.orpha.net/ORDO/Orphanet_2162
+Ventricular fibrillation	http://www.ebi.ac.uk/efo/EFO_0004269
+HOLOPROSENCEPHALY 3	http://www.orpha.net/ORDO/Orphanet_2286
 ALOPECIA UNIVERSALIS CONGENITA	http://www.orpha.net/ORDO/Orphanet_701
-Photosensitive trichothiodystrophy	http://www.orpha.net/ORDO/Orphanet_276258	http://www.orpha.net/ORDO/Orphanet_122302
+Photosensitive trichothiodystrophy	http://www.orpha.net/ORDO/Orphanet_276258
 Progressive sclerosing poliodystrophy	http://www.orpha.net/ORDO/Orphanet_726
 Pyogenic arthritis	http://www.orpha.net/ORDO/Orphanet_48104
 Serum calcium level	http://www.ebi.ac.uk/efo/EFO_0001063
-TENORIO SYNDROME	http://purl.obolibrary.org/obo/HP_0002312	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0000445	http://purl.obolibrary.org/obo/HP_0000270	http://purl.obolibrary.org/obo/HP_0000158	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000998	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000574	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000506	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0002090	http://purl.obolibrary.org/obo/HP_0002020	http://purl.obolibrary.org/obo/HP_0002104	http://purl.obolibrary.org/obo/HP_0001097	http://purl.obolibrary.org/obo/HP_0001943	http://purl.obolibrary.org/obo/HP_0000739	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0001279	http://purl.obolibrary.org/obo/HP_0100021	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0002003
+TENORIO SYNDROME	http://purl.obolibrary.org/obo/HP_0002312
 Congenital disorder of glycosylation type 1L	http://www.orpha.net/ORDO/Orphanet_79328
 NEMALINE MYOPATHY 5	http://www.orpha.net/ORDO/Orphanet_607
 HYPERCAROTENEMIA AND VITAMIN A DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_199285
@@ -2678,86 +2678,86 @@ Lymphoproliferative syndrome 2	http://www.orpha.net/ORDO/Orphanet_238510
 JUVENILE POLYPOSIS SYNDROME	http://www.orpha.net/ORDO/Orphanet_2929
 ALPORT SYNDROME	http://www.orpha.net/ORDO/Orphanet_88919
 Hereditary elliptocytosis	http://www.orpha.net/ORDO/Orphanet_288
-MYOPIA 22	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000545
+MYOPIA 22	http://purl.obolibrary.org/obo/HP_0007663
 Joubert syndrome 25	http://www.orpha.net/ORDO/Orphanet_475
 RETINITIS PIGMENTOSA 55	http://www.orpha.net/ORDO/Orphanet_791
-Amelogenesis imperfecta	http://purl.obolibrary.org/obo/HP_0006311	http://purl.obolibrary.org/obo/HP_0000705	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001417	http://www.orpha.net/ORDO/Orphanet_100032	http://purl.obolibrary.org/obo/HP_0000679
-BERNARD-SOULIER SYNDROME	http://purl.obolibrary.org/obo/HP_0000421	http://purl.obolibrary.org/obo/HP_0000132	http://purl.obolibrary.org/obo/HP_0006298	http://purl.obolibrary.org/obo/HP_0011877	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0004446	http://purl.obolibrary.org/obo/HP_0001878	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000967	http://purl.obolibrary.org/obo/HP_0000225	http://www.orpha.net/ORDO/Orphanet_274	http://purl.obolibrary.org/obo/HP_0001744
+Amelogenesis imperfecta	http://purl.obolibrary.org/obo/HP_0006311
+BERNARD-SOULIER SYNDROME	http://purl.obolibrary.org/obo/HP_0000421
 Charcot-Marie-Tooth disease dominant intermediate 3	http://www.orpha.net/ORDO/Orphanet_166
 Exudative vitreoretinopathy	http://www.orpha.net/ORDO/Orphanet_98668
 Retinitis pigmentosa 58	http://www.orpha.net/ORDO/Orphanet_791
 OPTIC ATROPHY 9	http://purl.obolibrary.org/obo/HP_0000648
-SPERMATOGENIC FAILURE 9	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0012205
+SPERMATOGENIC FAILURE 9	http://purl.obolibrary.org/obo/HP_0000007
 LEBER CONGENITAL AMAUROSIS 12	http://www.orpha.net/ORDO/Orphanet_65
 Osteopoikilosis with melorheostosis	http://www.orpha.net/ORDO/Orphanet_2485
 Flexed deformity	http://purl.obolibrary.org/obo/HP_0001762
 Spastic paraplegia 9	http://purl.obolibrary.org/obo/HP_0001258
 SHPRINTZEN-GOLDBERG SYNDROME	http://www.orpha.net/ORDO/Orphanet_2462
 Congenital erythropoietic porphyria	http://www.orpha.net/ORDO/Orphanet_79277
-Pneumothorax	http://purl.obolibrary.org/obo/HP_0002108	http://purl.obolibrary.org/obo/HP_0002103	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0000006
+Pneumothorax	http://purl.obolibrary.org/obo/HP_0002108
 Megaloblastic anemia	http://www.orpha.net/ORDO/Orphanet_49827
-Cone-rod dystrophy 18	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000603	http://purl.obolibrary.org/obo/HP_0000548	http://purl.obolibrary.org/obo/HP_0008001	http://purl.obolibrary.org/obo/HP_0011003
-BONE MINERAL DENSITY QUANTITATIVE TRAIT LOCUS 18	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0001423	http://purl.obolibrary.org/obo/HP_0000938
+Cone-rod dystrophy 18	http://purl.obolibrary.org/obo/HP_0000007
+BONE MINERAL DENSITY QUANTITATIVE TRAIT LOCUS 18	http://purl.obolibrary.org/obo/HP_0000939
 Deficiency of phosphoserine phosphatase	http://www.orpha.net/ORDO/Orphanet_79350
-Thyroid agenesis	http://purl.obolibrary.org/obo/HP_0000820	http://purl.obolibrary.org/obo/HP_0000958	http://purl.obolibrary.org/obo/HP_0000158	http://purl.obolibrary.org/obo/HP_0005990	http://purl.obolibrary.org/obo/HP_0001392	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0100028	http://purl.obolibrary.org/obo/HP_0003270	http://purl.obolibrary.org/obo/HP_0008191	http://purl.obolibrary.org/obo/HP_0001662	http://purl.obolibrary.org/obo/HP_0010318	http://purl.obolibrary.org/obo/HP_0001254	http://purl.obolibrary.org/obo/HP_0000157	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0002925	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0004491	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0002045	http://purl.obolibrary.org/obo/HP_0000853	http://purl.obolibrary.org/obo/HP_0001615	http://purl.obolibrary.org/obo/HP_0002360	http://purl.obolibrary.org/obo/HP_0000851	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0002904	http://purl.obolibrary.org/obo/HP_0000280	http://purl.obolibrary.org/obo/HP_0000235
-EHLERS-DANLOS SYNDROME	http://purl.obolibrary.org/obo/HP_0001659	http://www.orpha.net/ORDO/Orphanet_2953	http://purl.obolibrary.org/obo/HP_0001653	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0001388	http://purl.obolibrary.org/obo/HP_0001075	http://purl.obolibrary.org/obo/HP_0001848	http://purl.obolibrary.org/obo/HP_0000974	http://purl.obolibrary.org/obo/HP_0000963	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0002816	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0001634	http://purl.obolibrary.org/obo/HP_0000023	http://purl.obolibrary.org/obo/HP_0000977
-Alacrima	http://purl.obolibrary.org/obo/HP_0000522	http://purl.obolibrary.org/obo/HP_0000966	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000962	http://purl.obolibrary.org/obo/HP_0003474	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0002459	http://purl.obolibrary.org/obo/HP_0001611	http://purl.obolibrary.org/obo/HP_0009916	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0001278	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002571	http://purl.obolibrary.org/obo/HP_0000639
-Hypotrichosis 13	http://purl.obolibrary.org/obo/HP_0001006	http://purl.obolibrary.org/obo/HP_0002224
+Thyroid agenesis	http://purl.obolibrary.org/obo/HP_0000820
+EHLERS-DANLOS SYNDROME	http://purl.obolibrary.org/obo/HP_0001659
+Alacrima	http://purl.obolibrary.org/obo/HP_0000522
+Hypotrichosis 13	http://purl.obolibrary.org/obo/HP_0001006
 Robinow syndrome	http://www.orpha.net/ORDO/Orphanet_97360
 Malignant tumor of esophagus	http://www.ebi.ac.uk/efo/EFO_0000616
 CORTICAL MALFORMATIONS	http://www.orpha.net/ORDO/Orphanet_280640
-RHEUMATOID ARTHRITIS	http://www.ebi.ac.uk/efo/EFO_0000685	http://www.ebi.ac.uk/efo/EFO_0002690	http://www.ebi.ac.uk/efo/EFO_0003779
-Dystonia 5	http://www.orpha.net/ORDO/Orphanet_98808	http://www.orpha.net/ORDO/Orphanet_238583
+RHEUMATOID ARTHRITIS	http://www.ebi.ac.uk/efo/EFO_0000685
+Dystonia 5	http://www.orpha.net/ORDO/Orphanet_98808
 GALACTOSIALIDOSIS	http://www.orpha.net/ORDO/Orphanet_351
-IMMUNODEFICIENCY 17	http://purl.obolibrary.org/obo/HP_0001890	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0002242	http://purl.obolibrary.org/obo/HP_0000964	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0001508
+IMMUNODEFICIENCY 17	http://purl.obolibrary.org/obo/HP_0001890
 Supravalvar aortic stenosis	http://www.orpha.net/ORDO/Orphanet_3193
 Disproportionate tall stature	http://purl.obolibrary.org/obo/HP_0001519
 Hyperimmunoglobulin E syndrome	http://www.ebi.ac.uk/efo/EFO_0003775
 Cockayne syndrome type A	http://www.orpha.net/ORDO/Orphanet_191
 MICROCORNEA	http://www.orpha.net/ORDO/Orphanet_1871
-CONE-ROD DYSTROPHY 7	http://purl.obolibrary.org/obo/HP_0000551	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000548	http://purl.obolibrary.org/obo/HP_0012045	http://purl.obolibrary.org/obo/HP_0011504	http://purl.obolibrary.org/obo/HP_0000505
-Torsades de pointes	http://www.ebi.ac.uk/efo/EFO_0005307	http://www.ebi.ac.uk/efo/EFO_0004269
+CONE-ROD DYSTROPHY 7	http://purl.obolibrary.org/obo/HP_0000551
+Torsades de pointes	http://www.ebi.ac.uk/efo/EFO_0005307
 Early infantile epileptic encephalopathy 5	http://www.orpha.net/ORDO/Orphanet_1934
 BLEPHAROPHIMOSIS PTOSIS AND EPICANTHUS INVERSUS	http://www.orpha.net/ORDO/Orphanet_126
-IMMUNODEFICIENCY 24	http://purl.obolibrary.org/obo/HP_0030253	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0008348	http://purl.obolibrary.org/obo/HP_0001888	http://purl.obolibrary.org/obo/HP_0005364
+IMMUNODEFICIENCY 24	http://purl.obolibrary.org/obo/HP_0030253
 RETINITIS PIGMENTOSA 68	http://www.orpha.net/ORDO/Orphanet_791
-CARNITINE PALMITOYLTRANSFERASE II DEFICIENCY	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0001987	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0001403	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0001640	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002913	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003201	http://purl.obolibrary.org/obo/HP_0003326	http://purl.obolibrary.org/obo/HP_0001254	http://purl.obolibrary.org/obo/HP_0003198	http://purl.obolibrary.org/obo/HP_0003394	http://purl.obolibrary.org/obo/HP_0005943	http://purl.obolibrary.org/obo/HP_0001399	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0001943	http://purl.obolibrary.org/obo/HP_0003552	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0001985	http://purl.obolibrary.org/obo/HP_0011675	http://purl.obolibrary.org/obo/HP_0002017	http://purl.obolibrary.org/obo/HP_0002910
-Lissencephaly 6	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0001302	http://purl.obolibrary.org/obo/HP_0001339	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0002509	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001338	http://purl.obolibrary.org/obo/HP_0009879	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0000340	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002126
+CARNITINE PALMITOYLTRANSFERASE II DEFICIENCY	http://purl.obolibrary.org/obo/HP_0002013
+Lissencephaly 6	http://purl.obolibrary.org/obo/HP_0001347
 Peroxisome biogenesis disorder 7A	http://www.orpha.net/ORDO/Orphanet_79189
-PHEOCHROMOCYTOMA	http://www.ebi.ac.uk/efo/EFO_0000616	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0000621	http://www.ebi.ac.uk/efo/EFO_0000681	http://www.ebi.ac.uk/efo/EFO_0000239
+PHEOCHROMOCYTOMA	http://www.ebi.ac.uk/efo/EFO_0000616
 MIGRAINE	http://www.ebi.ac.uk/efo/EFO_0003821
-Mitochondrial myopathy	http://www.orpha.net/ORDO/Orphanet_206966	http://www.ebi.ac.uk/efo/EFO_0004145
-LESCH-NYHAN SYNDROME	http://www.orpha.net/ORDO/Orphanet_510	http://www.orpha.net/ORDO/Orphanet_79233
+Mitochondrial myopathy	http://www.orpha.net/ORDO/Orphanet_206966
+LESCH-NYHAN SYNDROME	http://www.orpha.net/ORDO/Orphanet_510
 DONNAI-BARROW SYNDROME	http://www.orpha.net/ORDO/Orphanet_2143
-PARAMYOTONIA CONGENITA/HYPERKALEMIC PERIODIC PARALYSIS	http://www.orpha.net/ORDO/Orphanet_682	http://www.orpha.net/ORDO/Orphanet_684
+PARAMYOTONIA CONGENITA/HYPERKALEMIC PERIODIC PARALYSIS	http://www.orpha.net/ORDO/Orphanet_682
 Desbuquois syndrome	http://www.orpha.net/ORDO/Orphanet_1425
-Palmoplantar keratoderma and woolly hair	http://purl.obolibrary.org/obo/HP_0002231	http://purl.obolibrary.org/obo/HP_0002224	http://purl.obolibrary.org/obo/HP_0002209	http://purl.obolibrary.org/obo/HP_0000982	http://purl.obolibrary.org/obo/HP_0000653	http://purl.obolibrary.org/obo/HP_0000535	http://purl.obolibrary.org/obo/HP_0040149
-Metachromatic leukodystrophy	http://www.orpha.net/ORDO/Orphanet_512	http://www.orpha.net/ORDO/Orphanet_309263	http://www.orpha.net/ORDO/Orphanet_309271
+Palmoplantar keratoderma and woolly hair	http://purl.obolibrary.org/obo/HP_0002231
+Metachromatic leukodystrophy	http://www.orpha.net/ORDO/Orphanet_512
 Marden-Walker syndrome	http://www.orpha.net/ORDO/Orphanet_2461
 RETINITIS PIGMENTOSA 11	http://www.orpha.net/ORDO/Orphanet_791
 Apparent mineralocorticoid excess	http://www.orpha.net/ORDO/Orphanet_320
 METHEMOGLOBINEMIA	http://www.orpha.net/ORDO/Orphanet_139373
 BLOOM SYNDROME	http://www.orpha.net/ORDO/Orphanet_125
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 8	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0002089	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0001522	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0003324
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 8	http://purl.obolibrary.org/obo/HP_0000007
 MEDULLARY CYSTIC KIDNEY DISEASE 2	http://www.orpha.net/ORDO/Orphanet_34149
 Parkinson disease 13	http://www.orpha.net/ORDO/Orphanet_2828
-Auditory neuropathy	http://www.ebi.ac.uk/efo/EFO_0001063	http://www.ebi.ac.uk/efo/EFO_0004149
-BOTHNIA RETINAL DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_85128	http://www.orpha.net/ORDO/Orphanet_52427
-Glucose-6-phosphate transport defect	http://www.orpha.net/ORDO/Orphanet_79258	http://www.orpha.net/ORDO/Orphanet_79259
-Congenital muscular dystrophy-dystroglycanopathy with mental retardation	http://www.ebi.ac.uk/efo/EFO_0003847	http://www.orpha.net/ORDO/Orphanet_97242	http://www.orpha.net/ORDO/Orphanet_263
-KERATOCONUS 1	http://www.orpha.net/ORDO/Orphanet_156071	http://www.orpha.net/ORDO/Orphanet_98973
-JERVELL AND LANGE-NIELSEN SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_768	http://www.orpha.net/ORDO/Orphanet_90647
+Auditory neuropathy	http://www.ebi.ac.uk/efo/EFO_0001063
+BOTHNIA RETINAL DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_85128
+Glucose-6-phosphate transport defect	http://www.orpha.net/ORDO/Orphanet_79258
+Congenital muscular dystrophy-dystroglycanopathy with mental retardation	http://www.ebi.ac.uk/efo/EFO_0003847
+KERATOCONUS 1	http://www.orpha.net/ORDO/Orphanet_156071
+JERVELL AND LANGE-NIELSEN SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_768
 Bare lymphocyte syndrome type 2	http://www.orpha.net/ORDO/Orphanet_572
-IMMUNODEFICIENCY WITH HYPER-IgM	http://purl.obolibrary.org/obo/HP_0001875	http://purl.obolibrary.org/obo/HP_0012115	http://purl.obolibrary.org/obo/HP_0004798	http://purl.obolibrary.org/obo/HP_0002720	http://purl.obolibrary.org/obo/HP_0002718	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0003496	http://purl.obolibrary.org/obo/HP_0002959	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0002716	http://purl.obolibrary.org/obo/HP_0000230	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0005419	http://purl.obolibrary.org/obo/HP_0002961	http://purl.obolibrary.org/obo/HP_0001878	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0004315	http://purl.obolibrary.org/obo/HP_0005479	http://purl.obolibrary.org/obo/HP_0010280	http://purl.obolibrary.org/obo/HP_0002849	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0002847	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0000031	http://purl.obolibrary.org/obo/HP_0200117
+IMMUNODEFICIENCY WITH HYPER-IgM	http://purl.obolibrary.org/obo/HP_0001875
 Myocardial infarction 1	http://www.ebi.ac.uk/efo/EFO_0000612
-Pyloric stenosis	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0005977	http://purl.obolibrary.org/obo/HP_0002021	http://purl.obolibrary.org/obo/HP_0002587	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001426
-Paragangliomas 3	http://purl.obolibrary.org/obo/HP_0003334	http://purl.obolibrary.org/obo/HP_0001011	http://purl.obolibrary.org/obo/HP_0001606	http://purl.obolibrary.org/obo/HP_0003001	http://purl.obolibrary.org/obo/HP_0000361	http://purl.obolibrary.org/obo/HP_0001676	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001686	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0001613	http://purl.obolibrary.org/obo/HP_0002640	http://purl.obolibrary.org/obo/HP_0001962	http://purl.obolibrary.org/obo/HP_0001673	http://purl.obolibrary.org/obo/HP_0001649	http://purl.obolibrary.org/obo/HP_0030074	http://purl.obolibrary.org/obo/HP_0000740	http://purl.obolibrary.org/obo/HP_0000975	http://purl.obolibrary.org/obo/HP_0002331	http://purl.obolibrary.org/obo/HP_0002377	http://purl.obolibrary.org/obo/HP_0006748	http://purl.obolibrary.org/obo/HP_0006737
-ECTODERMAL DYSPLASIA 11B	http://www.orpha.net/ORDO/Orphanet_79373	http://www.orpha.net/ORDO/Orphanet_248
+Pyloric stenosis	http://purl.obolibrary.org/obo/HP_0000006
+Paragangliomas 3	http://purl.obolibrary.org/obo/HP_0003334
+ECTODERMAL DYSPLASIA 11B	http://www.orpha.net/ORDO/Orphanet_79373
 CEREBELLAR ATAXIA AND MENTAL RETARDATION WITH QUADRUPEDAL LOCOMOTION 1	http://www.ebi.ac.uk/efo/EFO_0003847
 SMITH-LEMLI-OPITZ SYNDROME	http://www.orpha.net/ORDO/Orphanet_818
-Argininosuccinate Lyase Deficiency	http://purl.obolibrary.org/obo/HP_0003217	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0001951	http://purl.obolibrary.org/obo/HP_0001987	http://purl.obolibrary.org/obo/HP_0000737	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0009886	http://purl.obolibrary.org/obo/HP_0001395	http://purl.obolibrary.org/obo/HP_0002181	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001950	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001254	http://purl.obolibrary.org/obo/HP_0002038	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0005961	http://purl.obolibrary.org/obo/HP_0011362	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0003355	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0011359	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0003623	http://purl.obolibrary.org/obo/HP_0001259	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0003218
+Argininosuccinate Lyase Deficiency	http://purl.obolibrary.org/obo/HP_0003217
 Frontonasal dysplasia 2	http://www.orpha.net/ORDO/Orphanet_250
-FECHTNER SYNDROME	http://purl.obolibrary.org/obo/HP_0000421	http://purl.obolibrary.org/obo/HP_0000132	http://purl.obolibrary.org/obo/HP_0000093	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001892	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0008619	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003774	http://purl.obolibrary.org/obo/HP_0000123	http://purl.obolibrary.org/obo/HP_0002239	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0008264	http://purl.obolibrary.org/obo/HP_0000790	http://purl.obolibrary.org/obo/HP_0001757	http://purl.obolibrary.org/obo/HP_0002907	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0001977	http://purl.obolibrary.org/obo/HP_0001658	http://purl.obolibrary.org/obo/HP_0000519	http://purl.obolibrary.org/obo/HP_0001902	http://purl.obolibrary.org/obo/HP_0003010
+FECHTNER SYNDROME	http://purl.obolibrary.org/obo/HP_0000421
 PARKINSON DISEASE 8	http://www.ebi.ac.uk/efo/EFO_0002508
 MAST SYNDROME	http://www.orpha.net/ORDO/Orphanet_101001
 PIGMENTED PARAVENOUS CHORIORETINAL ATROPHY	http://www.orpha.net/ORDO/Orphanet_251295
@@ -2765,42 +2765,42 @@ Autoimmune thyroid disease 3	http://www.ebi.ac.uk/efo/EFO_0006812
 Mental retardation 21	http://www.ebi.ac.uk/efo/EFO_0003847
 Autosomal recessive congenital ichthyosis 2	http://www.orpha.net/ORDO/Orphanet_281097
 Achromatopsia 5	http://www.orpha.net/ORDO/Orphanet_49382
-AORTIC ANEURYSM	http://purl.obolibrary.org/obo/HP_0008034	http://purl.obolibrary.org/obo/HP_0001659	http://purl.obolibrary.org/obo/HP_0004942	http://purl.obolibrary.org/obo/HP_0004933	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0011834	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0001677	http://purl.obolibrary.org/obo/HP_0001647	http://purl.obolibrary.org/obo/HP_0002622	http://purl.obolibrary.org/obo/HP_0002647	http://purl.obolibrary.org/obo/HP_0001297	http://purl.obolibrary.org/obo/HP_0012180	http://purl.obolibrary.org/obo/HP_0005181
+AORTIC ANEURYSM	http://purl.obolibrary.org/obo/HP_0008034
 Familial porencephaly	http://www.orpha.net/ORDO/Orphanet_99810
 NEUROPSYCHIATRIC DISORDER AND EARLY-ONSET CATARACT	http://www.ebi.ac.uk/efo/EFO_0001059
-Acrofacial dysostosis	http://purl.obolibrary.org/obo/HP_0008551	http://purl.obolibrary.org/obo/HP_0002980	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000400	http://purl.obolibrary.org/obo/HP_0000327	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0008807	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0000453	http://purl.obolibrary.org/obo/HP_0004325
+Acrofacial dysostosis	http://purl.obolibrary.org/obo/HP_0008551
 Familial exudative vitreoretinopathy	http://www.orpha.net/ORDO/Orphanet_891
 ALPHA-1-ANTITRYPSIN DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_60
 Retinitis pigmentosa 59	http://www.orpha.net/ORDO/Orphanet_791
 Succinate-semialdehyde dehydrogenase deficiency	http://www.orpha.net/ORDO/Orphanet_22
 NEUTROPHIL IMMUNODEFICIENCY SYNDROME	http://www.orpha.net/ORDO/Orphanet_183707
-Immunodeficiency 22	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0012490	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002960
+Immunodeficiency 22	http://purl.obolibrary.org/obo/HP_0002014
 Hereditary C1 esterase inhibitor deficiency - dysfunctional factor	http://www.orpha.net/ORDO/Orphanet_100051
 INCLUSION BODY MYOPATHY 3	http://www.ebi.ac.uk/efo/EFO_0007323
 SPONDYLOEPIPHYSEAL DYSPLASIA WITH CONGENITAL JOINT DISLOCATIONS	http://www.orpha.net/ORDO/Orphanet_263463
 Syndromic X-linked mental retardation 16	http://www.ebi.ac.uk/efo/EFO_0003847
 ESOPHAGEAL CARCINOMA	http://www.ebi.ac.uk/efo/EFO_0002916
-ACHONDROPLASIA	http://www.orpha.net/ORDO/Orphanet_429	http://www.orpha.net/ORDO/Orphanet_15
-Sudden cardiac death	http://www.ebi.ac.uk/efo/EFO_0004278	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0004269	http://www.ebi.ac.uk/efo/EFO_0000538
-PROPROTEIN CONVERTASE 1/3 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0003745	http://purl.obolibrary.org/obo/HP_0000044	http://purl.obolibrary.org/obo/HP_0001513	http://purl.obolibrary.org/obo/HP_0000786	http://purl.obolibrary.org/obo/HP_0002024	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0012051	http://purl.obolibrary.org/obo/HP_0011473	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0008220
+ACHONDROPLASIA	http://www.orpha.net/ORDO/Orphanet_429
+Sudden cardiac death	http://www.ebi.ac.uk/efo/EFO_0004278
+PROPROTEIN CONVERTASE 1/3 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0003745
 Osteitis deformans	http://www.ebi.ac.uk/efo/EFO_0004261
-Oguchis disease	http://www.orpha.net/ORDO/Orphanet_75382	http://www.orpha.net/ORDO/Orphanet_791
-POLYCYTHEMIA VERA	http://www.ebi.ac.uk/efo/EFO_0002429	http://www.ebi.ac.uk/efo/EFO_0000222
-Hemoglobinopathy	http://www.orpha.net/ORDO/Orphanet_68364	http://www.orpha.net/ORDO/Orphanet_178330
-Microcephaly with mental retardation and digital anomalies	http://purl.obolibrary.org/obo/HP_0011451	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0004220	http://purl.obolibrary.org/obo/HP_0004692	http://purl.obolibrary.org/obo/HP_0000278	http://purl.obolibrary.org/obo/HP_0005780	http://purl.obolibrary.org/obo/HP_0001822	http://purl.obolibrary.org/obo/HP_0002943	http://purl.obolibrary.org/obo/HP_0000448	http://purl.obolibrary.org/obo/HP_0006216	http://purl.obolibrary.org/obo/HP_0000718	http://purl.obolibrary.org/obo/HP_0001249
+Oguchis disease	http://www.orpha.net/ORDO/Orphanet_75382
+POLYCYTHEMIA VERA	http://www.ebi.ac.uk/efo/EFO_0002429
+Hemoglobinopathy	http://www.orpha.net/ORDO/Orphanet_68364
+Microcephaly with mental retardation and digital anomalies	http://purl.obolibrary.org/obo/HP_0011451
 BRODY MYOPATHY	http://www.orpha.net/ORDO/Orphanet_53347
-Tyrosinase-negative oculocutaneous albinism	http://www.orpha.net/ORDO/Orphanet_79431	http://www.orpha.net/ORDO/Orphanet_79434
+Tyrosinase-negative oculocutaneous albinism	http://www.orpha.net/ORDO/Orphanet_79431
 DIEGO BLOOD GROUP ANTIGEN	http://www.orpha.net/ORDO/Orphanet_119669
 LARON SYNDROME WITH UNDETECTABLE SERUM GH-BINDING PROTEIN	http://www.orpha.net/ORDO/Orphanet_633
-Congenital dyserythropoietic anemia	http://www.orpha.net/ORDO/Orphanet_98873	http://www.orpha.net/ORDO/Orphanet_98869
-Giant axonal neuropathy	http://purl.obolibrary.org/obo/HP_0003376	http://purl.obolibrary.org/obo/HP_0006886	http://purl.obolibrary.org/obo/HP_0001638	http://purl.obolibrary.org/obo/HP_0003431	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0006937	http://purl.obolibrary.org/obo/HP_0003444	http://purl.obolibrary.org/obo/HP_0003383	http://purl.obolibrary.org/obo/HP_0003693	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003477	http://purl.obolibrary.org/obo/HP_0001765	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0002460	http://www.orpha.net/ORDO/Orphanet_643	http://purl.obolibrary.org/obo/HP_0001761
-CAPILLARY MALFORMATION-ARTERIOVENOUS MALFORMATION	http://purl.obolibrary.org/obo/HP_0005306	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0100026
+Congenital dyserythropoietic anemia	http://www.orpha.net/ORDO/Orphanet_98873
+Giant axonal neuropathy	http://purl.obolibrary.org/obo/HP_0003376
+CAPILLARY MALFORMATION-ARTERIOVENOUS MALFORMATION	http://purl.obolibrary.org/obo/HP_0005306
 Dilated cardiomyopathy 1FF	http://www.ebi.ac.uk/efo/EFO_0000407
 EPIDERMODYSPLASIA VERRUCIFORMIS	http://www.orpha.net/ORDO/Orphanet_302
 Epithelial recurrent erosion dystrophy	http://www.orpha.net/ORDO/Orphanet_293381
 Alveolar capillary dysplasia with misalignment of pulmonary veins	http://www.orpha.net/ORDO/Orphanet_210122
 Myoclonic dystonia	http://www.orpha.net/ORDO/Orphanet_36899
-Cortisone reductase deficiency 2	http://purl.obolibrary.org/obo/HP_0005616	http://purl.obolibrary.org/obo/HP_0000855	http://purl.obolibrary.org/obo/HP_0001513	http://purl.obolibrary.org/obo/HP_0000956	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0012411
+Cortisone reductase deficiency 2	http://purl.obolibrary.org/obo/HP_0005616
 Aarskog syndrome	http://www.orpha.net/ORDO/Orphanet_915
 APOLIPOPROTEIN A-I DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_425
 Polyendocrine-polyneuropathy syndrome	http://www.orpha.net/ORDO/Orphanet_453533
@@ -2808,14 +2808,14 @@ PREECLAMPSIA/ECLAMPSIA 5	http://www.ebi.ac.uk/efo/EFO_0000668
 Adult neuronal ceroid lipofuscinosis	http://www.orpha.net/ORDO/Orphanet_79262
 Attention deficit hyperactivity disorder	http://www.ebi.ac.uk/efo/EFO_0003888
 SHORT-RIB THORACIC DYSPLASIA 10 WITHOUT POLYDACTYLY	http://www.orpha.net/ORDO/Orphanet_2913
-Thoracic aortic aneurysms and dissections	http://www.ebi.ac.uk/efo/EFO_0001666	http://www.ebi.ac.uk/efo/EFO_0004282
+Thoracic aortic aneurysms and dissections	http://www.ebi.ac.uk/efo/EFO_0001666
 Hypohidrotic X-linked ectodermal dysplasia	http://www.orpha.net/ORDO/Orphanet_181
-BRONCHIECTASIS WITH OR WITHOUT ELEVATED SWEAT CHLORIDE 3	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002110	http://purl.obolibrary.org/obo/HP_0004469
+BRONCHIECTASIS WITH OR WITHOUT ELEVATED SWEAT CHLORIDE 3	http://purl.obolibrary.org/obo/HP_0000006
 epileptic encephalopathy	http://www.ebi.ac.uk/efo/EFO_0000474
-Congenital bilateral absence of the vas deferens	http://www.orpha.net/ORDO/Orphanet_586	http://www.orpha.net/ORDO/Orphanet_48
-IMMUNODEFICIENCY 37	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004313	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0002383	http://purl.obolibrary.org/obo/HP_0002719
-ACTH-INDEPENDENT MACRONODULAR ADRENAL HYPERPLASIA 2	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0008231	http://purl.obolibrary.org/obo/HP_0012743	http://purl.obolibrary.org/obo/HP_0000311	http://purl.obolibrary.org/obo/HP_0003074
-ROTHMUND-THOMSON SYNDROME	http://www.orpha.net/ORDO/Orphanet_3021	http://www.orpha.net/ORDO/Orphanet_2909
+Congenital bilateral absence of the vas deferens	http://www.orpha.net/ORDO/Orphanet_586
+IMMUNODEFICIENCY 37	http://purl.obolibrary.org/obo/HP_0001250
+ACTH-INDEPENDENT MACRONODULAR ADRENAL HYPERPLASIA 2	http://purl.obolibrary.org/obo/HP_0000939
+ROTHMUND-THOMSON SYNDROME	http://www.orpha.net/ORDO/Orphanet_3021
 Christianson syndrome	http://www.orpha.net/ORDO/Orphanet_85278
 LETHAL CONGENITAL CONTRACTURE SYNDROME 7	http://www.orpha.net/ORDO/Orphanet_294965
 Congenital glucose-galactose malabsorption	http://www.orpha.net/ORDO/Orphanet_35710
@@ -2828,128 +2828,128 @@ RUBINSTEIN-TAYBI SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_783
 Age-related macular degeneration 6	http://www.ebi.ac.uk/efo/EFO_0001365
 Distal arthrogryposis type 8	http://www.orpha.net/ORDO/Orphanet_65743
 Mitochondrial encephalomyopathy	http://www.orpha.net/ORDO/Orphanet_68380
-Citrullinemia type II	http://www.orpha.net/ORDO/Orphanet_247585	http://www.orpha.net/ORDO/Orphanet_247598
+Citrullinemia type II	http://www.orpha.net/ORDO/Orphanet_247585
 ODONTOHYPOPHOSPHATASIA	http://www.orpha.net/ORDO/Orphanet_247685
 Coxa plana	http://www.ebi.ac.uk/efo/EFO_0007341
-Epidermal nevus syndrome	http://www.orpha.net/ORDO/Orphanet_35125	http://www.orpha.net/ORDO/Orphanet_3071
-Choroid plexus papilloma	http://www.ebi.ac.uk/efo/EFO_1000177	http://www.ebi.ac.uk/efo/EFO_0000637
-IMMUNODEFICIENCY 31C	http://purl.obolibrary.org/obo/HP_0002728	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0001888	http://purl.obolibrary.org/obo/HP_0001890	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0000819	http://purl.obolibrary.org/obo/HP_0000964	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0002958	http://purl.obolibrary.org/obo/HP_0000821	http://purl.obolibrary.org/obo/HP_0011473	http://purl.obolibrary.org/obo/HP_0000823
-Epilepsy with grand mal seizures on awakening	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0002123	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002121	http://purl.obolibrary.org/obo/HP_0002352	http://purl.obolibrary.org/obo/HP_0001138	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001123	http://purl.obolibrary.org/obo/HP_0007193	http://purl.obolibrary.org/obo/HP_0002315	http://purl.obolibrary.org/obo/HP_0000532	http://purl.obolibrary.org/obo/HP_0002066
+Epidermal nevus syndrome	http://www.orpha.net/ORDO/Orphanet_35125
+Choroid plexus papilloma	http://www.ebi.ac.uk/efo/EFO_1000177
+IMMUNODEFICIENCY 31C	http://purl.obolibrary.org/obo/HP_0002728
+Epilepsy with grand mal seizures on awakening	http://purl.obolibrary.org/obo/HP_0002070
 Autosomal dominant isolated somatotropin deficiency	http://www.orpha.net/ORDO/Orphanet_231679
-ADENYLATE KINASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001878	http://purl.obolibrary.org/obo/HP_0000007
+ADENYLATE KINASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001878
 Leucine-induced hypoglycemia	http://www.ebi.ac.uk/efo/EFO_0006856
-NOONAN SYNDROME 5	http://www.orpha.net/ORDO/Orphanet_500	http://www.orpha.net/ORDO/Orphanet_648
-Autosomal dominant hypohidrotic ectodermal dysplasia	http://www.orpha.net/ORDO/Orphanet_1810	http://www.orpha.net/ORDO/Orphanet_79373
-CHARGE association	http://www.orpha.net/ORDO/Orphanet_478	http://www.orpha.net/ORDO/Orphanet_174590	http://www.orpha.net/ORDO/Orphanet_138
+NOONAN SYNDROME 5	http://www.orpha.net/ORDO/Orphanet_500
+Autosomal dominant hypohidrotic ectodermal dysplasia	http://www.orpha.net/ORDO/Orphanet_1810
+CHARGE association	http://www.orpha.net/ORDO/Orphanet_478
 SPASTIC PARAPLEGIA 4	http://www.orpha.net/ORDO/Orphanet_100985
 Shprintzen syndrome	http://www.orpha.net/ORDO/Orphanet_567
-Fibrosis of extraocular muscles	http://purl.obolibrary.org/obo/HP_0007867	http://purl.obolibrary.org/obo/HP_0001491	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0009891	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002553	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0007911	http://purl.obolibrary.org/obo/HP_0001249
+Fibrosis of extraocular muscles	http://purl.obolibrary.org/obo/HP_0007867
 Vesicoureteral reflux 8	http://www.ebi.ac.uk/efo/EFO_0007536
-Myoglobinuria	http://purl.obolibrary.org/obo/HP_0003200	http://purl.obolibrary.org/obo/HP_0003652	http://purl.obolibrary.org/obo/HP_0001427	http://purl.obolibrary.org/obo/HP_0008305
-SPINAL MUSCULAR ATROPHY	http://purl.obolibrary.org/obo/HP_0002398	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0003457	http://www.orpha.net/ORDO/Orphanet_140450	http://purl.obolibrary.org/obo/HP_0002378	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0009027	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0001308	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0001761	http://www.orpha.net/ORDO/Orphanet_206713	http://purl.obolibrary.org/obo/HP_0007269
+Myoglobinuria	http://purl.obolibrary.org/obo/HP_0003200
+SPINAL MUSCULAR ATROPHY	http://purl.obolibrary.org/obo/HP_0002398
 Beta-houston-thalassemia	http://www.orpha.net/ORDO/Orphanet_848
 RETINITIS PIGMENTOSA 10	http://www.orpha.net/ORDO/Orphanet_791
 Deficiency of acetyl-CoA acetyltransferase	http://www.orpha.net/ORDO/Orphanet_590
 Pyruvate dehydrogenase lipoic acid synthetase deficiency	http://www.orpha.net/ORDO/Orphanet_401859
-ZIMMERMANN-LABAND SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_3473	http://www.orpha.net/ORDO/Orphanet_420561
+ZIMMERMANN-LABAND SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_3473
 Tooth agenesis	http://www.ebi.ac.uk/efo/EFO_0005410
-Adult junctional epidermolysis bullosa	http://www.orpha.net/ORDO/Orphanet_89843	http://www.orpha.net/ORDO/Orphanet_305
+Adult junctional epidermolysis bullosa	http://www.orpha.net/ORDO/Orphanet_89843
 CATARACT 6	http://www.ebi.ac.uk/efo/EFO_0001059
 Early onset focal segmental glomerulosclerosis	http://purl.obolibrary.org/obo/HP_0001263
 Myotonic dystrophy-like myopathy	http://www.ebi.ac.uk/efo/EFO_0004145
-HEMOCHROMATOSIS	http://purl.obolibrary.org/obo/HP_0000044	http://www.orpha.net/ORDO/Orphanet_139491	http://www.ebi.ac.uk/efo/EFO_1000642	http://purl.obolibrary.org/obo/HP_0003281	http://purl.obolibrary.org/obo/HP_0001394	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001638	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0003452	http://purl.obolibrary.org/obo/HP_0000953	http://purl.obolibrary.org/obo/HP_0011031	http://purl.obolibrary.org/obo/HP_0011462	http://www.orpha.net/ORDO/Orphanet_123411
-SPASTIC PARAPLEGIA 42	http://purl.obolibrary.org/obo/HP_0002395	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0002064	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0001761
-Familial cancer of breast	http://www.orpha.net/ORDO/Orphanet_227535	http://www.orpha.net/ORDO/Orphanet_145	http://www.orpha.net/ORDO/Orphanet_319462
-LEUKODYSTROPHY	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0000582	http://purl.obolibrary.org/obo/HP_0001583	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0007220	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002187	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001328	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0003390	http://purl.obolibrary.org/obo/HP_0002599	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0003429	http://purl.obolibrary.org/obo/HP_0001266	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0001249	http://www.orpha.net/ORDO/Orphanet_68356	http://purl.obolibrary.org/obo/HP_0000164	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0002415	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0002191	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0003431	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0002104	http://purl.obolibrary.org/obo/HP_0002313	http://purl.obolibrary.org/obo/HP_0002540	http://purl.obolibrary.org/obo/HP_0003745	http://purl.obolibrary.org/obo/HP_0002465	http://purl.obolibrary.org/obo/HP_0005484	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0002071	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0003623	http://purl.obolibrary.org/obo/HP_0010628	http://purl.obolibrary.org/obo/HP_0006808	http://purl.obolibrary.org/obo/HP_0002059
-HENNEKAM LYMPHANGIECTASIA-LYMPHEDEMA SYNDROME	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0010554	http://purl.obolibrary.org/obo/HP_0000086	http://purl.obolibrary.org/obo/HP_0005183	http://purl.obolibrary.org/obo/HP_0001302	http://purl.obolibrary.org/obo/HP_0006531	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000076	http://purl.obolibrary.org/obo/HP_0000501	http://purl.obolibrary.org/obo/HP_0001698	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0000085	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0004279	http://purl.obolibrary.org/obo/HP_0000212	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0002035	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0002243	http://purl.obolibrary.org/obo/HP_0000189	http://purl.obolibrary.org/obo/HP_0000337	http://purl.obolibrary.org/obo/HP_0000677	http://purl.obolibrary.org/obo/HP_0000752	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0001007	http://purl.obolibrary.org/obo/HP_0001004	http://purl.obolibrary.org/obo/HP_0008229	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0011065	http://purl.obolibrary.org/obo/HP_0002593	http://purl.obolibrary.org/obo/HP_0000278	http://purl.obolibrary.org/obo/HP_0200055	http://purl.obolibrary.org/obo/HP_0003073	http://purl.obolibrary.org/obo/HP_0012385	http://purl.obolibrary.org/obo/HP_0004440	http://purl.obolibrary.org/obo/HP_0002866	http://purl.obolibrary.org/obo/HP_0007598	http://purl.obolibrary.org/obo/HP_0003298	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000684	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001773	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0012368	http://purl.obolibrary.org/obo/HP_0000319	http://purl.obolibrary.org/obo/HP_0001055	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000126	http://purl.obolibrary.org/obo/HP_0001530	http://purl.obolibrary.org/obo/HP_0100539	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0009473	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0002202	http://purl.obolibrary.org/obo/HP_0001629
+HEMOCHROMATOSIS	http://purl.obolibrary.org/obo/HP_0000044
+SPASTIC PARAPLEGIA 42	http://purl.obolibrary.org/obo/HP_0002395
+Familial cancer of breast	http://www.orpha.net/ORDO/Orphanet_227535
+LEUKODYSTROPHY	http://purl.obolibrary.org/obo/HP_0001371
+HENNEKAM LYMPHANGIECTASIA-LYMPHEDEMA SYNDROME	http://purl.obolibrary.org/obo/HP_0000272
 Charcot-Marie-Tooth disease type 2B	http://www.orpha.net/ORDO/Orphanet_166
 CONE-ROD DYSTROPHY 13	http://www.orpha.net/ORDO/Orphanet_1872
-WAARDENBURG SYNDROME	http://purl.obolibrary.org/obo/HP_0002226	http://purl.obolibrary.org/obo/HP_0007990	http://purl.obolibrary.org/obo/HP_0002216	http://purl.obolibrary.org/obo/HP_0000664	http://purl.obolibrary.org/obo/HP_0002227	http://purl.obolibrary.org/obo/HP_0000458	http://purl.obolibrary.org/obo/HP_0001022	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0007443	http://www.orpha.net/ORDO/Orphanet_388	http://purl.obolibrary.org/obo/HP_0000135	http://purl.obolibrary.org/obo/HP_0000635	http://purl.obolibrary.org/obo/HP_0001100	http://purl.obolibrary.org/obo/HP_0002211	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0008527	http://purl.obolibrary.org/obo/HP_0002251	http://purl.obolibrary.org/obo/HP_0001053	http://www.orpha.net/ORDO/Orphanet_3440	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0001425	http://purl.obolibrary.org/obo/HP_0000430
+WAARDENBURG SYNDROME	http://purl.obolibrary.org/obo/HP_0002226
 Aase syndrome	http://www.orpha.net/ORDO/Orphanet_124
-LIPODYSTROPHY	http://purl.obolibrary.org/obo/HP_0000855	http://purl.obolibrary.org/obo/HP_0003124	http://purl.obolibrary.org/obo/HP_0002901	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001007	http://purl.obolibrary.org/obo/HP_0002155	http://purl.obolibrary.org/obo/HP_0000819	http://purl.obolibrary.org/obo/HP_0000956	http://purl.obolibrary.org/obo/HP_0009125	http://purl.obolibrary.org/obo/HP_0003758	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001397	http://purl.obolibrary.org/obo/HP_0001433
+LIPODYSTROPHY	http://purl.obolibrary.org/obo/HP_0000855
 MYD88 DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_183713
 NEURODEGENERATION WITH BRAIN IRON ACCUMULATION 4	http://www.orpha.net/ORDO/Orphanet_289560
 Hereditary nonpolyposis colorectal cancer type 6	http://www.orpha.net/ORDO/Orphanet_144
 Insulin resistance syndrome	http://www.orpha.net/ORDO/Orphanet_2297
-Epidermolysis bullosa simplex	http://purl.obolibrary.org/obo/HP_0000007	http://www.orpha.net/ORDO/Orphanet_79396	http://purl.obolibrary.org/obo/HP_0001075	http://www.orpha.net/ORDO/Orphanet_79399	http://purl.obolibrary.org/obo/HP_0008404	http://www.orpha.net/ORDO/Orphanet_304
+Epidermolysis bullosa simplex	http://purl.obolibrary.org/obo/HP_0000007
 AMISH INFANTILE EPILEPSY SYNDROME	http://www.orpha.net/ORDO/Orphanet_171714
 Colonic adenocarcinoma	http://www.ebi.ac.uk/efo/EFO_0000365
 Deficiency of pyrroline-5-carboxylate reductase	http://www.orpha.net/ORDO/Orphanet_79101
 Congenital disorder of glycosylation type 1x	http://www.orpha.net/ORDO/Orphanet_137
 BARDET-BIEDL SYNDROME 16	http://www.orpha.net/ORDO/Orphanet_110
-PITUITARY HORMONE DEFICIENCY COMBINED 4	http://www.orpha.net/ORDO/Orphanet_95494	http://www.orpha.net/ORDO/Orphanet_467
+PITUITARY HORMONE DEFICIENCY COMBINED 4	http://www.orpha.net/ORDO/Orphanet_95494
 Autosomal recessive centronuclear myopathy	http://www.orpha.net/ORDO/Orphanet_169186
 HEPATIC LIPASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_140905
-FACIAL DYSMORPHISM	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0007421	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0000337	http://purl.obolibrary.org/obo/HP_0002653	http://purl.obolibrary.org/obo/HP_0004482
-MULTIPLE CONGENITAL ANOMALIES-HYPOTONIA-SEIZURES SYNDROME 3	http://purl.obolibrary.org/obo/HP_0000348	http://purl.obolibrary.org/obo/HP_0000341	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0003022	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001520	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000164	http://purl.obolibrary.org/obo/HP_0002150	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000540	http://purl.obolibrary.org/obo/HP_0001723	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000194	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0000121	http://purl.obolibrary.org/obo/HP_0002002	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000107	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0003186	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0002059
+FACIAL DYSMORPHISM	http://purl.obolibrary.org/obo/HP_0000272
+MULTIPLE CONGENITAL ANOMALIES-HYPOTONIA-SEIZURES SYNDROME 3	http://purl.obolibrary.org/obo/HP_0000348
 Yakut short stature syndrome	http://www.orpha.net/ORDO/Orphanet_2616
 Early infantile epileptic encephalopathy 34	http://www.orpha.net/ORDO/Orphanet_1934
 Premature ovarian failure 8	http://www.ebi.ac.uk/efo/EFO_0004266
 Trichorhinophalangeal syndrome type 3	http://www.orpha.net/ORDO/Orphanet_324764
-NEUROFIBROMATOSIS	http://purl.obolibrary.org/obo/HP_0002385	http://purl.obolibrary.org/obo/HP_0009737	http://purl.obolibrary.org/obo/HP_0001480	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000957	http://purl.obolibrary.org/obo/HP_0006851	http://purl.obolibrary.org/obo/HP_0010302	http://purl.obolibrary.org/obo/HP_0007340
+NEUROFIBROMATOSIS	http://purl.obolibrary.org/obo/HP_0002385
 Thyrotoxic periodic paralysis	http://www.orpha.net/ORDO/Orphanet_79102
-Hereditary breast and ovarian cancer syndrome	http://www.orpha.net/ORDO/Orphanet_145	http://www.orpha.net/ORDO/Orphanet_227535
-Classical galactosemia	http://www.orpha.net/ORDO/Orphanet_352	http://www.orpha.net/ORDO/Orphanet_79239
-HYPOMYELINATION	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000817	http://purl.obolibrary.org/obo/HP_0006829	http://purl.obolibrary.org/obo/HP_0006808
-MYASTHENIC SYNDROME	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0000467	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0002355	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0000218	http://www.orpha.net/ORDO/Orphanet_590	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0001558	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0000276	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0000007	http://www.orpha.net/ORDO/Orphanet_98913	http://purl.obolibrary.org/obo/HP_0002465	http://purl.obolibrary.org/obo/HP_0000602	http://purl.obolibrary.org/obo/HP_0000774	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0010628	http://purl.obolibrary.org/obo/HP_0000275	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0003388
+Hereditary breast and ovarian cancer syndrome	http://www.orpha.net/ORDO/Orphanet_145
+Classical galactosemia	http://www.orpha.net/ORDO/Orphanet_352
+HYPOMYELINATION	http://purl.obolibrary.org/obo/HP_0001347
+MYASTHENIC SYNDROME	http://purl.obolibrary.org/obo/HP_0001371
 HOLOPROSENCEPHALY 7	http://www.orpha.net/ORDO/Orphanet_2162
-AICARDI-GOUTIERES SYNDROME 2	http://purl.obolibrary.org/obo/HP_0009704	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002135	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0001298	http://purl.obolibrary.org/obo/HP_0002059
-Lung cancer	http://www.ebi.ac.uk/efo/EFO_0001365	http://www.ebi.ac.uk/efo/EFO_0001071
+AICARDI-GOUTIERES SYNDROME 2	http://purl.obolibrary.org/obo/HP_0009704
+Lung cancer	http://www.ebi.ac.uk/efo/EFO_0001365
 SeSAME syndrome	http://www.orpha.net/ORDO/Orphanet_199343
 LOEYS-DIETZ SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_60030
-SPINOCEREBELLAR ATAXIA 29	http://purl.obolibrary.org/obo/HP_0002136	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0002335	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0002470	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0006855	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0002075	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0000639
+SPINOCEREBELLAR ATAXIA 29	http://purl.obolibrary.org/obo/HP_0002136
 PARKINSON DISEASE	http://www.ebi.ac.uk/efo/EFO_0002508
-PARKINSONISM WITH SPASTICITY	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002322	http://purl.obolibrary.org/obo/HP_0002067	http://purl.obolibrary.org/obo/HP_0001300	http://purl.obolibrary.org/obo/HP_0002396	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0003487
+PARKINSONISM WITH SPASTICITY	http://purl.obolibrary.org/obo/HP_0001347
 X-linked severe combined immunodeficiency	http://www.ebi.ac.uk/efo/EFO_0005555
-CHOPS SYNDROME	http://purl.obolibrary.org/obo/HP_0000527	http://purl.obolibrary.org/obo/HP_0002714	http://purl.obolibrary.org/obo/HP_0000076	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0011951	http://purl.obolibrary.org/obo/HP_0006528	http://purl.obolibrary.org/obo/HP_0000085	http://purl.obolibrary.org/obo/HP_0002777	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0001513	http://purl.obolibrary.org/obo/HP_0000574	http://purl.obolibrary.org/obo/HP_0001671	http://purl.obolibrary.org/obo/HP_0100874	http://purl.obolibrary.org/obo/HP_0001601	http://purl.obolibrary.org/obo/HP_0000311	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0002020	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0000280
+CHOPS SYNDROME	http://purl.obolibrary.org/obo/HP_0000527
 Orofaciodigital syndrome 6	http://www.orpha.net/ORDO/Orphanet_140997
 Cone-rod dystrophy amelogenesis imperfecta	http://www.orpha.net/ORDO/Orphanet_88661
 REFSUM DISEASE	http://www.orpha.net/ORDO/Orphanet_773
 Coronary heart disease 2	http://www.ebi.ac.uk/efo/EFO_0001645
-Aortic aneurysm	http://purl.obolibrary.org/obo/HP_0004953	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0012727	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0005110	http://purl.obolibrary.org/obo/HP_0000768	http://purl.obolibrary.org/obo/HP_0000006	http://www.ebi.ac.uk/efo/EFO_0001666	http://purl.obolibrary.org/obo/HP_0001634	http://purl.obolibrary.org/obo/HP_0001166
+Aortic aneurysm	http://purl.obolibrary.org/obo/HP_0004953
 Combined malonic and methylmalonic aciduria	http://www.orpha.net/ORDO/Orphanet_289504
 CONOTRUNCAL ANOMALY FACE SYNDROME/VELOCARDIOFACIAL SYNDROME	http://www.orpha.net/ORDO/Orphanet_567
 Cutis laxa-corneal clouding-oligophrenia syndrome	http://www.orpha.net/ORDO/Orphanet_2962
 SIALIDOSIS	http://www.orpha.net/ORDO/Orphanet_309294
-SYMPHALANGISM	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0009177	http://purl.obolibrary.org/obo/HP_0006143
+SYMPHALANGISM	http://purl.obolibrary.org/obo/HP_0001763
 PURINE NUCLEOSIDE PHOSPHORYLASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_760
 INSOMNIA	http://www.ebi.ac.uk/efo/EFO_0004698
 ATRIAL SEPTAL DEFECT 4	http://www.ebi.ac.uk/efo/EFO_1000825
-Atrophia bulborum hereditaria	http://www.orpha.net/ORDO/Orphanet_649	http://www.orpha.net/ORDO/Orphanet_891
+Atrophia bulborum hereditaria	http://www.orpha.net/ORDO/Orphanet_649
 Glutaric aciduria	http://www.orpha.net/ORDO/Orphanet_25
 PETERS ANOMALY	http://www.orpha.net/ORDO/Orphanet_708
 Insulin-dependent diabetes mellitus secretory diarrhea syndrome	http://purl.obolibrary.org/obo/HP_0002014
-BARDET-BIEDL SYNDROME 2/6	http://www.orpha.net/ORDO/Orphanet_110	http://www.orpha.net/ORDO/Orphanet_2473
-Malignant tumor of urinary bladder	http://www.ebi.ac.uk/efo/EFO_0001378	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0005584	http://www.ebi.ac.uk/efo/EFO_0001061	http://www.ebi.ac.uk/efo/EFO_0004145	http://www.ebi.ac.uk/efo/EFO_0000616
+BARDET-BIEDL SYNDROME 2/6	http://www.orpha.net/ORDO/Orphanet_110
+Malignant tumor of urinary bladder	http://www.ebi.ac.uk/efo/EFO_0001378
 Bardet-Biedl syndrome 15	http://www.orpha.net/ORDO/Orphanet_110
-HUTCHINSON-GILFORD PROGERIA SYNDROME	http://www.orpha.net/ORDO/Orphanet_740	http://www.orpha.net/ORDO/Orphanet_2670
+HUTCHINSON-GILFORD PROGERIA SYNDROME	http://www.orpha.net/ORDO/Orphanet_740
 Spinocerebellar ataxia 23	http://www.orpha.net/ORDO/Orphanet_101108
 Autoimmune lymphoproliferative syndrome	http://www.orpha.net/ORDO/Orphanet_3261
 Periventricular nodular heterotopia 6	http://www.orpha.net/ORDO/Orphanet_98892
 Methemoglobinemia type 4	http://purl.obolibrary.org/obo/HP_0012119
 HERMANSKY-PUDLAK SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_79430
-Infantile GM1 gangliosidosis	http://www.orpha.net/ORDO/Orphanet_79256	http://www.orpha.net/ORDO/Orphanet_309144	http://www.orpha.net/ORDO/Orphanet_309310	http://www.orpha.net/ORDO/Orphanet_79255
+Infantile GM1 gangliosidosis	http://www.orpha.net/ORDO/Orphanet_79256
 BRANCHIOOCULOFACIAL SYNDROME	http://www.orpha.net/ORDO/Orphanet_1297
-Juvenile retinoschisis	http://www.orpha.net/ORDO/Orphanet_792	http://www.orpha.net/ORDO/Orphanet_71862
+Juvenile retinoschisis	http://www.orpha.net/ORDO/Orphanet_792
 TARSAL-CARPAL COALITION SYNDROME	http://www.orpha.net/ORDO/Orphanet_1412
 CARDIOFACIOCUTANEOUS SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_1340
 Severe autosomal recessive muscular dystrophy of childhood - North African type	http://www.orpha.net/ORDO/Orphanet_98473
-NAIL DISORDER	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001806
-Dilated cardiomyopathy 1AA	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+NAIL DISORDER	http://purl.obolibrary.org/obo/HP_0000007
+Dilated cardiomyopathy 1AA	http://www.ebi.ac.uk/efo/EFO_0000407
 CHOREOATHETOSIS	http://www.ebi.ac.uk/efo/EFO_0004705
 Miller syndrome	http://www.orpha.net/ORDO/Orphanet_246
 Maple syrup urine disease type 2	http://www.orpha.net/ORDO/Orphanet_511
-TERMINAL OSSEOUS DYSPLASIA	http://purl.obolibrary.org/obo/HP_0004987	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0010614	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0005921	http://purl.obolibrary.org/obo/HP_0000190	http://purl.obolibrary.org/obo/HP_0001000	http://purl.obolibrary.org/obo/HP_0010675	http://purl.obolibrary.org/obo/HP_0000612	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0005011	http://purl.obolibrary.org/obo/HP_0100490	http://purl.obolibrary.org/obo/HP_0001831	http://purl.obolibrary.org/obo/HP_0001863	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0011355	http://purl.obolibrary.org/obo/HP_0002828	http://purl.obolibrary.org/obo/HP_0001836
+TERMINAL OSSEOUS DYSPLASIA	http://purl.obolibrary.org/obo/HP_0004987
 Deficiency of butyrylcholine esterase	http://www.orpha.net/ORDO/Orphanet_132
 Ataxia-oculomotor apraxia 3	http://www.orpha.net/ORDO/Orphanet_64753
-Myopathy	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0003327	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0000278	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0002522	http://purl.obolibrary.org/obo/HP_0002901	http://purl.obolibrary.org/obo/HP_0003546	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003687	http://purl.obolibrary.org/obo/HP_0001699	http://purl.obolibrary.org/obo/HP_0003273	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003326	http://purl.obolibrary.org/obo/HP_0003198	http://purl.obolibrary.org/obo/HP_0003388	http://purl.obolibrary.org/obo/HP_0003394	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0009027	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0006829	http://www.ebi.ac.uk/efo/EFO_0004145	http://purl.obolibrary.org/obo/HP_0008981	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0003324	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0003306	http://purl.obolibrary.org/obo/HP_0011675	http://purl.obolibrary.org/obo/HP_0000616	http://purl.obolibrary.org/obo/HP_0000602	http://purl.obolibrary.org/obo/HP_0003722	http://purl.obolibrary.org/obo/HP_0010628
-ECTOPIA LENTIS ET PUPILLAE	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0009917	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0000541	http://purl.obolibrary.org/obo/HP_0001083	http://purl.obolibrary.org/obo/HP_0011003
-Leri Weill dyschondrosteosis	http://www.orpha.net/ORDO/Orphanet_2632	http://www.orpha.net/ORDO/Orphanet_240
-IMMUNODEFICIENCY 15	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0011947	http://purl.obolibrary.org/obo/HP_0002028	http://purl.obolibrary.org/obo/HP_0004432
+Myopathy	http://purl.obolibrary.org/obo/HP_0001371
+ECTOPIA LENTIS ET PUPILLAE	http://purl.obolibrary.org/obo/HP_0000007
+Leri Weill dyschondrosteosis	http://www.orpha.net/ORDO/Orphanet_2632
+IMMUNODEFICIENCY 15	http://purl.obolibrary.org/obo/HP_0003593
 Neurodegeration	http://purl.obolibrary.org/obo/HP_0001522
-TRICHOTHIODYSTROPHY 5	http://purl.obolibrary.org/obo/HP_0001305	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0002283	http://purl.obolibrary.org/obo/HP_0000348	http://purl.obolibrary.org/obo/HP_0002217	http://purl.obolibrary.org/obo/HP_0002719	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0002299	http://purl.obolibrary.org/obo/HP_0005328	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0004313	http://purl.obolibrary.org/obo/HP_0008070	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000965	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0006313
+TRICHOTHIODYSTROPHY 5	http://purl.obolibrary.org/obo/HP_0001305
 NEMALINE MYOPATHY 7	http://www.orpha.net/ORDO/Orphanet_607
-Arrhythmogenic right ventricular cardiomyopathy ?	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0004269
+Arrhythmogenic right ventricular cardiomyopathy ?	http://www.ebi.ac.uk/efo/EFO_0000407
 HAIR MORPHOLOGY 1	http://www.ebi.ac.uk/efo/EFO_0005038
 Hereditary sensory neuropathy type IE	http://www.ebi.ac.uk/efo/EFO_0004149
 Cataract 1	http://www.ebi.ac.uk/efo/EFO_0001059
@@ -2957,49 +2957,49 @@ Schinzel-Giedion syndrome	http://www.orpha.net/ORDO/Orphanet_798
 Mental retardation 30	http://www.ebi.ac.uk/efo/EFO_0003847
 Myofibrillar myopathy 1	http://www.orpha.net/ORDO/Orphanet_593
 Charcot-Marie-Tooth disease type 2D	http://www.orpha.net/ORDO/Orphanet_166
-PORPHYRIA CUTANEA TARDA	http://www.orpha.net/ORDO/Orphanet_101330	http://www.orpha.net/ORDO/Orphanet_443062	http://www.orpha.net/ORDO/Orphanet_95159
-CREATINE PHOSPHOKINASE	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003710
+PORPHYRIA CUTANEA TARDA	http://www.orpha.net/ORDO/Orphanet_101330
+CREATINE PHOSPHOKINASE	http://purl.obolibrary.org/obo/HP_0003236
 PRION DISEASE	http://www.ebi.ac.uk/efo/EFO_0004720
 Brugada syndrome (shorter-than-normal QT interval)	http://www.orpha.net/ORDO/Orphanet_130
 Thyrotoxic periodic paralysis 2	http://www.orpha.net/ORDO/Orphanet_79102
 MYELODYSPLASTIC SYNDROME	http://www.ebi.ac.uk/efo/EFO_0000198
-SPASTIC PARAPLEGIA 56	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0002317	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002135	http://purl.obolibrary.org/obo/HP_0002395	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0040083
-Multiple epiphyseal dysplasia 4	http://www.orpha.net/ORDO/Orphanet_628	http://www.orpha.net/ORDO/Orphanet_93307
+SPASTIC PARAPLEGIA 56	http://purl.obolibrary.org/obo/HP_0100543
+Multiple epiphyseal dysplasia 4	http://www.orpha.net/ORDO/Orphanet_628
 POLYGLUCOSAN BODY MYOPATHY 1 WITH OR WITHOUT IMMUNODEFICIENCY	http://www.orpha.net/ORDO/Orphanet_397937
 X-Linked Mental Retardation 41	http://www.ebi.ac.uk/efo/EFO_0003847
 NAXOS DISEASE	http://www.orpha.net/ORDO/Orphanet_34217
-FG syndrome	http://purl.obolibrary.org/obo/HP_0001627	http://purl.obolibrary.org/obo/HP_0002021	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000348	http://purl.obolibrary.org/obo/HP_0000708	http://purl.obolibrary.org/obo/HP_0000204	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0005490	http://purl.obolibrary.org/obo/HP_0002023	http://purl.obolibrary.org/obo/HP_0000678	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0001739	http://purl.obolibrary.org/obo/HP_0011266	http://purl.obolibrary.org/obo/HP_0002242	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0001357	http://purl.obolibrary.org/obo/HP_0002828	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0009466	http://purl.obolibrary.org/obo/HP_0000189	http://purl.obolibrary.org/obo/HP_0000337	http://purl.obolibrary.org/obo/HP_0010609	http://purl.obolibrary.org/obo/HP_0001338	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0008070	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0002353	http://purl.obolibrary.org/obo/HP_0000453	http://purl.obolibrary.org/obo/HP_0001620	http://purl.obolibrary.org/obo/HP_0001476	http://purl.obolibrary.org/obo/HP_0005833	http://purl.obolibrary.org/obo/HP_0001212	http://purl.obolibrary.org/obo/HP_0012385	http://purl.obolibrary.org/obo/HP_0011304	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0009762	http://purl.obolibrary.org/obo/HP_0002938	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0002213	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0010055	http://purl.obolibrary.org/obo/HP_0007018	http://purl.obolibrary.org/obo/HP_0000260	http://purl.obolibrary.org/obo/HP_0000298	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0001545	http://purl.obolibrary.org/obo/HP_0000766	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0002282	http://purl.obolibrary.org/obo/HP_0030084	http://purl.obolibrary.org/obo/HP_0002236	http://purl.obolibrary.org/obo/HP_0002025	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0001159	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0000194	http://purl.obolibrary.org/obo/HP_0000179	http://purl.obolibrary.org/obo/HP_0000448	http://purl.obolibrary.org/obo/HP_0000960	http://purl.obolibrary.org/obo/HP_0000954	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0004299	http://purl.obolibrary.org/obo/HP_0002566	http://purl.obolibrary.org/obo/HP_0007370	http://purl.obolibrary.org/obo/HP_0000174	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0001171	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0009473	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0000023
-Cutis Gyrata syndrome of Beare and Stevenson	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0003246	http://purl.obolibrary.org/obo/HP_0100761	http://purl.obolibrary.org/obo/HP_0000452	http://purl.obolibrary.org/obo/HP_0000048	http://purl.obolibrary.org/obo/HP_0000982	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0009804	http://purl.obolibrary.org/obo/HP_0001545	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0000956	http://purl.obolibrary.org/obo/HP_0002676	http://purl.obolibrary.org/obo/HP_0000364	http://purl.obolibrary.org/obo/HP_0000268	http://purl.obolibrary.org/obo/HP_0007517	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0010669	http://purl.obolibrary.org/obo/HP_0009906	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000189	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0001274	http://purl.obolibrary.org/obo/HP_0002098	http://purl.obolibrary.org/obo/HP_0001597	http://purl.obolibrary.org/obo/HP_0001732	http://purl.obolibrary.org/obo/HP_0004450	http://purl.obolibrary.org/obo/HP_0001377	http://purl.obolibrary.org/obo/HP_0001363	http://purl.obolibrary.org/obo/HP_0001792	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0000995	http://purl.obolibrary.org/obo/HP_0000453	http://purl.obolibrary.org/obo/HP_0000391	http://purl.obolibrary.org/obo/HP_0000400
-ACHONDROGENESIS	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000923	http://purl.obolibrary.org/obo/HP_0004348	http://purl.obolibrary.org/obo/HP_0000882	http://purl.obolibrary.org/obo/HP_0010306	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0010675	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0010660	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000774	http://purl.obolibrary.org/obo/HP_0000894	http://purl.obolibrary.org/obo/HP_0001831	http://purl.obolibrary.org/obo/HP_0000476	http://purl.obolibrary.org/obo/HP_0000773	http://purl.obolibrary.org/obo/HP_0003826	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0001538	http://purl.obolibrary.org/obo/HP_0001789	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0000474	http://purl.obolibrary.org/obo/HP_0004331	http://purl.obolibrary.org/obo/HP_0004606	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0002652	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000916	http://purl.obolibrary.org/obo/HP_0003521	http://purl.obolibrary.org/obo/HP_0002984	http://purl.obolibrary.org/obo/HP_0002983	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0006703	http://purl.obolibrary.org/obo/HP_0006489	http://purl.obolibrary.org/obo/HP_0001552	http://purl.obolibrary.org/obo/HP_0003175	http://purl.obolibrary.org/obo/HP_0002757	http://purl.obolibrary.org/obo/HP_0001561	http://purl.obolibrary.org/obo/HP_0000256
-INFLAMMATORY BOWEL DISEASE 25	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000143	http://purl.obolibrary.org/obo/HP_0005224	http://purl.obolibrary.org/obo/HP_0004387	http://purl.obolibrary.org/obo/HP_0009789
+FG syndrome	http://purl.obolibrary.org/obo/HP_0001627
+Cutis Gyrata syndrome of Beare and Stevenson	http://purl.obolibrary.org/obo/HP_0000272
+ACHONDROGENESIS	http://purl.obolibrary.org/obo/HP_0000272
+INFLAMMATORY BOWEL DISEASE 25	http://purl.obolibrary.org/obo/HP_0000007
 Polymorphous corneal dystrophy	http://www.orpha.net/ORDO/Orphanet_98973
-HYPERPARATHYROIDISM 1	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003072	http://purl.obolibrary.org/obo/HP_0008200
+HYPERPARATHYROIDISM 1	http://purl.obolibrary.org/obo/HP_0000006
 Nephronophthisis 7	http://www.orpha.net/ORDO/Orphanet_655
 Hand foot uterus syndrome	http://www.orpha.net/ORDO/Orphanet_2438
 CRANIOECTODERMAL DYSPLASIA 3	http://www.orpha.net/ORDO/Orphanet_1515
 Hemorrhagic destruction of the brain	http://www.ebi.ac.uk/efo/EFO_0001059
-DIAMOND-BLACKFAN ANEMIA 5	http://purl.obolibrary.org/obo/HP_0012133	http://purl.obolibrary.org/obo/HP_0000047	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001882	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0001972	http://purl.obolibrary.org/obo/HP_0001629
-Pachyonychia congenita type 2	http://www.orpha.net/ORDO/Orphanet_2309	http://www.orpha.net/ORDO/Orphanet_841
+DIAMOND-BLACKFAN ANEMIA 5	http://purl.obolibrary.org/obo/HP_0012133
+Pachyonychia congenita type 2	http://www.orpha.net/ORDO/Orphanet_2309
 BARDET-BIEDL SYNDROME 12	http://www.orpha.net/ORDO/Orphanet_110
 Common variable immunodeficiency 1	http://www.orpha.net/ORDO/Orphanet_1572
 Syndactyly Cenani Lenz type	http://www.orpha.net/ORDO/Orphanet_90025
 GLYCINE N-METHYLTRANSFERASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_289891
 Congenital adrenal hyperplasia	http://www.orpha.net/ORDO/Orphanet_418
 ECTODERMAL DYSPLASIA-SYNDACTYLY SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_247820
-HURLER SYNDROME	http://www.orpha.net/ORDO/Orphanet_93473	http://www.orpha.net/ORDO/Orphanet_93476	http://www.orpha.net/ORDO/Orphanet_579
+HURLER SYNDROME	http://www.orpha.net/ORDO/Orphanet_93473
 Hydatidiform mole	http://www.ebi.ac.uk/efo/EFO_1000298
 OTOSPONDYLOMEGAEPIPHYSEAL DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_1427
 Amyotrophic lateral sclerosis type 9	http://www.ebi.ac.uk/efo/EFO_0000253
 IRAK4 DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_70592
 CENTRAL HYPOVENTILATION SYNDROME	http://www.orpha.net/ORDO/Orphanet_388
 Nemaline myopathy 8	http://www.orpha.net/ORDO/Orphanet_607
-Pituitary hormone deficiency	http://www.orpha.net/ORDO/Orphanet_95494	http://www.orpha.net/ORDO/Orphanet_467
-Metaphyseal dysplasia without hypotrichosis	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003025	http://purl.obolibrary.org/obo/HP_0006028	http://purl.obolibrary.org/obo/HP_0002970	http://purl.obolibrary.org/obo/HP_0002644	http://purl.obolibrary.org/obo/HP_0002983	http://purl.obolibrary.org/obo/HP_0002715	http://purl.obolibrary.org/obo/HP_0001388	http://purl.obolibrary.org/obo/HP_0010230	http://purl.obolibrary.org/obo/HP_0000925	http://purl.obolibrary.org/obo/HP_0003510	http://purl.obolibrary.org/obo/HP_0010049	http://purl.obolibrary.org/obo/HP_0100255	http://purl.obolibrary.org/obo/HP_0003026	http://purl.obolibrary.org/obo/HP_0001595
-Preeclampsia	http://www.ebi.ac.uk/efo/EFO_0000464	http://www.ebi.ac.uk/efo/EFO_0000668
+Pituitary hormone deficiency	http://www.orpha.net/ORDO/Orphanet_95494
+Metaphyseal dysplasia without hypotrichosis	http://purl.obolibrary.org/obo/HP_0000007
+Preeclampsia	http://www.ebi.ac.uk/efo/EFO_0000464
 Familial abdominal aortic aneurysm 1	http://www.orpha.net/ORDO/Orphanet_86
 Retinitis pigmentosa 64	http://www.orpha.net/ORDO/Orphanet_791
 PREMATURE OVARIAN FAILURE 1	http://www.ebi.ac.uk/efo/EFO_0004266
-OPTIC ATROPHY AND CATARACT	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0002071	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000648
+OPTIC ATROPHY AND CATARACT	http://purl.obolibrary.org/obo/HP_0007663
 ODONTOONYCHODERMAL DYSPLASIA	http://www.orpha.net/ORDO/Orphanet_2721
 Subacute neuronopathic Gauchers disease	http://www.orpha.net/ORDO/Orphanet_77261
 Congenital disorder of glycosylation type 1D	http://www.orpha.net/ORDO/Orphanet_79321
@@ -3009,10 +3009,10 @@ Primary ciliary dyskinesia 25	http://www.orpha.net/ORDO/Orphanet_244
 Frank Ter Haar syndrome	http://www.orpha.net/ORDO/Orphanet_137834
 Congenital myopathy	http://www.orpha.net/ORDO/Orphanet_97245
 POLYMICROGYRIA WITH OPTIC NERVE HYPOPLASIA	http://www.orpha.net/ORDO/Orphanet_250972
-Medullary thyroid carcinoma	http://www.orpha.net/ORDO/Orphanet_653	http://www.orpha.net/ORDO/Orphanet_99361	http://www.orpha.net/ORDO/Orphanet_247698
-Peroxisomal fatty acyl-coa reductase 1 disorder	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000219	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002553	http://purl.obolibrary.org/obo/HP_0000280	http://purl.obolibrary.org/obo/HP_0000400
+Medullary thyroid carcinoma	http://www.orpha.net/ORDO/Orphanet_653
+Peroxisomal fatty acyl-coa reductase 1 disorder	http://purl.obolibrary.org/obo/HP_0001252
 Pontocerebellar hypoplasia type 3	http://www.orpha.net/ORDO/Orphanet_97249
-Olivopontocerebellar hypoplasia	http://www.orpha.net/ORDO/Orphanet_166063	http://www.orpha.net/ORDO/Orphanet_98523
+Olivopontocerebellar hypoplasia	http://www.orpha.net/ORDO/Orphanet_166063
 Alexanders disease	http://www.orpha.net/ORDO/Orphanet_58
 Rapp-Hodgkin ectodermal dysplasia syndrome	http://www.orpha.net/ORDO/Orphanet_238468
 AROMATASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_91
@@ -3026,62 +3026,62 @@ ENHANCED S-CONE SYNDROME	http://www.orpha.net/ORDO/Orphanet_53540
 HOLOPROSENCEPHALY 5	http://www.orpha.net/ORDO/Orphanet_2162
 Opitz-Frias syndrome	http://www.orpha.net/ORDO/Orphanet_2745
 RETINITIS PIGMENTOSA	http://www.orpha.net/ORDO/Orphanet_791
-Coronary artery disease	http://www.ebi.ac.uk/efo/EFO_0000378	http://www.ebi.ac.uk/efo/EFO_0001645	http://www.ebi.ac.uk/efo/EFO_0001365
+Coronary artery disease	http://www.ebi.ac.uk/efo/EFO_0000378
 Exercise-induced hyperinsulinemic hypoglycemia	http://www.orpha.net/ORDO/Orphanet_165991
-SPASTIC PARAPLEGIA 47	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0000341	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000154	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0010864	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000322	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0002518	http://purl.obolibrary.org/obo/HP_0000414	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002816	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0002515	http://purl.obolibrary.org/obo/HP_0000280
+SPASTIC PARAPLEGIA 47	http://purl.obolibrary.org/obo/HP_0003577
 STARGARDT DISEASE 3	http://www.orpha.net/ORDO/Orphanet_827
-ADULT SYNDROME	http://www.orpha.net/ORDO/Orphanet_139039	http://www.orpha.net/ORDO/Orphanet_978
-CHOLESTASIS	http://www.orpha.net/ORDO/Orphanet_172	http://www.orpha.net/ORDO/Orphanet_69665
+ADULT SYNDROME	http://www.orpha.net/ORDO/Orphanet_139039
+CHOLESTASIS	http://www.orpha.net/ORDO/Orphanet_172
 Partial albinism	http://purl.obolibrary.org/obo/HP_0007443
 Osteogenesis imperfecta type 1	http://www.orpha.net/ORDO/Orphanet_216796
 Cutaneous malignant melanoma 5	http://www.ebi.ac.uk/efo/EFO_0000389
-Combined oxidative phosphorylation deficiency 16	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0001414
+Combined oxidative phosphorylation deficiency 16	http://purl.obolibrary.org/obo/HP_0003593
 DIGITAL CLUBBING	http://www.orpha.net/ORDO/Orphanet_217059
 ARTS SYNDROME	http://www.orpha.net/ORDO/Orphanet_1187
 HYPOGONADOTROPIC HYPOGONADISM 18 WITH ANOSMIA	http://www.orpha.net/ORDO/Orphanet_174590
-GROWTH HORMONE INSENSITIVITY WITH IMMUNODEFICIENCY	http://purl.obolibrary.org/obo/HP_0003510	http://purl.obolibrary.org/obo/HP_0000824	http://purl.obolibrary.org/obo/HP_0002880
+GROWTH HORMONE INSENSITIVITY WITH IMMUNODEFICIENCY	http://purl.obolibrary.org/obo/HP_0003510
 Peroxisome biogenesis disorder 2A	http://www.orpha.net/ORDO/Orphanet_79189
 PSEUDOHERMAPHRODITISM	http://www.ebi.ac.uk/efo/EFO_0005579
-CONGENITAL CATARACTS	http://purl.obolibrary.org/obo/HP_0007182	http://purl.obolibrary.org/obo/HP_0000044	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0002072	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000276	http://purl.obolibrary.org/obo/HP_0000764	http://purl.obolibrary.org/obo/HP_0004349	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0000762	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000164	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000815	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0011096	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0008214	http://purl.obolibrary.org/obo/HP_0000519	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0008734	http://purl.obolibrary.org/obo/HP_0000639	http://www.orpha.net/ORDO/Orphanet_300313	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0003431	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0000786	http://purl.obolibrary.org/obo/HP_0005105	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000078	http://purl.obolibrary.org/obo/HP_0010620	http://purl.obolibrary.org/obo/HP_0100022	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0008942	http://purl.obolibrary.org/obo/HP_0002751	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0100490	http://purl.obolibrary.org/obo/HP_0007178	http://purl.obolibrary.org/obo/HP_0001171	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002816	http://purl.obolibrary.org/obo/HP_0008056	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0000499	http://purl.obolibrary.org/obo/HP_0002059
+CONGENITAL CATARACTS	http://purl.obolibrary.org/obo/HP_0007182
 LYMPHOPROLIFERATIVE SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_238505
 CARPAL TUNNEL SYNDROME	http://www.ebi.ac.uk/efo/EFO_0004143
 Upshaw-Schulman syndrome	http://www.orpha.net/ORDO/Orphanet_93583
-Familial hypertrophic cardiomyopathy 19	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
-SPONDYLOMETAEPIPHYSEAL DYSPLASIA	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0008873	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0009803	http://purl.obolibrary.org/obo/HP_0000464	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0000767	http://purl.obolibrary.org/obo/HP_0002979	http://purl.obolibrary.org/obo/HP_0009164	http://purl.obolibrary.org/obo/HP_0001591	http://purl.obolibrary.org/obo/HP_0003026	http://purl.obolibrary.org/obo/HP_0000773	http://purl.obolibrary.org/obo/HP_0003015	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001840	http://purl.obolibrary.org/obo/HP_0000907	http://purl.obolibrary.org/obo/HP_0009875	http://purl.obolibrary.org/obo/HP_0005462	http://purl.obolibrary.org/obo/HP_0003320	http://purl.obolibrary.org/obo/HP_0010049	http://purl.obolibrary.org/obo/HP_0002176	http://purl.obolibrary.org/obo/HP_0000926	http://purl.obolibrary.org/obo/HP_0010655	http://purl.obolibrary.org/obo/HP_0005257	http://purl.obolibrary.org/obo/HP_0002983	http://purl.obolibrary.org/obo/HP_0002651	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0002091	http://purl.obolibrary.org/obo/HP_0006600	http://purl.obolibrary.org/obo/HP_0001230	http://purl.obolibrary.org/obo/HP_0000922	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0030043	http://purl.obolibrary.org/obo/HP_0006380	http://purl.obolibrary.org/obo/HP_0006532	http://purl.obolibrary.org/obo/HP_0003396	http://purl.obolibrary.org/obo/HP_0003467	http://purl.obolibrary.org/obo/HP_0003085	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0003311	http://purl.obolibrary.org/obo/HP_0040199	http://purl.obolibrary.org/obo/HP_0006009	http://purl.obolibrary.org/obo/HP_0002787	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0002869	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0002987
+Familial hypertrophic cardiomyopathy 19	http://www.ebi.ac.uk/efo/EFO_0000318
+SPONDYLOMETAEPIPHYSEAL DYSPLASIA	http://purl.obolibrary.org/obo/HP_0000272
 Hyperphosphatasia with mental retardation syndrome 6	http://www.ebi.ac.uk/efo/EFO_0003847
 Follicular lymphoma	http://www.ebi.ac.uk/efo/EFO_0000096
-Intractable seizure	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0012444
-SPASTIC PARAPLEGIA 46	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0008003	http://purl.obolibrary.org/obo/HP_0002406	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0000020	http://purl.obolibrary.org/obo/HP_0000789	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0002064	http://purl.obolibrary.org/obo/HP_0002346	http://purl.obolibrary.org/obo/HP_0011448	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0002166	http://purl.obolibrary.org/obo/HP_0000726	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0006986	http://purl.obolibrary.org/obo/HP_0007340	http://purl.obolibrary.org/obo/HP_0002059	http://purl.obolibrary.org/obo/HP_0011449
+Intractable seizure	http://purl.obolibrary.org/obo/HP_0001263
+SPASTIC PARAPLEGIA 46	http://purl.obolibrary.org/obo/HP_0003677
 Seckel syndrome 9	http://www.orpha.net/ORDO/Orphanet_808
 Autosomal recessive congenital ichthyosis 4B	http://www.orpha.net/ORDO/Orphanet_281097
-Megaloblastic anemia due to dihydrofolate reductase deficiency	http://purl.obolibrary.org/obo/HP_0000980	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001876	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0002121	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002421	http://purl.obolibrary.org/obo/HP_0005484	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0012448	http://purl.obolibrary.org/obo/HP_0001889	http://purl.obolibrary.org/obo/HP_0002059
+Megaloblastic anemia due to dihydrofolate reductase deficiency	http://purl.obolibrary.org/obo/HP_0000980
 Dilated cardiomyopathy 1L	http://www.ebi.ac.uk/efo/EFO_0000407
 Simpson-Golabi-Behmel syndrome	http://www.orpha.net/ORDO/Orphanet_373
 Congenital myasthenic syndrome with tubular aggregates 1	http://www.orpha.net/ORDO/Orphanet_590
 Atypical hemolytic uremic syndrome	http://www.orpha.net/ORDO/Orphanet_2134
 SCLEROSTEOSIS	http://www.orpha.net/ORDO/Orphanet_3152
 SPASTIC PARAPLEGIA 10	http://purl.obolibrary.org/obo/HP_0001258
-Dilated cardiomyopathy 1M	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+Dilated cardiomyopathy 1M	http://www.ebi.ac.uk/efo/EFO_0000407
 USHER SYNDROME	http://www.orpha.net/ORDO/Orphanet_886
-MACULAR DEGENERATION	http://purl.obolibrary.org/obo/HP_0000608	http://www.ebi.ac.uk/efo/EFO_0001365	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000505
-Metatrophic dysplasia	http://www.orpha.net/ORDO/Orphanet_263482	http://www.orpha.net/ORDO/Orphanet_2635	http://www.orpha.net/ORDO/Orphanet_93314
+MACULAR DEGENERATION	http://purl.obolibrary.org/obo/HP_0000608
+Metatrophic dysplasia	http://www.orpha.net/ORDO/Orphanet_263482
 Focal segmental glomerulosclerosis 3	http://www.ebi.ac.uk/efo/EFO_0004236
-Palmoplantar keratoderma	http://purl.obolibrary.org/obo/HP_0000982	http://purl.obolibrary.org/obo/HP_0000006
+Palmoplantar keratoderma	http://purl.obolibrary.org/obo/HP_0000982
 Common variable immunodeficiency 10	http://www.orpha.net/ORDO/Orphanet_1572
 Leber congenital amaurosis 17	http://www.orpha.net/ORDO/Orphanet_65
-LEIGH SYNDROME DUE TO MITOCHONDRIAL COMPLEX I DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_506	http://www.orpha.net/ORDO/Orphanet_550	http://www.orpha.net/ORDO/Orphanet_255210	http://www.orpha.net/ORDO/Orphanet_289527
-SPINOCEREBELLAR ATAXIA 14	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000317	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0000716	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0004373	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0007018	http://purl.obolibrary.org/obo/HP_0001268	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0002354	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002073	http://purl.obolibrary.org/obo/HP_0006938	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0000639
-HYPOPARATHYROIDISM-RETARDATION-DYSMORPHISM SYNDROME	http://purl.obolibrary.org/obo/HP_0005374	http://purl.obolibrary.org/obo/HP_0003416	http://purl.obolibrary.org/obo/HP_0000829	http://purl.obolibrary.org/obo/HP_0005214	http://purl.obolibrary.org/obo/HP_0000358	http://purl.obolibrary.org/obo/HP_0000348	http://purl.obolibrary.org/obo/HP_0200055	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0000682	http://purl.obolibrary.org/obo/HP_0002199	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0008736	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0002718	http://purl.obolibrary.org/obo/HP_0002901	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0007759	http://purl.obolibrary.org/obo/HP_0008846	http://purl.obolibrary.org/obo/HP_0000490	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001773	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000233	http://purl.obolibrary.org/obo/HP_0003198	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0000444	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0004279	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0008198	http://purl.obolibrary.org/obo/HP_0008572	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000483	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0000193	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0005686	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0002905	http://purl.obolibrary.org/obo/HP_0008056	http://purl.obolibrary.org/obo/HP_0011001	http://purl.obolibrary.org/obo/HP_0001281
+LEIGH SYNDROME DUE TO MITOCHONDRIAL COMPLEX I DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_506
+SPINOCEREBELLAR ATAXIA 14	http://purl.obolibrary.org/obo/HP_0001347
+HYPOPARATHYROIDISM-RETARDATION-DYSMORPHISM SYNDROME	http://purl.obolibrary.org/obo/HP_0005374
 METAPHYSEAL CHONDRODYSPLASIA	http://www.orpha.net/ORDO/Orphanet_174
 NEMALINE MYOPATHY 4	http://www.orpha.net/ORDO/Orphanet_607
-Combined oxidative phosphorylation deficiency 22	http://purl.obolibrary.org/obo/HP_0002092	http://purl.obolibrary.org/obo/HP_0003348	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0001298
+Combined oxidative phosphorylation deficiency 22	http://purl.obolibrary.org/obo/HP_0002092
 Neonatal hypotonia	http://purl.obolibrary.org/obo/HP_0001319
-Joubert syndrome 2	http://www.orpha.net/ORDO/Orphanet_475	http://www.orpha.net/ORDO/Orphanet_564
+Joubert syndrome 2	http://www.orpha.net/ORDO/Orphanet_475
 Megalencephaly cutis marmorata telangiectatica congenita	http://www.orpha.net/ORDO/Orphanet_1556
 Congenital muscular hypertrophy-cerebral syndrome	http://www.ebi.ac.uk/efo/EFO_0002460
-DYSTONIA 6	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002451	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002356	http://purl.obolibrary.org/obo/HP_0000234	http://purl.obolibrary.org/obo/HP_0012049	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0000473	http://purl.obolibrary.org/obo/HP_0001304	http://purl.obolibrary.org/obo/HP_0012048
+DYSTONIA 6	http://purl.obolibrary.org/obo/HP_0000006
 LETHAL CONGENITAL CONTRACTURE SYNDROME 8	http://www.orpha.net/ORDO/Orphanet_294965
-N-ACETYLASPARTATE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002078	http://purl.obolibrary.org/obo/HP_0000252
+N-ACETYLASPARTATE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001263
 Asparagine synthetase deficiency	http://www.orpha.net/ORDO/Orphanet_391376
 VACTERL association	http://www.orpha.net/ORDO/Orphanet_887
 CEREBROOCULOFACIOSKELETAL SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_1466
@@ -3089,89 +3089,89 @@ Congenital disorder of glycosylation type 1s	http://www.orpha.net/ORDO/Orphanet_
 mitochondrial 3-hydroxy-3-methylglutaryl-CoA synthase deficiency	http://www.orpha.net/ORDO/Orphanet_35701
 Coronary heart disease	http://www.ebi.ac.uk/efo/EFO_0001645
 Retinitis pigmentosa 60	http://www.orpha.net/ORDO/Orphanet_791
-Pseudoachondroplastic spondyloepiphyseal dysplasia syndrome	http://www.orpha.net/ORDO/Orphanet_93308	http://www.orpha.net/ORDO/Orphanet_750
-SPHEROCYTOSIS	http://www.orpha.net/ORDO/Orphanet_822	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001923	http://purl.obolibrary.org/obo/HP_0001878	http://purl.obolibrary.org/obo/HP_0004444	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0005502
+Pseudoachondroplastic spondyloepiphyseal dysplasia syndrome	http://www.orpha.net/ORDO/Orphanet_93308
+SPHEROCYTOSIS	http://www.orpha.net/ORDO/Orphanet_822
 Early myoclonic encephalopathy	http://www.orpha.net/ORDO/Orphanet_1935
-Juvenile myopathy	http://www.orpha.net/ORDO/Orphanet_550	http://www.orpha.net/ORDO/Orphanet_255210	http://www.orpha.net/ORDO/Orphanet_104
-AMELOGENESIS IMPERFECTA	http://purl.obolibrary.org/obo/HP_0011073	http://purl.obolibrary.org/obo/HP_0006285	http://purl.obolibrary.org/obo/HP_0000682	http://purl.obolibrary.org/obo/HP_0000264	http://purl.obolibrary.org/obo/HP_0002997	http://purl.obolibrary.org/obo/HP_0001231	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000687	http://purl.obolibrary.org/obo/HP_0000670	http://purl.obolibrary.org/obo/HP_0009722	http://purl.obolibrary.org/obo/HP_0000684	http://purl.obolibrary.org/obo/HP_0000268	http://purl.obolibrary.org/obo/HP_0001595	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0000705	http://purl.obolibrary.org/obo/HP_0011085	http://purl.obolibrary.org/obo/HP_0006297	http://purl.obolibrary.org/obo/HP_0200095	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0004493	http://purl.obolibrary.org/obo/HP_0006501	http://purl.obolibrary.org/obo/HP_0000311	http://www.orpha.net/ORDO/Orphanet_88661	http://purl.obolibrary.org/obo/HP_0010620	http://purl.obolibrary.org/obo/HP_0000691	http://purl.obolibrary.org/obo/HP_0006286	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0000679	http://purl.obolibrary.org/obo/HP_0002687	http://purl.obolibrary.org/obo/HP_0009102	http://purl.obolibrary.org/obo/HP_0002224	http://purl.obolibrary.org/obo/HP_0001808	http://purl.obolibrary.org/obo/HP_0011001
-Cytochrome-c oxidase deficiency	http://www.orpha.net/ORDO/Orphanet_123512	http://www.orpha.net/ORDO/Orphanet_254905
-Gaucher's disease type 1	http://www.orpha.net/ORDO/Orphanet_77261	http://www.orpha.net/ORDO/Orphanet_77259	http://www.orpha.net/ORDO/Orphanet_355	http://www.orpha.net/ORDO/Orphanet_77260	http://www.orpha.net/ORDO/Orphanet_85212
+Juvenile myopathy	http://www.orpha.net/ORDO/Orphanet_550
+AMELOGENESIS IMPERFECTA	http://purl.obolibrary.org/obo/HP_0011073
+Cytochrome-c oxidase deficiency	http://www.orpha.net/ORDO/Orphanet_123512
+Gaucher's disease type 1	http://www.orpha.net/ORDO/Orphanet_77261
 PARIETAL FORAMINA 2	http://www.orpha.net/ORDO/Orphanet_60015
 Congenital generalized lipodystrophy type 1	http://www.ebi.ac.uk/efo/EFO_1000681
 Parkinsonism/MELAS overlap syndrome	http://www.orpha.net/ORDO/Orphanet_550
 Steel syndrome	http://www.orpha.net/ORDO/Orphanet_438117
-Favism	http://purl.obolibrary.org/obo/HP_0001923	http://purl.obolibrary.org/obo/HP_0004814	http://purl.obolibrary.org/obo/HP_0008282	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0006579
+Favism	http://purl.obolibrary.org/obo/HP_0001923
 Congenital ocular coloboma	http://www.orpha.net/ORDO/Orphanet_194
 Ritscher-schinzel syndrome 2	http://www.orpha.net/ORDO/Orphanet_7
-LEUKEMIA	http://purl.obolibrary.org/obo/HP_0001873	http://www.ebi.ac.uk/efo/EFO_0000565
+LEUKEMIA	http://purl.obolibrary.org/obo/HP_0001873
 Lissencephaly 4	http://www.orpha.net/ORDO/Orphanet_48471
 HEART-HAND SYNDROME	http://www.orpha.net/ORDO/Orphanet_168796
-SPINOCEREBELLAR ATAXIA 26	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0001151	http://purl.obolibrary.org/obo/HP_0000641	http://purl.obolibrary.org/obo/HP_0002078	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0000639
-Familial hypertrophic cardiomyopathy 11	http://www.ebi.ac.uk/efo/EFO_0000318	http://www.ebi.ac.uk/efo/EFO_0000538
+SPINOCEREBELLAR ATAXIA 26	http://purl.obolibrary.org/obo/HP_0002311
+Familial hypertrophic cardiomyopathy 11	http://www.ebi.ac.uk/efo/EFO_0000318
 NEURODEGENERATION WITH BRAIN IRON ACCUMULATION 6	http://www.orpha.net/ORDO/Orphanet_385
 Primary autosomal recessive microcephaly 2	http://www.orpha.net/ORDO/Orphanet_2512
 Keratosis follicularis	http://www.ebi.ac.uk/efo/EFO_0004124
 Knuckle pads	http://www.orpha.net/ORDO/Orphanet_2698
-ATRANSFERRINEMIA	http://purl.obolibrary.org/obo/HP_0001369	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0001931	http://purl.obolibrary.org/obo/HP_0001732	http://purl.obolibrary.org/obo/HP_0000821	http://purl.obolibrary.org/obo/HP_0010978	http://purl.obolibrary.org/obo/HP_0012239	http://purl.obolibrary.org/obo/HP_0001392
-SPASTIC PARAPLEGIA 9B	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0009027	http://purl.obolibrary.org/obo/HP_0002445	http://purl.obolibrary.org/obo/HP_0007024	http://purl.obolibrary.org/obo/HP_0000016	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0003487
+ATRANSFERRINEMIA	http://purl.obolibrary.org/obo/HP_0001369
+SPASTIC PARAPLEGIA 9B	http://purl.obolibrary.org/obo/HP_0001347
 SCLEROSTEOSIS 2	http://www.orpha.net/ORDO/Orphanet_3152
 Koolen-de Vries syndrome	http://www.orpha.net/ORDO/Orphanet_96169
 MORM syndrome	http://www.orpha.net/ORDO/Orphanet_75858
 CONGENITAL HEART DEFECTS	http://www.ebi.ac.uk/efo/EFO_0005207
-MUSCULAR DYSTROPHY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003691	http://purl.obolibrary.org/obo/HP_0010628	http://purl.obolibrary.org/obo/HP_0002987	http://purl.obolibrary.org/obo/HP_0003560	http://purl.obolibrary.org/obo/HP_0003676
+MUSCULAR DYSTROPHY	http://purl.obolibrary.org/obo/HP_0000007
 Carney complex	http://www.orpha.net/ORDO/Orphanet_1359
 Aplasia cutis congenita	http://www.orpha.net/ORDO/Orphanet_1114
-SPINOCEREBELLAR ATAXIA 11	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002073	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0000639
+SPINOCEREBELLAR ATAXIA 11	http://purl.obolibrary.org/obo/HP_0001347
 X-linked hydrocephalus syndrome	http://www.orpha.net/ORDO/Orphanet_2182
-Hay-Wells syndrome of ectodermal dysplasia	http://www.orpha.net/ORDO/Orphanet_238468	http://www.orpha.net/ORDO/Orphanet_1071
+Hay-Wells syndrome of ectodermal dysplasia	http://www.orpha.net/ORDO/Orphanet_238468
 Infantile-onset ascending hereditary spastic paralysis	http://www.orpha.net/ORDO/Orphanet_293168
 GLUTATHIONE SYNTHETASE DEFICIENCY OF ERYTHROCYTES	http://www.orpha.net/ORDO/Orphanet_32
 VESICOURETERAL REFLUX 3	http://www.orpha.net/ORDO/Orphanet_289365
 Epidermolytic palmoplantar keratoderma	http://www.orpha.net/ORDO/Orphanet_2199
-Myasthenic syndrome	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0000508	http://purl.obolibrary.org/obo/HP_0003200	http://purl.obolibrary.org/obo/HP_0003473	http://purl.obolibrary.org/obo/HP_0002359	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001763	http://purl.obolibrary.org/obo/HP_0002828	http://purl.obolibrary.org/obo/HP_0008180	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0003403	http://purl.obolibrary.org/obo/HP_0003691	http://purl.obolibrary.org/obo/HP_0003391	http://purl.obolibrary.org/obo/HP_0003307	http://purl.obolibrary.org/obo/HP_0002515	http://purl.obolibrary.org/obo/HP_0030205	http://purl.obolibrary.org/obo/HP_0003325
-NEUTROPENIA	http://purl.obolibrary.org/obo/HP_0001875	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0004808
+Myasthenic syndrome	http://purl.obolibrary.org/obo/HP_0001371
+NEUTROPENIA	http://purl.obolibrary.org/obo/HP_0001875
 Leber hereditary optic neuropathy with dystonia	http://www.orpha.net/ORDO/Orphanet_104
 Cytochrome c oxidase i deficiency	http://www.orpha.net/ORDO/Orphanet_123512
 FLOATING-HARBOR SYNDROME	http://www.orpha.net/ORDO/Orphanet_2044
-Tyrosine kinase 2 deficiency	http://purl.obolibrary.org/obo/HP_0003212	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0011274	http://purl.obolibrary.org/obo/HP_0002841	http://purl.obolibrary.org/obo/HP_0004429
+Tyrosine kinase 2 deficiency	http://purl.obolibrary.org/obo/HP_0003212
 Amyotrophic lateral sclerosis type 10	http://www.ebi.ac.uk/efo/EFO_0000253
 ATR-X syndrome	http://www.orpha.net/ORDO/Orphanet_847
 3-Methylglutaconic aciduria type 3	http://www.orpha.net/ORDO/Orphanet_67047
-PEROXISOME BIOGENESIS DISORDER 9B	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0010571	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0001249
+PEROXISOME BIOGENESIS DISORDER 9B	http://purl.obolibrary.org/obo/HP_0000007
 Severe primary microcephaly	http://purl.obolibrary.org/obo/HP_0003811
 Atelosteogenesis type 2	http://www.orpha.net/ORDO/Orphanet_56304
 Erythrocytosis	http://purl.obolibrary.org/obo/HP_0001901
 Corticosterone methyloxidase type 1 deficiency	http://www.orpha.net/ORDO/Orphanet_99763
 MULTIPLE ENDOCRINE NEOPLASIA	http://www.orpha.net/ORDO/Orphanet_276161
 EPISODIC PAIN SYNDROME	http://www.orpha.net/ORDO/Orphanet_306577
-RETINITIS PIGMENTOSA 7	http://www.orpha.net/ORDO/Orphanet_65	http://www.orpha.net/ORDO/Orphanet_791
+RETINITIS PIGMENTOSA 7	http://www.orpha.net/ORDO/Orphanet_65
 Parkinson disease 5	http://www.ebi.ac.uk/efo/EFO_0002508
 Nonsyndromic Hearing Loss and Deafness	http://www.ebi.ac.uk/efo/EFO_0001063
 CONE-ROD DYSTROPHY 19	http://purl.obolibrary.org/obo/HP_0000548
 Schwannomatosis 2	http://www.orpha.net/ORDO/Orphanet_93921
 RHABDOID TUMOR PREDISPOSITION SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_231108
 FISH-EYE DISEASE	http://www.orpha.net/ORDO/Orphanet_79292
-PROTHROMBIN DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000421	http://purl.obolibrary.org/obo/HP_0000132	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0005261	http://purl.obolibrary.org/obo/HP_0003645	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0008151	http://purl.obolibrary.org/obo/HP_0002239	http://purl.obolibrary.org/obo/HP_0000225	http://purl.obolibrary.org/obo/HP_0012201	http://purl.obolibrary.org/obo/HP_0003010
+PROTHROMBIN DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000421
 Multiple epiphyseal dysplasia 5	http://www.orpha.net/ORDO/Orphanet_93311
 MITOCHONDRIAL DNA DEPLETION SYNDROME 13 (ENCEPHALOMYOPATHIC TYPE);	http://www.orpha.net/ORDO/Orphanet_35698
 Multicentric osteolysis nephropathy	http://www.ebi.ac.uk/efo/EFO_0003086
 Systemic lupus erythematosus 11	http://www.ebi.ac.uk/efo/EFO_0002690
 LYMPHOPROLIFERATIVE SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_238510
 Multiple congenital exostosis	http://www.ebi.ac.uk/efo/EFO_0005560
-RETINITIS PIGMENTOSA 19	http://www.orpha.net/ORDO/Orphanet_827	http://www.orpha.net/ORDO/Orphanet_791
-GLOMUVENOUS MALFORMATIONS	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000951	http://purl.obolibrary.org/obo/HP_0001939
+RETINITIS PIGMENTOSA 19	http://www.orpha.net/ORDO/Orphanet_827
+GLOMUVENOUS MALFORMATIONS	http://purl.obolibrary.org/obo/HP_0000006
 Heinz body anemia	http://www.orpha.net/ORDO/Orphanet_178330
 Hereditary sensory and autonomic neuropathy type IIB	http://www.orpha.net/ORDO/Orphanet_140471
-DISORDERED STEROIDOGENESIS DUE TO CYTOCHROME P450 OXIDOREDUCTASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000062	http://purl.obolibrary.org/obo/HP_0003154	http://purl.obolibrary.org/obo/HP_0008258
+DISORDERED STEROIDOGENESIS DUE TO CYTOCHROME P450 OXIDOREDUCTASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000007
 ATRIAL SEPTAL DEFECT 3	http://www.ebi.ac.uk/efo/EFO_1000825
 HERMANSKY-PUDLAK SYNDROME 7	http://www.orpha.net/ORDO/Orphanet_79430
 Migraine	http://www.ebi.ac.uk/efo/EFO_0003821
 HYPERALPHALIPOPROTEINEMIA 2	http://www.orpha.net/ORDO/Orphanet_181428
 Primary pulmonary hypertension	http://www.ebi.ac.uk/efo/EFO_0001361
-ECTODERMAL DYSPLASIA 10A	http://www.orpha.net/ORDO/Orphanet_79373	http://www.orpha.net/ORDO/Orphanet_248
+ECTODERMAL DYSPLASIA 10A	http://www.orpha.net/ORDO/Orphanet_79373
 Mental retardation 18	http://www.ebi.ac.uk/efo/EFO_0003847
 Hereditary insensitivity to pain with anhidrosis	http://www.ebi.ac.uk/efo/EFO_0003843
-LEOPARD syndrome 1	http://www.orpha.net/ORDO/Orphanet_500	http://www.orpha.net/ORDO/Orphanet_648
+LEOPARD syndrome 1	http://www.orpha.net/ORDO/Orphanet_500
 CODAS syndrome	http://www.orpha.net/ORDO/Orphanet_1458
 Succinyl-CoA acetoacetate transferase deficiency	http://www.orpha.net/ORDO/Orphanet_832
 MITOCHONDRIAL DNA DEPLETION SYNDROME 11	http://www.orpha.net/ORDO/Orphanet_35698
@@ -3179,71 +3179,71 @@ Ganglioside sialidase deficiency	http://www.orpha.net/ORDO/Orphanet_578
 BODY MASS INDEX QUANTITATIVE TRAIT LOCUS 4	http://www.ebi.ac.uk/efo/EFO_0004340
 Chronic granuloma and hemolytic anemia	http://www.ebi.ac.uk/efo/EFO_0005558
 CIRRHOSIS	http://www.ebi.ac.uk/efo/EFO_0001422
-DYSTRANSTHYRETINEMIC EUTHYROIDAL HYPERTHYROXINEMIA	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0008247
+DYSTRANSTHYRETINEMIC EUTHYROIDAL HYPERTHYROXINEMIA	http://purl.obolibrary.org/obo/HP_0000006
 PYRUVATE DEHYDROGENASE E1-BETA DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_255138
-D-2-@HYDROXYGLUTARIC ACIDURIA 2	http://purl.obolibrary.org/obo/HP_0001638	http://purl.obolibrary.org/obo/HP_0012321	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000006
+D-2-@HYDROXYGLUTARIC ACIDURIA 2	http://purl.obolibrary.org/obo/HP_0001638
 Severe congenital neutropenia 6	http://www.orpha.net/ORDO/Orphanet_42738
-Ductal breast carcinoma	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0006318	http://www.ebi.ac.uk/efo/EFO_0000430
+Ductal breast carcinoma	http://www.ebi.ac.uk/efo/EFO_0000311
 BARDET-BIEDL SYNDROME 7	http://www.orpha.net/ORDO/Orphanet_110
 Focal segmental glomerulosclerosis and dilated cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0004236
 JOUBERT SYNDROME	http://www.orpha.net/ORDO/Orphanet_475
 NARCOLEPSY 7	http://www.ebi.ac.uk/efo/EFO_0000614
 SWANN BLOOD GROUP ANTIGEN	http://www.orpha.net/ORDO/Orphanet_119669
-NEPHRONOPHTHISIS 11	http://www.orpha.net/ORDO/Orphanet_475	http://www.orpha.net/ORDO/Orphanet_655
-GROWTH RETARDATION	http://purl.obolibrary.org/obo/HP_0001305	http://purl.obolibrary.org/obo/HP_0000278	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0000158	http://purl.obolibrary.org/obo/HP_0001339	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000238	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001276	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0001513	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0010808	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000193	http://purl.obolibrary.org/obo/HP_0001510	http://purl.obolibrary.org/obo/HP_0001792	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0000965	http://purl.obolibrary.org/obo/HP_0002678	http://purl.obolibrary.org/obo/HP_0000280	http://purl.obolibrary.org/obo/HP_0001629
-ARTHROGRYPOSIS	http://purl.obolibrary.org/obo/HP_0001181	http://purl.obolibrary.org/obo/HP_0000729	http://purl.obolibrary.org/obo/HP_0012385	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0002804	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0004976	http://purl.obolibrary.org/obo/HP_0000221	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000059	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000311	http://purl.obolibrary.org/obo/HP_0001848	http://purl.obolibrary.org/obo/HP_0000414	http://purl.obolibrary.org/obo/HP_0100490	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0003307	http://purl.obolibrary.org/obo/HP_0002553	http://purl.obolibrary.org/obo/HP_0002987	http://purl.obolibrary.org/obo/HP_0000308	http://purl.obolibrary.org/obo/HP_0002827
+NEPHRONOPHTHISIS 11	http://www.orpha.net/ORDO/Orphanet_475
+GROWTH RETARDATION	http://purl.obolibrary.org/obo/HP_0001305
+ARTHROGRYPOSIS	http://purl.obolibrary.org/obo/HP_0001181
 TRANSCOBALAMIN II DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_859
 RETINITIS PIGMENTOSA 25	http://www.orpha.net/ORDO/Orphanet_791
-ICHTHYOSIS VULGARIS	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0000976	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002099
+ICHTHYOSIS VULGARIS	http://purl.obolibrary.org/obo/HP_0008064
 KLIPPEL-FEIL SYNDROME 2	http://purl.obolibrary.org/obo/HP_0004602
-SPINOCEREBELLAR ATAXIA 12	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000317	http://purl.obolibrary.org/obo/HP_0007141	http://purl.obolibrary.org/obo/HP_0000496	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0000716	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002345	http://purl.obolibrary.org/obo/HP_0002346	http://purl.obolibrary.org/obo/HP_0002075	http://purl.obolibrary.org/obo/HP_0000739	http://purl.obolibrary.org/obo/HP_0001300	http://purl.obolibrary.org/obo/HP_0000726	http://purl.obolibrary.org/obo/HP_0002530	http://purl.obolibrary.org/obo/HP_0000746	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002073
+SPINOCEREBELLAR ATAXIA 12	http://purl.obolibrary.org/obo/HP_0001347
 DESMOSTEROLOSIS	http://www.orpha.net/ORDO/Orphanet_35107
 Mullerian aplasia and hyperandrogenism	http://www.orpha.net/ORDO/Orphanet_247768
-ANTERIOR SEGMENT MESENCHYMAL DYSGENESIS	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0007700	http://purl.obolibrary.org/obo/HP_0001115	http://purl.obolibrary.org/obo/HP_0009918	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0000501	http://purl.obolibrary.org/obo/HP_0000691	http://purl.obolibrary.org/obo/HP_0040199	http://purl.obolibrary.org/obo/HP_0011120	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0007759	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0001425	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0000627	http://purl.obolibrary.org/obo/HP_0007676	http://purl.obolibrary.org/obo/HP_0001320	http://purl.obolibrary.org/obo/HP_0000668
-PERIPHERAL NEUROPATHY	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0001609	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0009830	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0001760	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0008180	http://purl.obolibrary.org/obo/HP_0003676
+ANTERIOR SEGMENT MESENCHYMAL DYSGENESIS	http://purl.obolibrary.org/obo/HP_0000272
+PERIPHERAL NEUROPATHY	http://purl.obolibrary.org/obo/HP_0001284
 Hyperferritinemia cataract syndrome	http://www.ebi.ac.uk/efo/EFO_0001059
 Hyperinsulinism-hyperammonemia syndrome	http://www.orpha.net/ORDO/Orphanet_35878
 ULNAR-MAMMARY SYNDROME	http://www.orpha.net/ORDO/Orphanet_3138
-Hyperimmunoglobulin D with periodic fever	http://www.orpha.net/ORDO/Orphanet_343	http://www.orpha.net/ORDO/Orphanet_29	http://www.orpha.net/ORDO/Orphanet_79358
-COCKAYNE SYNDROME	http://purl.obolibrary.org/obo/HP_0000633	http://purl.obolibrary.org/obo/HP_0000303	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0000958	http://purl.obolibrary.org/obo/HP_0000992	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0007352	http://purl.obolibrary.org/obo/HP_0000509	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000491	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0000762	http://purl.obolibrary.org/obo/HP_0006958	http://purl.obolibrary.org/obo/HP_0002343	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007346	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0003130	http://purl.obolibrary.org/obo/HP_0007759	http://purl.obolibrary.org/obo/HP_0000670	http://purl.obolibrary.org/obo/HP_0003758	http://purl.obolibrary.org/obo/HP_0000689	http://purl.obolibrary.org/obo/HP_0000417	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0000054	http://purl.obolibrary.org/obo/HP_0001595	http://purl.obolibrary.org/obo/HP_0008639	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0003224	http://purl.obolibrary.org/obo/HP_0000540	http://purl.obolibrary.org/obo/HP_0001271	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0010234	http://purl.obolibrary.org/obo/HP_0011675	http://purl.obolibrary.org/obo/HP_0005328	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0003469	http://purl.obolibrary.org/obo/HP_0001029	http://purl.obolibrary.org/obo/HP_0000656	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0008070	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0000685	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0000292	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0000568	http://purl.obolibrary.org/obo/HP_0000093	http://purl.obolibrary.org/obo/HP_0000377	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0001009	http://purl.obolibrary.org/obo/HP_0001266	http://purl.obolibrary.org/obo/HP_0002866	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0002135	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0003079	http://purl.obolibrary.org/obo/HP_0002542	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000621	http://purl.obolibrary.org/obo/HP_0000613	http://purl.obolibrary.org/obo/HP_0002684	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0003278	http://purl.obolibrary.org/obo/HP_0000987	http://purl.obolibrary.org/obo/HP_0001525	http://purl.obolibrary.org/obo/HP_0001000	http://purl.obolibrary.org/obo/HP_0001480	http://purl.obolibrary.org/obo/HP_0000649	http://purl.obolibrary.org/obo/HP_0003510	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000580	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0001268	http://purl.obolibrary.org/obo/HP_0000939	http://purl.obolibrary.org/obo/HP_0008839	http://purl.obolibrary.org/obo/HP_0011359	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0000680	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0000970	http://purl.obolibrary.org/obo/HP_0004334	http://purl.obolibrary.org/obo/HP_0001376	http://purl.obolibrary.org/obo/HP_0007676	http://purl.obolibrary.org/obo/HP_0002059	http://purl.obolibrary.org/obo/HP_0002545
+Hyperimmunoglobulin D with periodic fever	http://www.orpha.net/ORDO/Orphanet_343
+COCKAYNE SYNDROME	http://purl.obolibrary.org/obo/HP_0000633
 Myhre syndrome	http://www.orpha.net/ORDO/Orphanet_2588
 Cerebellar vermis hypoplasia	http://purl.obolibrary.org/obo/HP_0001320
 Focal segmental glomerulosclerosis	http://www.ebi.ac.uk/efo/EFO_0004236
-Clear cell carcinoma of kidney	http://www.ebi.ac.uk/efo/EFO_0000349	http://www.ebi.ac.uk/efo/EFO_0000400	http://www.ebi.ac.uk/efo/EFO_0001359
+Clear cell carcinoma of kidney	http://www.ebi.ac.uk/efo/EFO_0000349
 Sezary syndrome	http://www.ebi.ac.uk/efo/EFO_1000785
 WEILL-MARCHESANI SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_3449
-Pulmonary valve stenosis (rare)	http://www.ebi.ac.uk/efo/EFO_1001138	http://www.ebi.ac.uk/efo/EFO_0000275
+Pulmonary valve stenosis (rare)	http://www.ebi.ac.uk/efo/EFO_1001138
 SPASTIC PARAPLEGIA 2	http://purl.obolibrary.org/obo/HP_0001258
 MAPLE SYRUP URINE DISEASE	http://www.orpha.net/ORDO/Orphanet_511
 Familial hypokalemia-hypomagnesemia	http://www.orpha.net/ORDO/Orphanet_358
 RENPENNING SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_3242
-LINEAR SKIN DEFECTS WITH MULTIPLE CONGENITAL ANOMALIES 3	http://purl.obolibrary.org/obo/HP_0001274	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0001663	http://purl.obolibrary.org/obo/HP_0001695	http://purl.obolibrary.org/obo/HP_0006956	http://purl.obolibrary.org/obo/HP_0000564	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004756	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0000639
+LINEAR SKIN DEFECTS WITH MULTIPLE CONGENITAL ANOMALIES 3	http://purl.obolibrary.org/obo/HP_0001274
 GROWTH HORMONE DEFICIENCY WITH PITUITARY ANOMALIES	http://www.orpha.net/ORDO/Orphanet_3157
-Giant pigmented hairy nevus	http://www.orpha.net/ORDO/Orphanet_2481	http://www.orpha.net/ORDO/Orphanet_626
+Giant pigmented hairy nevus	http://www.orpha.net/ORDO/Orphanet_2481
 CARNITINE-ACYLCARNITINE TRANSLOCASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_159
 Zonular pulverulent cataract 3	http://www.orpha.net/ORDO/Orphanet_98984
-CONE-ROD DYSTROPHY	http://purl.obolibrary.org/obo/HP_0000551	http://purl.obolibrary.org/obo/HP_0008323	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000603	http://purl.obolibrary.org/obo/HP_0008002	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0200056	http://purl.obolibrary.org/obo/HP_0000548	http://purl.obolibrary.org/obo/HP_0000613	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001939
-Stormorken syndrome	http://purl.obolibrary.org/obo/HP_0000421	http://purl.obolibrary.org/obo/HP_0000615	http://purl.obolibrary.org/obo/HP_0003011	http://purl.obolibrary.org/obo/HP_0003750	http://purl.obolibrary.org/obo/HP_0010522	http://purl.obolibrary.org/obo/HP_0001743	http://purl.obolibrary.org/obo/HP_0002401	http://purl.obolibrary.org/obo/HP_0001928	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0000348	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003701	http://purl.obolibrary.org/obo/HP_0000448	http://purl.obolibrary.org/obo/HP_0001746	http://purl.obolibrary.org/obo/HP_0001872	http://purl.obolibrary.org/obo/HP_0000616	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0000490	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003326	http://purl.obolibrary.org/obo/HP_0000601	http://purl.obolibrary.org/obo/HP_0003198	http://purl.obolibrary.org/obo/HP_0001933	http://purl.obolibrary.org/obo/HP_0002167
-SYSTEMIC LUPUS ERYTHEMATOSUS	http://www.ebi.ac.uk/efo/EFO_0001068	http://www.ebi.ac.uk/efo/EFO_0002690
+CONE-ROD DYSTROPHY	http://purl.obolibrary.org/obo/HP_0000551
+Stormorken syndrome	http://purl.obolibrary.org/obo/HP_0000421
+SYSTEMIC LUPUS ERYTHEMATOSUS	http://www.ebi.ac.uk/efo/EFO_0001068
 CAMPOMELIC DYSPLASIA WITH AUTOSOMAL SEX REVERSAL	http://www.orpha.net/ORDO/Orphanet_140
-RADIOULNAR SYNOSTOSIS WITH AMEGAKARYOCYTIC THROMBOCYTOPENIA	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0005548	http://purl.obolibrary.org/obo/HP_0003272	http://purl.obolibrary.org/obo/HP_0003031	http://purl.obolibrary.org/obo/HP_0001159	http://purl.obolibrary.org/obo/HP_0006101	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000967	http://purl.obolibrary.org/obo/HP_0004859	http://purl.obolibrary.org/obo/HP_0006394	http://purl.obolibrary.org/obo/HP_0000979	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0002986	http://purl.obolibrary.org/obo/HP_0005037	http://purl.obolibrary.org/obo/HP_0001905	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0001915	http://purl.obolibrary.org/obo/HP_0003182	http://purl.obolibrary.org/obo/HP_0005528	http://purl.obolibrary.org/obo/HP_0002827	http://purl.obolibrary.org/obo/HP_0002974
+RADIOULNAR SYNOSTOSIS WITH AMEGAKARYOCYTIC THROMBOCYTOPENIA	http://purl.obolibrary.org/obo/HP_0001873
 Dysmorphism	http://purl.obolibrary.org/obo/HP_0001252
-BONE MARROW FAILURE	http://purl.obolibrary.org/obo/HP_0002863	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001915	http://purl.obolibrary.org/obo/HP_0005528
-Eichsfeld type congenital muscular dystrophy	http://www.orpha.net/ORDO/Orphanet_97242	http://www.orpha.net/ORDO/Orphanet_2020
-DYSKINESIA	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0000317	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0002072	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0100660	http://purl.obolibrary.org/obo/HP_0000739	http://purl.obolibrary.org/obo/HP_0002322	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0002509	http://purl.obolibrary.org/obo/HP_0003621
+BONE MARROW FAILURE	http://purl.obolibrary.org/obo/HP_0002863
+Eichsfeld type congenital muscular dystrophy	http://www.orpha.net/ORDO/Orphanet_97242
+DYSKINESIA	http://purl.obolibrary.org/obo/HP_0001347
 CAMPTODACTYLY-ARTHROPATHY-COXA VARA-PERICARDITIS SYNDROME	http://www.orpha.net/ORDO/Orphanet_2848
 Bulls eye macular dystrophy	http://www.ebi.ac.uk/efo/EFO_0001365
 DIAPHRAGMATIC HERNIA 3	http://www.ebi.ac.uk/efo/EFO_0007216
 Erythropoietic protoporphyria	http://www.orpha.net/ORDO/Orphanet_79278
-Beta-thalassemia major	http://www.orpha.net/ORDO/Orphanet_231214	http://www.orpha.net/ORDO/Orphanet_848
-Carcinoma of pancreas	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0002618
-Lafora disease	http://www.orpha.net/ORDO/Orphanet_98261	http://www.orpha.net/ORDO/Orphanet_501
+Beta-thalassemia major	http://www.orpha.net/ORDO/Orphanet_231214
+Carcinoma of pancreas	http://www.ebi.ac.uk/efo/EFO_0000311
+Lafora disease	http://www.orpha.net/ORDO/Orphanet_98261
 Vitelliform dystrophy	http://www.ebi.ac.uk/efo/EFO_0001365
 Slightly reduced reflexes	http://purl.obolibrary.org/obo/HP_0002075
-Diabetes Mellitus	http://purl.obolibrary.org/obo/HP_0000377	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0001684	http://purl.obolibrary.org/obo/HP_0005978	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000768	http://purl.obolibrary.org/obo/HP_0001387	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000609	http://purl.obolibrary.org/obo/HP_0000331	http://purl.obolibrary.org/obo/HP_0012642	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001732	http://purl.obolibrary.org/obo/HP_0010557	http://www.ebi.ac.uk/efo/EFO_0000400	http://purl.obolibrary.org/obo/HP_0001250	http://www.ebi.ac.uk/efo/EFO_0001359	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0000325	http://purl.obolibrary.org/obo/HP_0001002	http://purl.obolibrary.org/obo/HP_0000444
+Diabetes Mellitus	http://purl.obolibrary.org/obo/HP_0000377
 Osteopetrosis with renal tubular acidosis	http://www.orpha.net/ORDO/Orphanet_2785
 GAMMA-GLUTAMYLCYSTEINE SYNTHETASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_33574
-SPASTIC PARAPLEGIA 44	http://purl.obolibrary.org/obo/HP_0000020	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002064	http://purl.obolibrary.org/obo/HP_0002061	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0002936	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0006986	http://purl.obolibrary.org/obo/HP_0000514
+SPASTIC PARAPLEGIA 44	http://purl.obolibrary.org/obo/HP_0000020
 Sialic acid storage disease	http://www.orpha.net/ORDO/Orphanet_309324
 COWDEN SYNDROME 6	http://www.orpha.net/ORDO/Orphanet_201
 ARTERIAL TORTUOSITY SYNDROME	http://www.orpha.net/ORDO/Orphanet_3342
@@ -3251,18 +3251,18 @@ FOCAL SEGMENTAL GLOMERULOSCLEROSIS 6	http://www.ebi.ac.uk/efo/EFO_0004236
 Dent disease 1	http://www.orpha.net/ORDO/Orphanet_1652
 NEMALINE MYOPATHY 2	http://www.orpha.net/ORDO/Orphanet_607
 Autism 1	http://www.ebi.ac.uk/efo/EFO_0003758
-Mitochondrial myopathy with lactic acidosis	http://purl.obolibrary.org/obo/HP_0003348	http://purl.obolibrary.org/obo/HP_0001269	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0001939	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0040083	http://purl.obolibrary.org/obo/HP_0003198	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0003542	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0003457	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0002384	http://purl.obolibrary.org/obo/HP_0008504	http://purl.obolibrary.org/obo/HP_0002572	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0003737	http://purl.obolibrary.org/obo/HP_0003391	http://purl.obolibrary.org/obo/HP_0000407
-SPASTIC PARAPLEGIA 53	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0001288	http://purl.obolibrary.org/obo/HP_0002169	http://purl.obolibrary.org/obo/HP_0001258	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000768	http://purl.obolibrary.org/obo/HP_0002808
-Dilated cardiomyopathy 1P	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318
-DYSKERATOSIS CONGENITA X-LINKED	http://www.orpha.net/ORDO/Orphanet_1775	http://www.orpha.net/ORDO/Orphanet_3322
+Mitochondrial myopathy with lactic acidosis	http://purl.obolibrary.org/obo/HP_0003348
+SPASTIC PARAPLEGIA 53	http://purl.obolibrary.org/obo/HP_0000007
+Dilated cardiomyopathy 1P	http://www.ebi.ac.uk/efo/EFO_0000407
+DYSKERATOSIS CONGENITA X-LINKED	http://www.orpha.net/ORDO/Orphanet_1775
 ALZHEIMER DISEASE 18	http://www.ebi.ac.uk/efo/EFO_0000249
-RETINITIS PIGMENTOSA 39	http://www.orpha.net/ORDO/Orphanet_231178	http://www.orpha.net/ORDO/Orphanet_791
-HYPOTRICHOSIS 11	http://purl.obolibrary.org/obo/HP_0100840	http://purl.obolibrary.org/obo/HP_0001006	http://purl.obolibrary.org/obo/HP_0002221	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0200102
-CRANIODIAPHYSEAL DYSPLASIA	http://purl.obolibrary.org/obo/HP_0005464	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0000452	http://purl.obolibrary.org/obo/HP_0003155	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0004493	http://purl.obolibrary.org/obo/HP_0001349	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0001085	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0011120	http://purl.obolibrary.org/obo/HP_0003165	http://purl.obolibrary.org/obo/HP_0000529	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0003034	http://purl.obolibrary.org/obo/HP_0002315	http://purl.obolibrary.org/obo/HP_0002516	http://purl.obolibrary.org/obo/HP_0000900
-Gerstmann-Straussler-Scheinker syndrome	http://www.orpha.net/ORDO/Orphanet_356	http://www.orpha.net/ORDO/Orphanet_157941
+RETINITIS PIGMENTOSA 39	http://www.orpha.net/ORDO/Orphanet_231178
+HYPOTRICHOSIS 11	http://purl.obolibrary.org/obo/HP_0100840
+CRANIODIAPHYSEAL DYSPLASIA	http://purl.obolibrary.org/obo/HP_0005464
+Gerstmann-Straussler-Scheinker syndrome	http://www.orpha.net/ORDO/Orphanet_356
 Protan defect	http://www.ebi.ac.uk/efo/EFO_0005580
 Hystrix-like ichthyosis with deafness	http://www.ebi.ac.uk/efo/EFO_0001063
-SPINOCEREBELLAR ATAXIA 8	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0000716	http://purl.obolibrary.org/obo/HP_0009830	http://purl.obolibrary.org/obo/HP_0002459	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002172	http://purl.obolibrary.org/obo/HP_0002311	http://purl.obolibrary.org/obo/HP_0100315	http://purl.obolibrary.org/obo/HP_0002322	http://purl.obolibrary.org/obo/HP_0000298	http://purl.obolibrary.org/obo/HP_0001300	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0002529	http://purl.obolibrary.org/obo/HP_0000738	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0011960	http://purl.obolibrary.org/obo/HP_0000012	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0007256	http://purl.obolibrary.org/obo/HP_0000751	http://purl.obolibrary.org/obo/HP_0002067	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0002062	http://purl.obolibrary.org/obo/HP_0003587	http://purl.obolibrary.org/obo/HP_0007772	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0002360	http://purl.obolibrary.org/obo/HP_0000641	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0000726	http://purl.obolibrary.org/obo/HP_0000763	http://purl.obolibrary.org/obo/HP_0007311	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0002073	http://purl.obolibrary.org/obo/HP_0001621	http://purl.obolibrary.org/obo/HP_0000514
+SPINOCEREBELLAR ATAXIA 8	http://purl.obolibrary.org/obo/HP_0001337
 PROLONGED ELECTRORETINAL RESPONSE SUPPRESSION	http://www.orpha.net/ORDO/Orphanet_75374
 Pituitary dependent hypercortisolism	http://www.orpha.net/ORDO/Orphanet_553
 PACHYONYCHIA CONGENITA 4	http://www.orpha.net/ORDO/Orphanet_2309
@@ -3273,28 +3273,28 @@ PSEUDOHYPERKALEMIA	http://www.orpha.net/ORDO/Orphanet_90044
 CHILBLAIN LUPUS 2	http://www.orpha.net/ORDO/Orphanet_90280
 Loeys-Dietz syndrome	http://www.orpha.net/ORDO/Orphanet_60030
 RETINITIS PIGMENTOSA 2	http://www.orpha.net/ORDO/Orphanet_791
-Dyggve-Melchior-Clausen syndrome	http://www.orpha.net/ORDO/Orphanet_178355	http://www.orpha.net/ORDO/Orphanet_239
+Dyggve-Melchior-Clausen syndrome	http://www.orpha.net/ORDO/Orphanet_178355
 Howel-Evans syndrome	http://www.orpha.net/ORDO/Orphanet_1959
 CYSTATHIONINURIA	http://www.orpha.net/ORDO/Orphanet_212
 PARIETAL FORAMINA 1	http://www.orpha.net/ORDO/Orphanet_60015
-ATRIAL STANDSTILL 2	http://purl.obolibrary.org/obo/HP_0001638	http://purl.obolibrary.org/obo/HP_0001662
-Aicardi-Goutieres syndrome 7	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0001047	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0000100	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000737	http://purl.obolibrary.org/obo/HP_0002135	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002633	http://purl.obolibrary.org/obo/HP_0000496	http://purl.obolibrary.org/obo/HP_0001873	http://purl.obolibrary.org/obo/HP_0010702	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001285	http://purl.obolibrary.org/obo/HP_0002376	http://purl.obolibrary.org/obo/HP_0002059
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 3	http://purl.obolibrary.org/obo/HP_0008347	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001298	http://purl.obolibrary.org/obo/HP_0011924	http://purl.obolibrary.org/obo/HP_0003819	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003201	http://purl.obolibrary.org/obo/HP_0002878	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0008872	http://purl.obolibrary.org/obo/HP_0011923	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0005157	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0001558	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0001138	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0002119	http://purl.obolibrary.org/obo/HP_0001655	http://purl.obolibrary.org/obo/HP_0001263
+ATRIAL STANDSTILL 2	http://purl.obolibrary.org/obo/HP_0001638
+Aicardi-Goutieres syndrome 7	http://purl.obolibrary.org/obo/HP_0001511
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 3	http://purl.obolibrary.org/obo/HP_0008347
 BARDET-BIEDL SYNDROME 8	http://www.orpha.net/ORDO/Orphanet_110
 Optic Atrophy Type 1	http://www.orpha.net/ORDO/Orphanet_103
-CILIARY DYSKINESIA	http://purl.obolibrary.org/obo/HP_0012384	http://purl.obolibrary.org/obo/HP_0000388	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0012207	http://purl.obolibrary.org/obo/HP_0012262	http://purl.obolibrary.org/obo/HP_0012256	http://purl.obolibrary.org/obo/HP_0000389	http://purl.obolibrary.org/obo/HP_0012208	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0004469	http://purl.obolibrary.org/obo/HP_0002643	http://purl.obolibrary.org/obo/HP_0012260	http://purl.obolibrary.org/obo/HP_0003546	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0003251	http://purl.obolibrary.org/obo/HP_0002205	http://purl.obolibrary.org/obo/HP_0011108	http://purl.obolibrary.org/obo/HP_0006532	http://purl.obolibrary.org/obo/HP_0005938	http://purl.obolibrary.org/obo/HP_0012259	http://purl.obolibrary.org/obo/HP_0100582	http://purl.obolibrary.org/obo/HP_0002110	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0200109	http://www.orpha.net/ORDO/Orphanet_244	http://purl.obolibrary.org/obo/HP_0002257	http://purl.obolibrary.org/obo/HP_0000789	http://purl.obolibrary.org/obo/HP_0011109	http://purl.obolibrary.org/obo/HP_0001696	http://purl.obolibrary.org/obo/HP_0000246	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0002837	http://purl.obolibrary.org/obo/HP_0000403	http://purl.obolibrary.org/obo/HP_0012257	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0002098	http://purl.obolibrary.org/obo/HP_0012263	http://purl.obolibrary.org/obo/HP_0200073	http://purl.obolibrary.org/obo/HP_0012735	http://purl.obolibrary.org/obo/HP_0100750	http://purl.obolibrary.org/obo/HP_0012265
-MULTIPLE CONGENITAL ANOMALIES-HYPOTONIA-SEIZURES SYNDROME 1	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0000341	http://purl.obolibrary.org/obo/HP_0000646	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0001266	http://purl.obolibrary.org/obo/HP_0000034	http://purl.obolibrary.org/obo/HP_0000076	http://purl.obolibrary.org/obo/HP_0002265	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002023	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000233	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002025	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000194	http://purl.obolibrary.org/obo/HP_0002020	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0000396	http://purl.obolibrary.org/obo/HP_0000126	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0001561	http://purl.obolibrary.org/obo/HP_0000280	http://purl.obolibrary.org/obo/HP_0000256
+CILIARY DYSKINESIA	http://purl.obolibrary.org/obo/HP_0012384
+MULTIPLE CONGENITAL ANOMALIES-HYPOTONIA-SEIZURES SYNDROME 1	http://purl.obolibrary.org/obo/HP_0003577
 CATARACT 43	http://www.ebi.ac.uk/efo/EFO_0001059
 Oculomaxillofacial dysostosis	http://www.orpha.net/ORDO/Orphanet_1794
 HYPERTHYROXINEMIA	http://www.ebi.ac.uk/efo/EFO_0004127
-HYPOCALCEMIA	http://purl.obolibrary.org/obo/HP_0000787	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003401	http://purl.obolibrary.org/obo/HP_0002900	http://purl.obolibrary.org/obo/HP_0000848	http://www.orpha.net/ORDO/Orphanet_112	http://purl.obolibrary.org/obo/HP_0002901	http://purl.obolibrary.org/obo/HP_0000121	http://purl.obolibrary.org/obo/HP_0002135	http://purl.obolibrary.org/obo/HP_0002150	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0002917	http://purl.obolibrary.org/obo/HP_0001281	http://purl.obolibrary.org/obo/HP_0003394	http://purl.obolibrary.org/obo/HP_0012211
+HYPOCALCEMIA	http://purl.obolibrary.org/obo/HP_0000787
 BECKWITH-WIEDEMANN SYNDROME	http://www.orpha.net/ORDO/Orphanet_116
 Familial hemiplegic migraine type 3	http://www.ebi.ac.uk/efo/EFO_0003821
-COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 10	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0003348	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0001942	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0001943	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0011675	http://purl.obolibrary.org/obo/HP_0002465	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001508
+COMBINED OXIDATIVE PHOSPHORYLATION DEFICIENCY 10	http://purl.obolibrary.org/obo/HP_0100543
 Liver failure acute infantile	http://www.orpha.net/ORDO/Orphanet_217371
-Hyperlipoproteinemia	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0000660	http://purl.obolibrary.org/obo/HP_0003077	http://purl.obolibrary.org/obo/HP_0001733	http://purl.obolibrary.org/obo/HP_0003124	http://purl.obolibrary.org/obo/HP_0002574	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0002018	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001013	http://purl.obolibrary.org/obo/HP_0000952	http://purl.obolibrary.org/obo/HP_0012238	http://purl.obolibrary.org/obo/HP_0010980	http://purl.obolibrary.org/obo/HP_0001433
+Hyperlipoproteinemia	http://purl.obolibrary.org/obo/HP_0002013
 Foveal hypoplasia and presenile cataract syndrome	http://www.ebi.ac.uk/efo/EFO_0001059
-Benign familial neonatal seizures 1	http://www.orpha.net/ORDO/Orphanet_1949	http://www.orpha.net/ORDO/Orphanet_1934
+Benign familial neonatal seizures 1	http://www.orpha.net/ORDO/Orphanet_1949
 Friedreichs ataxia	http://www.orpha.net/ORDO/Orphanet_183518
 MARSHALL/STICKLER SYNDROME	http://www.orpha.net/ORDO/Orphanet_828
 Renal carnitine transport defect	http://www.orpha.net/ORDO/Orphanet_158
@@ -3304,65 +3304,65 @@ GALACTOSE EPIMERASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_79238
 Familial renal hypouricemia	http://www.orpha.net/ORDO/Orphanet_94088
 Neuroblastoma 3	http://www.ebi.ac.uk/efo/EFO_0000621
 CONE-ROD DYSTROPHY 2	http://www.orpha.net/ORDO/Orphanet_1872
-Hypoprebetalipoproteinemia	http://www.orpha.net/ORDO/Orphanet_157855	http://www.orpha.net/ORDO/Orphanet_157850	http://www.orpha.net/ORDO/Orphanet_385
+Hypoprebetalipoproteinemia	http://www.orpha.net/ORDO/Orphanet_157855
 NETHERTON SYNDROME	http://www.orpha.net/ORDO/Orphanet_634
 Dysequilibrium syndrome	http://www.orpha.net/ORDO/Orphanet_1766
 SORSBY FUNDUS DYSTROPHY	http://www.orpha.net/ORDO/Orphanet_59181
 Dilated cardiomyopathy 1CC	http://www.ebi.ac.uk/efo/EFO_0000407
-IMMUNODEFICIENCY DUE TO DEFECT IN CD3-ZETA	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0004385	http://purl.obolibrary.org/obo/HP_0005353	http://purl.obolibrary.org/obo/HP_0005403	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0001880
-MYOCLONUS	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003581	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0002527
+IMMUNODEFICIENCY DUE TO DEFECT IN CD3-ZETA	http://purl.obolibrary.org/obo/HP_0000007
+MYOCLONUS	http://purl.obolibrary.org/obo/HP_0003677
 MAST CELL DISEASE	http://www.orpha.net/ORDO/Orphanet_2467
 Maple syrup urine disease type 1A	http://www.orpha.net/ORDO/Orphanet_511
-Mitchell-Riley syndrome	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0005235	http://purl.obolibrary.org/obo/HP_0005912	http://purl.obolibrary.org/obo/HP_0003074	http://purl.obolibrary.org/obo/HP_0002247	http://purl.obolibrary.org/obo/HP_0011467	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002566	http://purl.obolibrary.org/obo/HP_0001545	http://purl.obolibrary.org/obo/HP_0011985	http://purl.obolibrary.org/obo/HP_0002904	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0002024
+Mitchell-Riley syndrome	http://purl.obolibrary.org/obo/HP_0001511
 ROIFMAN SYNDROME	http://www.orpha.net/ORDO/Orphanet_353298
-COLON CANCER	http://www.ebi.ac.uk/efo/EFO_0004288	http://www.ebi.ac.uk/efo/EFO_0000365
-GLAUCOMA 1	http://purl.obolibrary.org/obo/HP_0007854	http://purl.obolibrary.org/obo/HP_0012108	http://purl.obolibrary.org/obo/HP_0007906	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0012796	http://www.ebi.ac.uk/efo/EFO_0000516
-Bone fragility with contractures	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0002756	http://purl.obolibrary.org/obo/HP_0000377	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0002714	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0004944	http://purl.obolibrary.org/obo/HP_0002164	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0003393	http://purl.obolibrary.org/obo/HP_0003090	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0002680	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0012368	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0000978	http://purl.obolibrary.org/obo/HP_0001762	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0009110	http://purl.obolibrary.org/obo/HP_0000926	http://purl.obolibrary.org/obo/HP_0006184	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0003196	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000586	http://purl.obolibrary.org/obo/HP_0002208	http://purl.obolibrary.org/obo/HP_0002987
-METHYLMALONATE SEMIALDEHYDE DEHYDROGENASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0001942
-Ventricular tachycardia	http://www.ebi.ac.uk/efo/EFO_0004269	http://www.ebi.ac.uk/efo/EFO_0005306
-IMMUNODEFICIENCY 16	http://purl.obolibrary.org/obo/HP_0004844	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001876	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0100726	http://purl.obolibrary.org/obo/HP_0001744
-Cardiac conduction disease with or without dilated cardiomyopathy	http://purl.obolibrary.org/obo/HP_0004749	http://purl.obolibrary.org/obo/HP_0001644	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001692	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0011711	http://purl.obolibrary.org/obo/HP_0005110
+COLON CANCER	http://www.ebi.ac.uk/efo/EFO_0004288
+GLAUCOMA 1	http://purl.obolibrary.org/obo/HP_0007854
+Bone fragility with contractures	http://purl.obolibrary.org/obo/HP_0000272
+METHYLMALONATE SEMIALDEHYDE DEHYDROGENASE DEFICIENCY	http://purl.obolibrary.org/obo/HP_0000252
+Ventricular tachycardia	http://www.ebi.ac.uk/efo/EFO_0004269
+IMMUNODEFICIENCY 16	http://purl.obolibrary.org/obo/HP_0004844
+Cardiac conduction disease with or without dilated cardiomyopathy	http://purl.obolibrary.org/obo/HP_0004749
 RETINITIS PIGMENTOSA 26	http://www.orpha.net/ORDO/Orphanet_791
 Cataract 4	http://www.ebi.ac.uk/efo/EFO_0001059
-RENAL CELL CARCINOMA	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0006766
-PEROXISOME BIOGENESIS DISORDER 6B	http://purl.obolibrary.org/obo/HP_0003693	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0007772	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000556	http://purl.obolibrary.org/obo/HP_0000641	http://purl.obolibrary.org/obo/HP_0001410	http://purl.obolibrary.org/obo/HP_0000505	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0002500	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0002936	http://purl.obolibrary.org/obo/HP_0000639
-RETT SYNDROME	http://www.orpha.net/ORDO/Orphanet_72	http://www.orpha.net/ORDO/Orphanet_3095	http://www.orpha.net/ORDO/Orphanet_209370	http://www.orpha.net/ORDO/Orphanet_3077	http://www.orpha.net/ORDO/Orphanet_778
-TRANSIENT BULLOUS DERMOLYSIS OF THE NEWBORN	http://www.orpha.net/ORDO/Orphanet_89843	http://www.orpha.net/ORDO/Orphanet_79411
+RENAL CELL CARCINOMA	http://purl.obolibrary.org/obo/HP_0000006
+PEROXISOME BIOGENESIS DISORDER 6B	http://purl.obolibrary.org/obo/HP_0003693
+RETT SYNDROME	http://www.orpha.net/ORDO/Orphanet_72
+TRANSIENT BULLOUS DERMOLYSIS OF THE NEWBORN	http://www.orpha.net/ORDO/Orphanet_89843
 AMYOTROPHIC LATERAL SCLEROSIS 1	http://www.ebi.ac.uk/efo/EFO_0000253
-JERVELL AND LANGE-NIELSEN SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_768	http://www.orpha.net/ORDO/Orphanet_90647
+JERVELL AND LANGE-NIELSEN SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_768
 Left ventricular noncompaction 8	http://www.orpha.net/ORDO/Orphanet_54260
 Primary progressive aphasia	http://www.orpha.net/ORDO/Orphanet_95432
 Pigmentary retinopathy and sensorineural deafness	http://www.ebi.ac.uk/efo/EFO_0003839
-Juvenile nephropathic cystinosis	http://www.orpha.net/ORDO/Orphanet_213	http://www.orpha.net/ORDO/Orphanet_411634
+Juvenile nephropathic cystinosis	http://www.orpha.net/ORDO/Orphanet_213
 Sensorineural deafness with hypertrophic cardiomyopathy	http://www.ebi.ac.uk/efo/EFO_0001063
-Meckel-Gruber syndrome	http://www.orpha.net/ORDO/Orphanet_65	http://www.orpha.net/ORDO/Orphanet_475	http://www.orpha.net/ORDO/Orphanet_564
-FRUCTOSURIA	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0011033
+Meckel-Gruber syndrome	http://www.orpha.net/ORDO/Orphanet_65
+FRUCTOSURIA	http://purl.obolibrary.org/obo/HP_0000007
 Antithrombin III deficiency	http://www.orpha.net/ORDO/Orphanet_82
 Pulmonary hypertension	http://www.ebi.ac.uk/efo/EFO_0001361
 POIKILODERMA WITH NEUTROPENIA	http://www.orpha.net/ORDO/Orphanet_221046
 Mosaic variegated aneuploidy syndrome 2	http://www.orpha.net/ORDO/Orphanet_1052
-Early infantile epileptic encephalopathy 7	http://www.orpha.net/ORDO/Orphanet_1949	http://www.orpha.net/ORDO/Orphanet_1934
+Early infantile epileptic encephalopathy 7	http://www.orpha.net/ORDO/Orphanet_1949
 RETINITIS PIGMENTOSA 40	http://www.orpha.net/ORDO/Orphanet_791
 BASAL LAMINAR DRUSEN	http://www.ebi.ac.uk/efo/EFO_1001155
-Retinitis pigmentosa	http://www.orpha.net/ORDO/Orphanet_231178	http://www.orpha.net/ORDO/Orphanet_791	http://www.orpha.net/ORDO/Orphanet_71862
-TETRALOGY OF FALLOT	http://www.orpha.net/ORDO/Orphanet_3303	http://www.orpha.net/ORDO/Orphanet_1480
-ATRIAL FIBRILLATION	http://purl.obolibrary.org/obo/HP_0004757	http://purl.obolibrary.org/obo/HP_0001962	http://purl.obolibrary.org/obo/HP_0005184	http://www.orpha.net/ORDO/Orphanet_334	http://purl.obolibrary.org/obo/HP_0005110	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0012248	http://www.orpha.net/ORDO/Orphanet_130	http://www.orpha.net/ORDO/Orphanet_768	http://www.ebi.ac.uk/efo/EFO_0000275
+Retinitis pigmentosa	http://www.orpha.net/ORDO/Orphanet_231178
+TETRALOGY OF FALLOT	http://www.orpha.net/ORDO/Orphanet_3303
+ATRIAL FIBRILLATION	http://purl.obolibrary.org/obo/HP_0004757
 Deficiency of aromatic-L-amino-acid decarboxylase	http://www.orpha.net/ORDO/Orphanet_35708
-Atrioventricular septal defect 5	http://purl.obolibrary.org/obo/HP_0011623	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0006695
-SEIZURES	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0002076	http://purl.obolibrary.org/obo/HP_0002197	http://purl.obolibrary.org/obo/HP_0040168	http://purl.obolibrary.org/obo/HP_0000006	http://www.orpha.net/ORDO/Orphanet_1949
-SHORT STATURE	http://purl.obolibrary.org/obo/HP_0002057	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0001852	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000540	http://purl.obolibrary.org/obo/HP_0000341	http://purl.obolibrary.org/obo/HP_0000324	http://purl.obolibrary.org/obo/HP_0000574	http://purl.obolibrary.org/obo/HP_0001159	http://purl.obolibrary.org/obo/HP_0000276	http://purl.obolibrary.org/obo/HP_0002213	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000545	http://purl.obolibrary.org/obo/HP_0000954	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0007663	http://purl.obolibrary.org/obo/HP_0000486	http://purl.obolibrary.org/obo/HP_0000520	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0002983	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000973	http://purl.obolibrary.org/obo/HP_0000286	http://purl.obolibrary.org/obo/HP_0000233	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0000248	http://purl.obolibrary.org/obo/HP_0008897	http://purl.obolibrary.org/obo/HP_0200068
-SPINOCEREBELLAR ATAXIA 7	http://www.orpha.net/ORDO/Orphanet_159904	http://www.orpha.net/ORDO/Orphanet_98764
-Chronic granulomatous disease	http://www.orpha.net/ORDO/Orphanet_379	http://www.orpha.net/ORDO/Orphanet_120935	http://www.orpha.net/ORDO/Orphanet_123524
-Somatotroph adenoma	http://www.ebi.ac.uk/efo/EFO_0007483	http://www.ebi.ac.uk/efo/EFO_1000052	http://www.ebi.ac.uk/efo/EFO_0000232
+Atrioventricular septal defect 5	http://purl.obolibrary.org/obo/HP_0011623
+SEIZURES	http://purl.obolibrary.org/obo/HP_0003829
+SHORT STATURE	http://purl.obolibrary.org/obo/HP_0002057
+SPINOCEREBELLAR ATAXIA 7	http://www.orpha.net/ORDO/Orphanet_159904
+Chronic granulomatous disease	http://www.orpha.net/ORDO/Orphanet_379
+Somatotroph adenoma	http://www.ebi.ac.uk/efo/EFO_0007483
 CORNELIA DE LANGE SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_199
 Colorectal cancer 1	http://www.ebi.ac.uk/efo/EFO_0005842
 Hereditary angioneurotic edema with normal C1 esterase inhibitor activity	http://www.orpha.net/ORDO/Orphanet_100054
-Renal hypodysplasia	http://purl.obolibrary.org/obo/HP_0003829	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0003774	http://purl.obolibrary.org/obo/HP_0000074	http://purl.obolibrary.org/obo/HP_0000076
+Renal hypodysplasia	http://purl.obolibrary.org/obo/HP_0003829
 Coproporphyria	http://www.orpha.net/ORDO/Orphanet_120783
 Amyotrophic lateral sclerosis type 1	http://www.ebi.ac.uk/efo/EFO_0000253
 HISTIDINEMIA	http://www.orpha.net/ORDO/Orphanet_2157
 SULFITE OXIDASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_833
-CATARACTS	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0007141	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0003416	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0000518	http://purl.obolibrary.org/obo/HP_0000343	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0004322	http://www.ebi.ac.uk/efo/EFO_0001059	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0000824	http://purl.obolibrary.org/obo/HP_0002936	http://purl.obolibrary.org/obo/HP_0001374	http://purl.obolibrary.org/obo/HP_0000639
+CATARACTS	http://purl.obolibrary.org/obo/HP_0001371
 SNOWFLAKE VITREORETINAL DEGENERATION	http://www.orpha.net/ORDO/Orphanet_91496
 Joubert syndrome 24	http://www.orpha.net/ORDO/Orphanet_475
 Congenital disorder of glycosylation type 2k	http://www.orpha.net/ORDO/Orphanet_137
@@ -3373,30 +3373,30 @@ Achromatopsia 6	http://www.orpha.net/ORDO/Orphanet_49382
 Glanzmanns thrombasthenia	http://www.orpha.net/ORDO/Orphanet_849
 SCHWANNOMATOSIS 1	http://www.orpha.net/ORDO/Orphanet_93921
 3-methylglutaconic aciduria with deafness	http://www.orpha.net/ORDO/Orphanet_352328
-JOUBERT SYNDROME 9	http://www.orpha.net/ORDO/Orphanet_475	http://www.orpha.net/ORDO/Orphanet_564
+JOUBERT SYNDROME 9	http://www.orpha.net/ORDO/Orphanet_475
 Townes syndrome	http://www.orpha.net/ORDO/Orphanet_857
 HERMANSKY-PUDLAK SYNDROME 6	http://www.orpha.net/ORDO/Orphanet_79430
 Generalized epilepsy with febrile seizures plus	http://www.ebi.ac.uk/efo/EFO_0000474
-Nakajo syndrome	http://purl.obolibrary.org/obo/HP_0001324	http://purl.obolibrary.org/obo/HP_0001090	http://purl.obolibrary.org/obo/HP_0008887	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0100534	http://purl.obolibrary.org/obo/HP_0010783	http://purl.obolibrary.org/obo/HP_0000158	http://purl.obolibrary.org/obo/HP_0000509	http://purl.obolibrary.org/obo/HP_0001640	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002155	http://purl.obolibrary.org/obo/HP_0002135	http://purl.obolibrary.org/obo/HP_0001635	http://purl.obolibrary.org/obo/HP_0000953	http://purl.obolibrary.org/obo/HP_0009125	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001935	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0002653	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0100807	http://purl.obolibrary.org/obo/HP_0100759	http://purl.obolibrary.org/obo/HP_0003565	http://purl.obolibrary.org/obo/HP_0002829	http://purl.obolibrary.org/obo/HP_0003202	http://purl.obolibrary.org/obo/HP_0000448	http://purl.obolibrary.org/obo/HP_0000179	http://purl.obolibrary.org/obo/HP_0010702	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0011675	http://purl.obolibrary.org/obo/HP_0002910	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0002987	http://purl.obolibrary.org/obo/HP_0000400
+Nakajo syndrome	http://purl.obolibrary.org/obo/HP_0001324
 Dominant dystrophic epidermolysis bullosa with absence of skin	http://www.orpha.net/ORDO/Orphanet_303
 SECKEL SYNDROME 6	http://www.orpha.net/ORDO/Orphanet_808
-HYPOTRICHOSIS AND RECURRENT SKIN VESICLES	http://purl.obolibrary.org/obo/HP_0200037	http://purl.obolibrary.org/obo/HP_0100840	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002215	http://purl.obolibrary.org/obo/HP_0002209	http://purl.obolibrary.org/obo/HP_0200102	http://purl.obolibrary.org/obo/HP_0001006
-HYPOGONADOTROPIC HYPOGONADISM 13 WITH OR WITHOUT ANOSMIA	http://purl.obolibrary.org/obo/HP_0000458	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002750	http://purl.obolibrary.org/obo/HP_0000013	http://purl.obolibrary.org/obo/HP_0000044
+HYPOTRICHOSIS AND RECURRENT SKIN VESICLES	http://purl.obolibrary.org/obo/HP_0200037
+HYPOGONADOTROPIC HYPOGONADISM 13 WITH OR WITHOUT ANOSMIA	http://purl.obolibrary.org/obo/HP_0000458
 EXFOLIATION SYNDROME	http://www.ebi.ac.uk/efo/EFO_0004235
 IRIDOGONIODYSGENESIS	http://www.orpha.net/ORDO/Orphanet_98634
 Raine syndrome	http://www.orpha.net/ORDO/Orphanet_1832
 COHEN SYNDROME	http://www.orpha.net/ORDO/Orphanet_193
-Conotruncal heart malformations	http://www.orpha.net/ORDO/Orphanet_3426	http://www.orpha.net/ORDO/Orphanet_2445	http://www.orpha.net/ORDO/Orphanet_3384
-HERPES SIMPLEX ENCEPHALITIS	http://www.orpha.net/ORDO/Orphanet_1930	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0012302
+Conotruncal heart malformations	http://www.orpha.net/ORDO/Orphanet_3426
+HERPES SIMPLEX ENCEPHALITIS	http://www.orpha.net/ORDO/Orphanet_1930
 Wilsons disease	http://www.orpha.net/ORDO/Orphanet_905
 APOLIPOPROTEIN C-III	http://www.orpha.net/ORDO/Orphanet_160053
-NIEMANN-PICK DISEASE	http://purl.obolibrary.org/obo/HP_0000733	http://purl.obolibrary.org/obo/HP_0000511	http://purl.obolibrary.org/obo/HP_0001791	http://purl.obolibrary.org/obo/HP_0003674	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002185	http://purl.obolibrary.org/obo/HP_0002524	http://purl.obolibrary.org/obo/HP_0001744	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0003464	http://purl.obolibrary.org/obo/HP_0003349	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0003640	http://purl.obolibrary.org/obo/HP_0004333	http://purl.obolibrary.org/obo/HP_0002371	http://purl.obolibrary.org/obo/HP_0002878	http://purl.obolibrary.org/obo/HP_0030223	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0000709	http://purl.obolibrary.org/obo/HP_0001982	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0000726	http://www.ebi.ac.uk/efo/EFO_0003096	http://purl.obolibrary.org/obo/HP_0001263	http://www.orpha.net/ORDO/Orphanet_123868	http://purl.obolibrary.org/obo/HP_0006579
+NIEMANN-PICK DISEASE	http://purl.obolibrary.org/obo/HP_0000733
 Bilateral undescended testicles	http://purl.obolibrary.org/obo/HP_0001252
-PARKINSON DISEASE 6	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002067	http://purl.obolibrary.org/obo/HP_0000716	http://purl.obolibrary.org/obo/HP_0003677	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0002172	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002322	http://purl.obolibrary.org/obo/HP_0000739	http://purl.obolibrary.org/obo/HP_0001300	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0000726	http://purl.obolibrary.org/obo/HP_0000012
-Tatton-Brown-rahman syndrome	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0000581	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000311	http://purl.obolibrary.org/obo/HP_0001537
+PARKINSON DISEASE 6	http://purl.obolibrary.org/obo/HP_0001347
+Tatton-Brown-rahman syndrome	http://purl.obolibrary.org/obo/HP_0001631
 Primary autosomal recessive microcephaly 8	http://www.orpha.net/ORDO/Orphanet_2512
-Cutaneous malignant melanoma 1	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0000389
-Amyloidogenic transthyretin amyloidosis	http://www.orpha.net/ORDO/Orphanet_85451	http://www.orpha.net/ORDO/Orphanet_69
+Cutaneous malignant melanoma 1	http://www.ebi.ac.uk/efo/EFO_0000311
+Amyloidogenic transthyretin amyloidosis	http://www.orpha.net/ORDO/Orphanet_85451
 Transient neonatal diabetes mellitus 3	http://www.orpha.net/ORDO/Orphanet_99886
 Multiminicore Disease	http://www.orpha.net/ORDO/Orphanet_598
 HYPOGONADOTROPIC HYPOGONADISM 2 WITH ANOSMIA	http://www.orpha.net/ORDO/Orphanet_174590
@@ -3404,29 +3404,29 @@ BODY MASS INDEX QUANTITATIVE TRAIT LOCUS 9	http://purl.obolibrary.org/obo/HP_000
 Glycogen Storage Disease Type VI	http://www.orpha.net/ORDO/Orphanet_369
 Genitopatellar syndrome	http://www.orpha.net/ORDO/Orphanet_85201
 SENIOR-LOKEN SYNDROME 4	http://www.orpha.net/ORDO/Orphanet_3156
-Gangliosidosis GM1 type 3	http://www.orpha.net/ORDO/Orphanet_79256	http://www.orpha.net/ORDO/Orphanet_309310	http://www.orpha.net/ORDO/Orphanet_309144	http://www.orpha.net/ORDO/Orphanet_79255
-COENZYME Q10 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001337	http://purl.obolibrary.org/obo/HP_0003652	http://purl.obolibrary.org/obo/HP_0003593	http://purl.obolibrary.org/obo/HP_0001876	http://purl.obolibrary.org/obo/HP_0002172	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0012240	http://purl.obolibrary.org/obo/HP_0000969	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002133	http://purl.obolibrary.org/obo/HP_0003323	http://purl.obolibrary.org/obo/HP_0007256	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0002151	http://purl.obolibrary.org/obo/HP_0002650	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0001903	http://purl.obolibrary.org/obo/HP_0000097	http://purl.obolibrary.org/obo/HP_0003128	http://purl.obolibrary.org/obo/HP_0001284	http://purl.obolibrary.org/obo/HP_0001653	http://purl.obolibrary.org/obo/HP_0001513	http://purl.obolibrary.org/obo/HP_0001328	http://purl.obolibrary.org/obo/HP_0003701	http://purl.obolibrary.org/obo/HP_0001399	http://purl.obolibrary.org/obo/HP_0001639	http://purl.obolibrary.org/obo/HP_0002093	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0100704	http://purl.obolibrary.org/obo/HP_0001612	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0000096	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0000093	http://purl.obolibrary.org/obo/HP_0003236	http://purl.obolibrary.org/obo/HP_0003674	http://purl.obolibrary.org/obo/HP_0001511	http://purl.obolibrary.org/obo/HP_0009830	http://purl.obolibrary.org/obo/HP_0003678	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0001256	http://purl.obolibrary.org/obo/HP_0003200	http://purl.obolibrary.org/obo/HP_0000100	http://purl.obolibrary.org/obo/HP_0001298	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0003546	http://purl.obolibrary.org/obo/HP_0000815	http://purl.obolibrary.org/obo/HP_0002168	http://purl.obolibrary.org/obo/HP_0200134	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0001662	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0001659	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0003828	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0001967	http://purl.obolibrary.org/obo/HP_0001319	http://purl.obolibrary.org/obo/HP_0000572	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0001712	http://purl.obolibrary.org/obo/HP_0001643	http://purl.obolibrary.org/obo/HP_0001761	http://purl.obolibrary.org/obo/HP_0002092	http://purl.obolibrary.org/obo/HP_0005484	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0000965	http://purl.obolibrary.org/obo/HP_0002059
+Gangliosidosis GM1 type 3	http://www.orpha.net/ORDO/Orphanet_79256
+COENZYME Q10 DEFICIENCY	http://purl.obolibrary.org/obo/HP_0001337
 Joubert syndrome 23	http://www.orpha.net/ORDO/Orphanet_475
 Nonsyndromic Deafness	http://www.orpha.net/ORDO/Orphanet_90641
-Cerebellar ataxia	http://www.ebi.ac.uk/efo/EFO_0000400	http://www.orpha.net/ORDO/Orphanet_314404
+Cerebellar ataxia	http://www.ebi.ac.uk/efo/EFO_0000400
 AURICULOCONDYLAR SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_137888
 HERMANSKY-PUDLAK SYNDROME 2	http://www.orpha.net/ORDO/Orphanet_79430
 Familial partial lipodystrophy 6	http://www.orpha.net/ORDO/Orphanet_98306
-LONG-CHAIN 3-HYDROXYACYL-CoA DEHYDROGENASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_5	http://www.orpha.net/ORDO/Orphanet_746
+LONG-CHAIN 3-HYDROXYACYL-CoA DEHYDROGENASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_5
 BARDET-BIEDL SYNDROME 5	http://www.orpha.net/ORDO/Orphanet_110
 Warts	http://www.orpha.net/ORDO/Orphanet_51636
 FRASIER SYNDROME	http://www.orpha.net/ORDO/Orphanet_347
 Hereditary sensory and autonomic neuropathy type IC	http://www.ebi.ac.uk/efo/EFO_0004149
-Lymphangiomyomatosis	http://www.orpha.net/ORDO/Orphanet_538	http://www.orpha.net/ORDO/Orphanet_805
-Familial type 3 hyperlipoproteinemia	http://www.orpha.net/ORDO/Orphanet_329481	http://www.orpha.net/ORDO/Orphanet_412
+Lymphangiomyomatosis	http://www.orpha.net/ORDO/Orphanet_538
+Familial type 3 hyperlipoproteinemia	http://www.orpha.net/ORDO/Orphanet_329481
 ACRODYSOSTOSIS 2	http://www.orpha.net/ORDO/Orphanet_950
-MARFAN SYNDROME	http://www.orpha.net/ORDO/Orphanet_1885	http://www.orpha.net/ORDO/Orphanet_2833	http://www.orpha.net/ORDO/Orphanet_558
-MULTIPLE CONGENITAL ANOMALIES-HYPOTONIA-SEIZURES SYNDROME 2	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000582	http://purl.obolibrary.org/obo/HP_0001371	http://purl.obolibrary.org/obo/HP_0002120	http://purl.obolibrary.org/obo/HP_0001341	http://purl.obolibrary.org/obo/HP_0002714	http://purl.obolibrary.org/obo/HP_0003155	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0000076	http://purl.obolibrary.org/obo/HP_0003517	http://purl.obolibrary.org/obo/HP_0000687	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0002521	http://purl.obolibrary.org/obo/HP_0001347	http://purl.obolibrary.org/obo/HP_0001321	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0000212	http://purl.obolibrary.org/obo/HP_0000160	http://purl.obolibrary.org/obo/HP_0007361	http://purl.obolibrary.org/obo/HP_0000207	http://purl.obolibrary.org/obo/HP_0011398	http://purl.obolibrary.org/obo/HP_0002240	http://purl.obolibrary.org/obo/HP_0100704	http://purl.obolibrary.org/obo/HP_0008064	http://purl.obolibrary.org/obo/HP_0001792	http://purl.obolibrary.org/obo/HP_0000239	http://purl.obolibrary.org/obo/HP_0001522	http://purl.obolibrary.org/obo/HP_0000280	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0001331	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0008936	http://purl.obolibrary.org/obo/HP_0000081	http://purl.obolibrary.org/obo/HP_0000269	http://purl.obolibrary.org/obo/HP_0001394	http://purl.obolibrary.org/obo/HP_0001520	http://purl.obolibrary.org/obo/HP_0002529	http://purl.obolibrary.org/obo/HP_0200134	http://purl.obolibrary.org/obo/HP_0001631	http://purl.obolibrary.org/obo/HP_0002123	http://purl.obolibrary.org/obo/HP_0001051	http://purl.obolibrary.org/obo/HP_0000218	http://purl.obolibrary.org/obo/HP_0000365	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0005280	http://purl.obolibrary.org/obo/HP_0000396	http://purl.obolibrary.org/obo/HP_0000691	http://purl.obolibrary.org/obo/HP_0005484	http://purl.obolibrary.org/obo/HP_0012448
+MARFAN SYNDROME	http://www.orpha.net/ORDO/Orphanet_1885
+MULTIPLE CONGENITAL ANOMALIES-HYPOTONIA-SEIZURES SYNDROME 2	http://purl.obolibrary.org/obo/HP_0000272
 Schizencephaly	http://www.orpha.net/ORDO/Orphanet_799
 Methylmalonic acidemia with homocystinuria cblD	http://www.orpha.net/ORDO/Orphanet_171059
-Familial cold urticaria	http://www.orpha.net/ORDO/Orphanet_575	http://www.orpha.net/ORDO/Orphanet_47045	http://www.orpha.net/ORDO/Orphanet_1451
+Familial cold urticaria	http://www.orpha.net/ORDO/Orphanet_575
 HOLOCARBOXYLASE SYNTHETASE DEFICIENCY	http://www.orpha.net/ORDO/Orphanet_79242
-HYPERCHOLANEMIA	http://purl.obolibrary.org/obo/HP_0002748	http://purl.obolibrary.org/obo/HP_0012202	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0011892	http://purl.obolibrary.org/obo/HP_0000989	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002570
+HYPERCHOLANEMIA	http://purl.obolibrary.org/obo/HP_0002748
 Abnormality of neuronal migration	http://purl.obolibrary.org/obo/HP_0002269
 Hereditary factor XI deficiency disease	http://www.orpha.net/ORDO/Orphanet_329
 LEBER CONGENITAL AMAUROSIS 16	http://www.orpha.net/ORDO/Orphanet_65
@@ -3441,61 +3441,61 @@ EMERY-DREIFUSS MUSCULAR DYSTROPHY 6	http://www.orpha.net/ORDO/Orphanet_261
 Dilated cardiomyopathy 1O	http://www.ebi.ac.uk/efo/EFO_0000318
 RETINITIS PIGMENTOSA 72	http://www.orpha.net/ORDO/Orphanet_791
 COMBINED CELLULAR AND HUMORAL IMMUNE DEFECTS WITH GRANULOMAS	http://www.orpha.net/ORDO/Orphanet_157949
-Xeroderma pigmentosum	http://www.orpha.net/ORDO/Orphanet_276258	http://purl.obolibrary.org/obo/HP_0000007	http://www.orpha.net/ORDO/Orphanet_910	http://www.orpha.net/ORDO/Orphanet_276255	http://purl.obolibrary.org/obo/HP_0008069	http://purl.obolibrary.org/obo/HP_0002011	http://purl.obolibrary.org/obo/HP_0003079	http://purl.obolibrary.org/obo/HP_0000992	http://www.orpha.net/ORDO/Orphanet_276267	http://purl.obolibrary.org/obo/HP_0200034	http://purl.obolibrary.org/obo/HP_0007587
+Xeroderma pigmentosum	http://www.orpha.net/ORDO/Orphanet_276258
 PARKES WEBER SYNDROME	http://www.orpha.net/ORDO/Orphanet_90307
-GAZE PALSY	http://purl.obolibrary.org/obo/HP_0100543	http://purl.obolibrary.org/obo/HP_0007817	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0000470	http://purl.obolibrary.org/obo/HP_0007650	http://purl.obolibrary.org/obo/HP_0002944	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0002808	http://purl.obolibrary.org/obo/HP_0000639
+GAZE PALSY	http://purl.obolibrary.org/obo/HP_0100543
 Acquired hemoglobin H disease	http://www.orpha.net/ORDO/Orphanet_231401
 CRANIOSYNOSTOSIS 4	http://www.orpha.net/ORDO/Orphanet_1531
 Childhood hepatocellular carcinoma	http://www.ebi.ac.uk/efo/EFO_0000182
-Triple-negative breast cancer	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0005537
-Lynch syndrome	http://www.ebi.ac.uk/efo/EFO_0000311	http://www.ebi.ac.uk/efo/EFO_0007354	http://www.ebi.ac.uk/efo/EFO_0001075	http://www.ebi.ac.uk/efo/EFO_0005842	http://www.ebi.ac.uk/efo/EFO_0000365
+Triple-negative breast cancer	http://www.ebi.ac.uk/efo/EFO_0000311
+Lynch syndrome	http://www.ebi.ac.uk/efo/EFO_0000311
 EPIDERMOLYSIS BULLOSA DYSTROPHICA	http://www.orpha.net/ORDO/Orphanet_303
 Spastic paraplegia 6	http://purl.obolibrary.org/obo/HP_0001258
-GLYCOGEN STORAGE DISEASE IV	http://www.orpha.net/ORDO/Orphanet_367	http://www.orpha.net/ORDO/Orphanet_79201
+GLYCOGEN STORAGE DISEASE IV	http://www.orpha.net/ORDO/Orphanet_367
 LHERMITTE-DUCLOS DISEASE	http://www.orpha.net/ORDO/Orphanet_65285
-HYPOSPADIAS 1	http://purl.obolibrary.org/obo/HP_0000051	http://purl.obolibrary.org/obo/HP_0001419
+HYPOSPADIAS 1	http://purl.obolibrary.org/obo/HP_0000051
 Mental retardation-hypotonic facies syndrome X-linked	http://www.ebi.ac.uk/efo/EFO_0003847
 SECKEL SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_808
-Charcot-Marie-Tooth disease type 1B	http://www.orpha.net/ORDO/Orphanet_101082	http://www.orpha.net/ORDO/Orphanet_64748	http://www.orpha.net/ORDO/Orphanet_166
+Charcot-Marie-Tooth disease type 1B	http://www.orpha.net/ORDO/Orphanet_101082
 SIDEROBLASTIC ANEMIA WITH B-CELL IMMUNODEFICIENCY	http://www.orpha.net/ORDO/Orphanet_369861
 PACHYONYCHIA CONGENITA	http://www.orpha.net/ORDO/Orphanet_2309
-Anophthalmia - microphthalmia	http://www.orpha.net/ORDO/Orphanet_98555	http://www.orpha.net/ORDO/Orphanet_377	http://www.orpha.net/ORDO/Orphanet_388
+Anophthalmia - microphthalmia	http://www.orpha.net/ORDO/Orphanet_98555
 Malformation of the heart and great vessels	http://purl.obolibrary.org/obo/HP_0002564
 Arthrogryposis multiplex congenita distal type 1	http://www.ebi.ac.uk/efo/EFO_0003857
 BRUGADA SYNDROME 5	http://www.orpha.net/ORDO/Orphanet_130
 OBSESSIVE-COMPULSIVE DISORDER	http://www.ebi.ac.uk/efo/EFO_0004242
-BENT BONE DYSPLASIA SYNDROME	http://purl.obolibrary.org/obo/HP_0000272	http://purl.obolibrary.org/obo/HP_0000057	http://purl.obolibrary.org/obo/HP_0000212	http://purl.obolibrary.org/obo/HP_0004440	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000369	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0001007	http://purl.obolibrary.org/obo/HP_0000894	http://purl.obolibrary.org/obo/HP_0011800	http://purl.obolibrary.org/obo/HP_0000316	http://purl.obolibrary.org/obo/HP_0001591	http://purl.obolibrary.org/obo/HP_0001433
-Langer mesomelic dysplasia syndrome	http://www.orpha.net/ORDO/Orphanet_2632	http://www.orpha.net/ORDO/Orphanet_240
+BENT BONE DYSPLASIA SYNDROME	http://purl.obolibrary.org/obo/HP_0000272
+Langer mesomelic dysplasia syndrome	http://www.orpha.net/ORDO/Orphanet_2632
 PROPIONIC ACIDEMIA	http://www.orpha.net/ORDO/Orphanet_35
-DIAMOND-BLACKFAN ANEMIA 8	http://purl.obolibrary.org/obo/HP_0001972	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0005518
+DIAMOND-BLACKFAN ANEMIA 8	http://purl.obolibrary.org/obo/HP_0001972
 Primary hypertrophic osteoarthropathy	http://www.orpha.net/ORDO/Orphanet_248095
 SQUAMOUS CELL CARCINOMA	http://www.ebi.ac.uk/efo/EFO_0000707
-HYPERPARATHYROIDISM 2	http://purl.obolibrary.org/obo/HP_0000787	http://purl.obolibrary.org/obo/HP_0006725	http://purl.obolibrary.org/obo/HP_0003072	http://purl.obolibrary.org/obo/HP_0100027	http://purl.obolibrary.org/obo/HP_0006735	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000843	http://purl.obolibrary.org/obo/HP_0000234	http://purl.obolibrary.org/obo/HP_0000113	http://purl.obolibrary.org/obo/HP_0002897	http://purl.obolibrary.org/obo/HP_0006766	http://purl.obolibrary.org/obo/HP_0002667	http://purl.obolibrary.org/obo/HP_0006781	http://purl.obolibrary.org/obo/HP_0008200	http://purl.obolibrary.org/obo/HP_0006780	http://purl.obolibrary.org/obo/HP_0010566
+HYPERPARATHYROIDISM 2	http://purl.obolibrary.org/obo/HP_0000787
 FUNDUS ALBIPUNCTATUS	http://www.orpha.net/ORDO/Orphanet_227796
-Dilated cardiomyopathy 1Y	http://www.ebi.ac.uk/efo/EFO_0000407	http://www.ebi.ac.uk/efo/EFO_0000318
+Dilated cardiomyopathy 1Y	http://www.ebi.ac.uk/efo/EFO_0000407
 RENAL CELL CARCINOMA WITH PARANEOPLASTIC ERYTHROCYTOSIS	http://www.ebi.ac.uk/efo/EFO_0000681
 PSORIASIS 15	http://www.orpha.net/ORDO/Orphanet_247353
-LEUKOENCEPHALOPATHY WITH VANISHING WHITE MATTER	http://www.orpha.net/ORDO/Orphanet_99853	http://www.orpha.net/ORDO/Orphanet_135
+LEUKOENCEPHALOPATHY WITH VANISHING WHITE MATTER	http://www.orpha.net/ORDO/Orphanet_99853
 RETINITIS PIGMENTOSA 46	http://www.orpha.net/ORDO/Orphanet_791
-Microphthalmia	http://purl.obolibrary.org/obo/HP_0002089	http://www.ebi.ac.uk/efo/EFO_0005569	http://purl.obolibrary.org/obo/HP_0000508	http://www.orpha.net/ORDO/Orphanet_2470	http://purl.obolibrary.org/obo/HP_0000377	http://purl.obolibrary.org/obo/HP_0000278	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000565	http://www.orpha.net/ORDO/Orphanet_98938	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0000589	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000455	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0000528	http://purl.obolibrary.org/obo/HP_0040080	http://purl.obolibrary.org/obo/HP_0001417	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000813	http://purl.obolibrary.org/obo/HP_0005156	http://purl.obolibrary.org/obo/HP_0000028	http://purl.obolibrary.org/obo/HP_0000776	http://purl.obolibrary.org/obo/HP_0002751	http://purl.obolibrary.org/obo/HP_0000482	http://purl.obolibrary.org/obo/HP_0012043	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000431	http://purl.obolibrary.org/obo/HP_0000568	http://purl.obolibrary.org/obo/HP_0001629
-LISSENCEPHALY 1	http://www.orpha.net/ORDO/Orphanet_99796	http://www.orpha.net/ORDO/Orphanet_48471
-Primary aldosteronism	http://purl.obolibrary.org/obo/HP_0000787	http://purl.obolibrary.org/obo/HP_0002510	http://purl.obolibrary.org/obo/HP_0200114	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000822	http://purl.obolibrary.org/obo/HP_0002900	http://purl.obolibrary.org/obo/HP_0002092	http://purl.obolibrary.org/obo/HP_0100704	http://purl.obolibrary.org/obo/HP_0001655	http://purl.obolibrary.org/obo/HP_0200128	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0100021	http://purl.obolibrary.org/obo/HP_0002069	http://purl.obolibrary.org/obo/HP_0001629	http://purl.obolibrary.org/obo/HP_0003351
-PULMONARY HYPERTENSION	http://www.ebi.ac.uk/efo/EFO_0000537	http://www.ebi.ac.uk/efo/EFO_0001361
-Brachydactyly	http://purl.obolibrary.org/obo/HP_0006165	http://purl.obolibrary.org/obo/HP_0009279	http://purl.obolibrary.org/obo/HP_0001032	http://purl.obolibrary.org/obo/HP_0001169	http://purl.obolibrary.org/obo/HP_0010107	http://purl.obolibrary.org/obo/HP_0004209	http://purl.obolibrary.org/obo/HP_0009462	http://purl.obolibrary.org/obo/HP_0001156	http://purl.obolibrary.org/obo/HP_0009882	http://purl.obolibrary.org/obo/HP_0006236	http://purl.obolibrary.org/obo/HP_0000684	http://purl.obolibrary.org/obo/HP_0010743	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0001204	http://purl.obolibrary.org/obo/HP_0006146	http://purl.obolibrary.org/obo/HP_0004279	http://purl.obolibrary.org/obo/HP_0009467	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0010049	http://purl.obolibrary.org/obo/HP_0006213	http://purl.obolibrary.org/obo/HP_0000677	http://purl.obolibrary.org/obo/HP_0009638	http://purl.obolibrary.org/obo/HP_0005194	http://purl.obolibrary.org/obo/HP_0001425
-SPINOCEREBELLAR ATAXIA 17	http://purl.obolibrary.org/obo/HP_0007668	http://purl.obolibrary.org/obo/HP_0002070	http://purl.obolibrary.org/obo/HP_0000716	http://purl.obolibrary.org/obo/HP_0011999	http://purl.obolibrary.org/obo/HP_0002072	http://purl.obolibrary.org/obo/HP_0002459	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0002506	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002172	http://purl.obolibrary.org/obo/HP_0100315	http://purl.obolibrary.org/obo/HP_0002322	http://purl.obolibrary.org/obo/HP_0000298	http://purl.obolibrary.org/obo/HP_0001300	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0002529	http://purl.obolibrary.org/obo/HP_0000640	http://purl.obolibrary.org/obo/HP_0000738	http://purl.obolibrary.org/obo/HP_0002063	http://purl.obolibrary.org/obo/HP_0002171	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0011960	http://purl.obolibrary.org/obo/HP_0000012	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0000743	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0000020	http://purl.obolibrary.org/obo/HP_0000757	http://purl.obolibrary.org/obo/HP_0002136	http://purl.obolibrary.org/obo/HP_0000751	http://purl.obolibrary.org/obo/HP_0002067	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0003587	http://purl.obolibrary.org/obo/HP_0000727	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0002300	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0002360	http://purl.obolibrary.org/obo/HP_0001336	http://purl.obolibrary.org/obo/HP_0002186	http://purl.obolibrary.org/obo/HP_0002403	http://purl.obolibrary.org/obo/HP_0000726	http://purl.obolibrary.org/obo/HP_0007311	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001289	http://purl.obolibrary.org/obo/HP_0001621	http://purl.obolibrary.org/obo/HP_0000718
+Microphthalmia	http://purl.obolibrary.org/obo/HP_0002089
+LISSENCEPHALY 1	http://www.orpha.net/ORDO/Orphanet_99796
+Primary aldosteronism	http://purl.obolibrary.org/obo/HP_0000787
+PULMONARY HYPERTENSION	http://www.ebi.ac.uk/efo/EFO_0000537
+Brachydactyly	http://purl.obolibrary.org/obo/HP_0006165
+SPINOCEREBELLAR ATAXIA 17	http://purl.obolibrary.org/obo/HP_0007668
 CATARACT 45	http://www.ebi.ac.uk/efo/EFO_0001059
-Cone-rod dystrophy 16	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0000548	http://purl.obolibrary.org/obo/HP_0100259	http://purl.obolibrary.org/obo/HP_0007401	http://purl.obolibrary.org/obo/HP_0000543
+Cone-rod dystrophy 16	http://purl.obolibrary.org/obo/HP_0000007
 Idiopathic hypercalcemia of infancy	http://purl.obolibrary.org/obo/HP_0003072
-McCune-Albright syndrome	http://www.orpha.net/ORDO/Orphanet_562	http://www.orpha.net/ORDO/Orphanet_553
-Congenital muscular dystrophy-dystroglycanopathy with brain and eye anomalies type A5	http://www.orpha.net/ORDO/Orphanet_371024	http://www.orpha.net/ORDO/Orphanet_263
+McCune-Albright syndrome	http://www.orpha.net/ORDO/Orphanet_562
+Congenital muscular dystrophy-dystroglycanopathy with brain and eye anomalies type A5	http://www.orpha.net/ORDO/Orphanet_371024
 DOUBLE-OUTLET RIGHT VENTRICLE	http://purl.obolibrary.org/obo/HP_0001719
-NOONAN SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_648	http://www.orpha.net/ORDO/Orphanet_1340
-Visceral myopathy	http://purl.obolibrary.org/obo/HP_0000021	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0000076	http://purl.obolibrary.org/obo/HP_0001537	http://purl.obolibrary.org/obo/HP_0001166	http://purl.obolibrary.org/obo/HP_0001561	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0000774	http://purl.obolibrary.org/obo/HP_0004395	http://purl.obolibrary.org/obo/HP_0001798	http://purl.obolibrary.org/obo/HP_0100867	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0010318	http://purl.obolibrary.org/obo/HP_0003363	http://purl.obolibrary.org/obo/HP_0010956	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0000368	http://purl.obolibrary.org/obo/HP_0000463	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0000426	http://purl.obolibrary.org/obo/HP_0000337	http://purl.obolibrary.org/obo/HP_0001733	http://purl.obolibrary.org/obo/HP_0000843	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0000311	http://purl.obolibrary.org/obo/HP_0010935	http://purl.obolibrary.org/obo/HP_0000126	http://purl.obolibrary.org/obo/HP_0002251	http://purl.obolibrary.org/obo/HP_0100490	http://purl.obolibrary.org/obo/HP_0004388	http://purl.obolibrary.org/obo/HP_0001376
+NOONAN SYNDROME 3	http://www.orpha.net/ORDO/Orphanet_648
+Visceral myopathy	http://purl.obolibrary.org/obo/HP_0000021
 Relapsing remitting multiple sclerosis	http://www.ebi.ac.uk/efo/EFO_0003929
 Rotor syndrome	http://www.orpha.net/ORDO/Orphanet_3111
-DIARRHEA 6	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002027	http://purl.obolibrary.org/obo/HP_0100502
+DIARRHEA 6	http://purl.obolibrary.org/obo/HP_0002014
 VITAMIN B12 PLASMA LEVEL QUANTITATIVE TRAIT LOCUS 1	http://www.ebi.ac.uk/efo/EFO_0004620
-TRANSIENT MYELOPROLIFERATIVE DISORDER OF DOWN SYNDROME	http://www.ebi.ac.uk/efo/EFO_0004251	http://www.ebi.ac.uk/efo/EFO_0000222
+TRANSIENT MYELOPROLIFERATIVE DISORDER OF DOWN SYNDROME	http://www.ebi.ac.uk/efo/EFO_0004251
 HOLOPROSENCEPHALY 4	http://www.orpha.net/ORDO/Orphanet_2162
 Sarcosine dehydrogenase deficiency	http://www.orpha.net/ORDO/Orphanet_3129
 RETINITIS PIGMENTOSA 69	http://www.orpha.net/ORDO/Orphanet_791
@@ -3503,22 +3503,22 @@ Amyotrophic lateral sclerosis type 11	http://www.ebi.ac.uk/efo/EFO_0000253
 Rhabdoid tumor predisposition syndrome 2	http://www.orpha.net/ORDO/Orphanet_231108
 BRUGADA SYNDROME 1	http://www.orpha.net/ORDO/Orphanet_130
 Congenital muscular dystrophy due to partial LAMA2 deficiency	http://www.orpha.net/ORDO/Orphanet_97242
-NEURODEGENERATION WITH BRAIN IRON ACCUMULATION 2B	http://purl.obolibrary.org/obo/HP_0000712	http://purl.obolibrary.org/obo/HP_0002072	http://purl.obolibrary.org/obo/HP_0001310	http://purl.obolibrary.org/obo/HP_0002180	http://purl.obolibrary.org/obo/HP_0001260	http://purl.obolibrary.org/obo/HP_0002185	http://purl.obolibrary.org/obo/HP_0000648	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001332	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0002080	http://purl.obolibrary.org/obo/HP_0003487	http://purl.obolibrary.org/obo/HP_0002066	http://purl.obolibrary.org/obo/HP_0000639	http://purl.obolibrary.org/obo/HP_0002067	http://purl.obolibrary.org/obo/HP_0002015	http://purl.obolibrary.org/obo/HP_0007772	http://purl.obolibrary.org/obo/HP_0000750	http://purl.obolibrary.org/obo/HP_0003812	http://purl.obolibrary.org/obo/HP_0000752	http://purl.obolibrary.org/obo/HP_0003676	http://purl.obolibrary.org/obo/HP_0002075	http://purl.obolibrary.org/obo/HP_0001268	http://purl.obolibrary.org/obo/HP_0000736	http://purl.obolibrary.org/obo/HP_0100710	http://purl.obolibrary.org/obo/HP_0011968	http://purl.obolibrary.org/obo/HP_0001257	http://purl.obolibrary.org/obo/HP_0001272	http://purl.obolibrary.org/obo/HP_0001884	http://purl.obolibrary.org/obo/HP_0002059
+NEURODEGENERATION WITH BRAIN IRON ACCUMULATION 2B	http://purl.obolibrary.org/obo/HP_0000712
 Adenylosuccinate lyase deficiency	http://www.orpha.net/ORDO/Orphanet_46
-BARTTER SYNDROME	http://purl.obolibrary.org/obo/HP_0003540	http://purl.obolibrary.org/obo/HP_0001960	http://purl.obolibrary.org/obo/HP_0003401	http://purl.obolibrary.org/obo/HP_0012605	http://purl.obolibrary.org/obo/HP_0002632	http://purl.obolibrary.org/obo/HP_0000848	http://www.orpha.net/ORDO/Orphanet_112	http://purl.obolibrary.org/obo/HP_0000969	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0002914	http://purl.obolibrary.org/obo/HP_0002150	http://purl.obolibrary.org/obo/HP_0002014	http://purl.obolibrary.org/obo/HP_0000934	http://purl.obolibrary.org/obo/HP_0001508	http://purl.obolibrary.org/obo/HP_0002917	http://purl.obolibrary.org/obo/HP_0002007	http://purl.obolibrary.org/obo/HP_0003158	http://purl.obolibrary.org/obo/HP_0001270	http://purl.obolibrary.org/obo/HP_0001944	http://purl.obolibrary.org/obo/HP_0001945	http://purl.obolibrary.org/obo/HP_0000121	http://purl.obolibrary.org/obo/HP_0004909	http://purl.obolibrary.org/obo/HP_0003527	http://purl.obolibrary.org/obo/HP_0000103	http://purl.obolibrary.org/obo/HP_0000111	http://purl.obolibrary.org/obo/HP_0000938	http://purl.obolibrary.org/obo/HP_0001518	http://purl.obolibrary.org/obo/HP_0000407	http://purl.obolibrary.org/obo/HP_0003113	http://purl.obolibrary.org/obo/HP_0001265	http://purl.obolibrary.org/obo/HP_0001425	http://purl.obolibrary.org/obo/HP_0000256	http://purl.obolibrary.org/obo/HP_0000859	http://purl.obolibrary.org/obo/HP_0000400	http://purl.obolibrary.org/obo/HP_0003577	http://purl.obolibrary.org/obo/HP_0002013	http://purl.obolibrary.org/obo/HP_0000083	http://purl.obolibrary.org/obo/HP_0001090	http://purl.obolibrary.org/obo/HP_0001563	http://purl.obolibrary.org/obo/HP_0003081	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0002902	http://purl.obolibrary.org/obo/HP_0001959	http://purl.obolibrary.org/obo/HP_0012213	http://purl.obolibrary.org/obo/HP_0000841	http://purl.obolibrary.org/obo/HP_0001250	http://purl.obolibrary.org/obo/HP_0004322	http://purl.obolibrary.org/obo/HP_0003394	http://purl.obolibrary.org/obo/HP_0003566	http://purl.obolibrary.org/obo/HP_0001252	http://purl.obolibrary.org/obo/HP_0000128	http://purl.obolibrary.org/obo/HP_0011220	http://purl.obolibrary.org/obo/HP_0002019	http://purl.obolibrary.org/obo/HP_0000127	http://purl.obolibrary.org/obo/HP_0002900	http://purl.obolibrary.org/obo/HP_0001622	http://purl.obolibrary.org/obo/HP_0003324	http://purl.obolibrary.org/obo/HP_0001263	http://purl.obolibrary.org/obo/HP_0000325	http://purl.obolibrary.org/obo/HP_0001281	http://purl.obolibrary.org/obo/HP_0001561
-GELEOPHYSIC DYSPLASIA 2	http://www.orpha.net/ORDO/Orphanet_969	http://www.orpha.net/ORDO/Orphanet_2623
+BARTTER SYNDROME	http://purl.obolibrary.org/obo/HP_0003540
+GELEOPHYSIC DYSPLASIA 2	http://www.orpha.net/ORDO/Orphanet_969
 3-Oxo-5 alpha-steroid delta 4-dehydrogenase deficiency	http://www.orpha.net/ORDO/Orphanet_753
-CANDIDIASIS	http://purl.obolibrary.org/obo/HP_0002728	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0001597	http://purl.obolibrary.org/obo/HP_0012203	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0002721	http://purl.obolibrary.org/obo/HP_0001287	http://purl.obolibrary.org/obo/HP_0000158	http://purl.obolibrary.org/obo/HP_0000498	http://purl.obolibrary.org/obo/HP_0009098	http://purl.obolibrary.org/obo/HP_0001871
-HYPOPLASTIC LEFT HEART SYNDROME	http://www.orpha.net/ORDO/Orphanet_2248	http://www.orpha.net/ORDO/Orphanet_98722
+CANDIDIASIS	http://purl.obolibrary.org/obo/HP_0002728
+HYPOPLASTIC LEFT HEART SYNDROME	http://www.orpha.net/ORDO/Orphanet_2248
 Fructose-biphosphatase deficiency	http://www.orpha.net/ORDO/Orphanet_348
 Short stature	http://www.orpha.net/ORDO/Orphanet_397623
 FUCOSIDOSIS	http://www.orpha.net/ORDO/Orphanet_349
-COMBINED IMMUNODEFICIENCY	http://purl.obolibrary.org/obo/HP_0000388	http://purl.obolibrary.org/obo/HP_0004315	http://purl.obolibrary.org/obo/HP_0000246	http://purl.obolibrary.org/obo/HP_0001419	http://purl.obolibrary.org/obo/HP_0002837	http://purl.obolibrary.org/obo/HP_0005415	http://purl.obolibrary.org/obo/HP_0005407	http://purl.obolibrary.org/obo/HP_0002090	http://purl.obolibrary.org/obo/HP_0005387
+COMBINED IMMUNODEFICIENCY	http://purl.obolibrary.org/obo/HP_0000388
 Congenital ectodermal dysplasia of face	http://www.orpha.net/ORDO/Orphanet_79133
-OROFACIODIGITAL SYNDROME XIV	http://purl.obolibrary.org/obo/HP_0000582	http://purl.obolibrary.org/obo/HP_0000175	http://purl.obolibrary.org/obo/HP_0001344	http://purl.obolibrary.org/obo/HP_0000506	http://purl.obolibrary.org/obo/HP_0000180	http://purl.obolibrary.org/obo/HP_0002079	http://purl.obolibrary.org/obo/HP_0001249	http://purl.obolibrary.org/obo/HP_0100259	http://purl.obolibrary.org/obo/HP_0000252	http://purl.obolibrary.org/obo/HP_0002419	http://purl.obolibrary.org/obo/HP_0001999	http://purl.obolibrary.org/obo/HP_0011069	http://purl.obolibrary.org/obo/HP_0000243	http://purl.obolibrary.org/obo/HP_0000054
-DIAMOND-BLACKFAN ANEMIA 14 WITH MANDIBULOFACIAL DYSOSTOSIS	http://purl.obolibrary.org/obo/HP_0000347	http://purl.obolibrary.org/obo/HP_0008551	http://purl.obolibrary.org/obo/HP_0000494	http://purl.obolibrary.org/obo/HP_0001972	http://purl.obolibrary.org/obo/HP_0000405	http://purl.obolibrary.org/obo/HP_0011800
-HYPOBETALIPOPROTEINEMIA	http://purl.obolibrary.org/obo/HP_0000007	http://purl.obolibrary.org/obo/HP_0000510	http://purl.obolibrary.org/obo/HP_0003563	http://purl.obolibrary.org/obo/HP_0000546	http://purl.obolibrary.org/obo/HP_0001315	http://purl.obolibrary.org/obo/HP_0012153	http://purl.obolibrary.org/obo/HP_0000006	http://purl.obolibrary.org/obo/HP_0001251	http://purl.obolibrary.org/obo/HP_0001927
-Autosomal recessive cutis laxa type IA	http://www.orpha.net/ORDO/Orphanet_90349	http://www.orpha.net/ORDO/Orphanet_209
+OROFACIODIGITAL SYNDROME XIV	http://purl.obolibrary.org/obo/HP_0000582
+DIAMOND-BLACKFAN ANEMIA 14 WITH MANDIBULOFACIAL DYSOSTOSIS	http://purl.obolibrary.org/obo/HP_0000347
+HYPOBETALIPOPROTEINEMIA	http://purl.obolibrary.org/obo/HP_0000007
+Autosomal recessive cutis laxa type IA	http://www.orpha.net/ORDO/Orphanet_90349
 ClinVar_Preferred_TraitName	Gary_updated_url_for_json
 Failure of tooth eruption, primary	http://purl.obolibrary.org/obo/GO_0044691
 Polycystic kidney disease, adult type	http://purl.obolibrary.org/obo/HP_0000113

--- a/tests/test_clinvar_to_evidence_strings.py
+++ b/tests/test_clinvar_to_evidence_strings.py
@@ -14,8 +14,8 @@ def _get_mappings():
     variant_summary_file = os.path.join(os.path.dirname(__file__), 'resources',
                                         'variant_summary_2016-05_test_extract.txt')
 
-    mappings = clinvar_to_evidence_strings.get_mappings(efo_mapping_file, ignore_file, None,
-                                                        snp_2_gene_file, variant_summary_file)
+    mappings = clinvar_to_evidence_strings.get_mappings(efo_mapping_file, snp_2_gene_file,
+                                                        variant_summary_file)
 
     return mappings
 

--- a/tests/test_clinvar_to_evidence_strings.py
+++ b/tests/test_clinvar_to_evidence_strings.py
@@ -123,9 +123,6 @@ class LoadEfoMappingTest(unittest.TestCase):
     def test_just_mapping_trait_2_efo(self):
         self.assertEqual(len(self.trait_2_efo), 5283)
 
-    def test_w_ignore_trait_2_efo(self):
-        self.assertEqual(len(self.trait_2_efo_w_ignore), 5055)
-
 
 class GetTermsFromFileTest(unittest.TestCase):
     #TODO do the same for adapt terms file?

--- a/tests/test_clinvar_to_evidence_strings.py
+++ b/tests/test_clinvar_to_evidence_strings.py
@@ -72,10 +72,10 @@ class CreateTraitTest(unittest.TestCase):
                                                              MAPPINGS.trait_2_efo)
 
     def test_clinvar_trait_list(self):
-        self.assertEqual(self.trait.clinvar_trait_list, ['Ciliary dyskinesia, primary, 7'])
+        self.assertEqual(self.trait.clinvar_name, 'ciliary dyskinesia, primary, 7')
 
     def test_efo_list(self):
-        self.assertEqual(self.trait.efo_list, ['http://www.ebi.ac.uk/efo/EFO_0003900'])
+        self.assertEqual(self.trait.ontology_name, 'http://www.ebi.ac.uk/efo/EFO_0003900')
 
     def test_return_none(self):
         none_trait = \

--- a/tests/test_clinvar_to_evidence_strings.py
+++ b/tests/test_clinvar_to_evidence_strings.py
@@ -75,7 +75,7 @@ class CreateTraitTest(unittest.TestCase):
         self.assertEqual(self.trait.clinvar_name, 'ciliary dyskinesia, primary, 7')
 
     def test_efo_list(self):
-        self.assertEqual(self.trait.ontology_name, 'http://www.ebi.ac.uk/efo/EFO_0003900')
+        self.assertEqual(self.trait.ontology_id, 'http://www.ebi.ac.uk/efo/EFO_0003900')
 
     def test_return_none(self):
         none_trait = \

--- a/tests/test_clinvar_to_evidence_strings.py
+++ b/tests/test_clinvar_to_evidence_strings.py
@@ -29,16 +29,15 @@ class GetMappingsTest(unittest.TestCase):
         cls.mappings = MAPPINGS
 
     def test_efo_mapping(self):
-        self.assertEqual(len(self.mappings.trait_2_efo), 5055)
-        self.assertEqual(len(self.mappings.unavailable_efo_dict), 0)
+        self.assertEqual(len(self.mappings.trait_2_efo), 5283)
 
         self.assertEqual(self.mappings.trait_2_efo["renal-hepatic-pancreatic dysplasia 2"],
-                         ['http://www.orpha.net/ORDO/Orphanet_294415'])
+                         ('http://www.orpha.net/ORDO/Orphanet_294415', None))
         self.assertEqual(self.mappings.trait_2_efo["frontotemporal dementia"],
-                         ['http://purl.obolibrary.org/obo/HP_0000713'])
+                         ('http://purl.obolibrary.org/obo/HP_0000713', None))
         self.assertEqual(
             self.mappings.trait_2_efo["3 beta-hydroxysteroid dehydrogenase deficiency"],
-            ['http://www.orpha.net/ORDO/Orphanet_90791'])
+            ('http://www.orpha.net/ORDO/Orphanet_90791', None))
 
     def test_consequence_type_dict(self):
         self.assertEqual(len(self.mappings.consequence_type_dict), 56)
@@ -119,29 +118,13 @@ class LoadEfoMappingTest(unittest.TestCase):
         cls.trait_2_efo, cls.unavailable_efo = \
             clinvar_to_evidence_strings.load_efo_mapping(efo_file)
         cls.trait_2_efo_w_ignore, cls.unavailable_efo_w_ignore = \
-            clinvar_to_evidence_strings.load_efo_mapping(efo_file, ignore_terms_file=ignore_file)
+            clinvar_to_evidence_strings.load_efo_mapping(efo_file)
 
     def test_just_mapping_trait_2_efo(self):
         self.assertEqual(len(self.trait_2_efo), 5283)
 
     def test_w_ignore_trait_2_efo(self):
         self.assertEqual(len(self.trait_2_efo_w_ignore), 5055)
-
-
-class GetUnmappedUrlTest(unittest.TestCase):
-    def test_orphanet(self):
-        url = "http://www.orpha.net/ORDO/Orphanet_2670"
-        self.assertEqual(clinvar_to_evidence_strings.get_unmapped_url(url),
-                         "http://purl.bioontology.org/ORDO/Orphanet_2670")
-
-    def test_hp(self):
-        url = "http://purl.obolibrary.org/obo/HP_0000545"
-        self.assertEqual(clinvar_to_evidence_strings.get_unmapped_url(url),
-                         "http://purl.bioontology.org/obo/HP_0000545")
-
-    def test_bad_url(self):
-        #TODO currently the function exits execution with bad urls
-        pass
 
 
 class GetTermsFromFileTest(unittest.TestCase):

--- a/tests/test_evidence_strings.py
+++ b/tests/test_evidence_strings.py
@@ -33,6 +33,7 @@ def get_args_CTTVGeneticsEvidenceString_init():
     trait.trait_counter = 0
     trait.clinvar_name = ""
     trait.ontology_id = 'http://www.orpha.net/ORDO/Orphanet_88991'
+    trait.ontology_label = None
 
     ensembl_gene_id = "ENSG00000197616"
 
@@ -66,6 +67,7 @@ def get_args_CTTVSomaticEvidenceString_init():
     trait.trait_counter = 0
     trait.clinvar_name = ""
     trait.ontology_id = 'http://www.ebi.ac.uk/efo/EFO_0003840'
+    trait.ontology_label = None
 
     ensembl_gene_id = "ENSG00000135486"
 

--- a/tests/test_evidence_strings.py
+++ b/tests/test_evidence_strings.py
@@ -32,7 +32,7 @@ def get_args_CTTVGeneticsEvidenceString_init():
     trait = SimpleNamespace()
     trait.trait_counter = 0
     trait.clinvar_name = ""
-    trait.ontology_name = 'http://www.orpha.net/ORDO/Orphanet_88991'
+    trait.ontology_id = 'http://www.orpha.net/ORDO/Orphanet_88991'
 
     ensembl_gene_id = "ENSG00000197616"
 
@@ -65,7 +65,7 @@ def get_args_CTTVSomaticEvidenceString_init():
     trait = SimpleNamespace()
     trait.trait_counter = 0
     trait.clinvar_name = ""
-    trait.ontology_name = 'http://www.ebi.ac.uk/efo/EFO_0003840'
+    trait.ontology_id = 'http://www.ebi.ac.uk/efo/EFO_0003840'
 
     ensembl_gene_id = "ENSG00000135486"
 

--- a/tests/test_evidence_strings.py
+++ b/tests/test_evidence_strings.py
@@ -46,13 +46,13 @@ def get_args_CTTVGeneticsEvidenceString_init():
 class CTTVGeneticsEvidenceStringInitTest(unittest.TestCase):
     maxDiff = None
     def setUp(self):
-        test_args = get_args_CTTVGeneticsEvidenceString_init()
-        self.evidence_string = evidence_strings.CTTVGeneticsEvidenceString(*test_args)
+        self.test_args = get_args_CTTVGeneticsEvidenceString_init()
+        self.evidence_string = evidence_strings.CTTVGeneticsEvidenceString(*self.test_args)
 
     def test_evidence_string(self):
         test_dict = {"literature": {"references": [{"lit_id": "http://europepmc.org/abstract/MED/12145752"}, {"lit_id": "http://europepmc.org/abstract/MED/21697857"}, {"lit_id": "http://europepmc.org/abstract/MED/11524702"}]}, "disease": {"id": ["http://www.orpha.net/ORDO/Orphanet_886"]}, "validated_against_schema_version": "1.2.3", "target": {"target_type": "http://identifiers.org/cttv.target/gene_variant", "id": ["http://identifiers.org/ensembl/ENSG00000163646"], "activity": "http://identifiers.org/cttv.activity/damaging_to_target"}, "sourceID": "eva", "evidence": {"gene2variant": {"is_associated": True, "provenance_type": {"expert": {"status": True, "statement": "Primary submitter of data"}, "database": {"id": "EVA", "dbxref": {"url": "http://identifiers.org/clinvar.record/RCV000004642", "id": "http://identifiers.org/clinvar", "version": "2015-04"}, "version": "1.0"}}, "evidence_codes": ["http://identifiers.org/eco/cttv_mapping_pipeline"], "date_asserted": "2015-06-27T00:00:00", "functional_consequence": "http://purl.obolibrary.org/obo/SO_0001587", "urls": [{"url": "http://www.ncbi.nlm.nih.gov/clinvar/RCV000004642", "nice_name": "Further details in ClinVar database"}]}, "variant2disease": {"is_associated": True, "provenance_type": {"literature": {"references": [{"lit_id": "http://europepmc.org/abstract/MED/12145752"}, {"lit_id": "http://europepmc.org/abstract/MED/21697857"}, {"lit_id": "http://europepmc.org/abstract/MED/11524702"}]}, "expert": {"status": True, "statement": "Primary submitter of data"}, "database": {"id": "EVA", "dbxref": {"url": "http://identifiers.org/clinvar.record/RCV000004642", "id": "http://identifiers.org/clinvar", "version": "2015-04"}, "version": "1.0"}}, "evidence_codes": ["http://purl.obolibrary.org/obo/ECO_0000205"], "date_asserted": "2015-06-27T00:00:00", "unique_experiment_reference": "http://europepmc.org/abstract/MED/12145752", "urls": [{"url": "http://www.ncbi.nlm.nih.gov/clinvar/RCV000004642", "nice_name": "Further details in ClinVar database"}], "resource_score": {"type": "pvalue", "method": {"url": "", "description": "Not provided by data supplier"}, "value": 1e-07}}}, "type": "genetic_association", "access_level": "public", "unique_association_fields": {"gene": "ENSG00000163646", "alleleOrigin": "germline", "phenotype": "http://www.orpha.net/ORDO/Orphanet_886", "clinvarAccession": "RCV000004642"}, "variant": {"type": "snp single", "id": ["http://identifiers.org/dbsnp/rs121908140"]}}
 
-        test_ev_string = evidence_strings.CTTVEvidenceString(test_dict)
+        test_ev_string = evidence_strings.CTTVEvidenceString(test_dict, trait=self.test_args[2])
 
         self.assertEqual(set(self.evidence_string.__dict__.values()), set(test_ev_string.__dict__.values()))
 
@@ -78,13 +78,13 @@ def get_args_CTTVSomaticEvidenceString_init():
 
 class CTTVSomaticEvidenceStringInitTest(unittest.TestCase):
     def setUp(self):
-        test_args = get_args_CTTVSomaticEvidenceString_init()
-        self.evidence_string = evidence_strings.CTTVSomaticEvidenceString(*test_args)
+        self.test_args = get_args_CTTVSomaticEvidenceString_init()
+        self.evidence_string = evidence_strings.CTTVSomaticEvidenceString(*self.test_args)
 
     def test_evidence_string(self):
         test_dict = {"literature": {"references": [{"lit_id": "http://europepmc.org/abstract/MED/8281160"}]}, "disease": {"id": ["http://www.ebi.ac.uk/efo/EFO_0000232"]}, "validated_against_schema_version": "1.2.3", "target": {"target_type": "http://identifiers.org/cttv.target/gene_variant", "id": ["http://identifiers.org/ensembl/ENSG00000134982"], "activity": "http://identifiers.org/cttv.activity/damaging_to_target"}, "sourceID": "eva_somatic", "type": "somatic_mutation", "access_level": "public", "unique_association_fields": {"gene": "ENSG00000134982", "alleleOrigin": "somatic", "phenotype": "http://www.ebi.ac.uk/efo/EFO_0000232", "clinvarAccession": "RCV000000851"}, "evidence": {"is_associated": True, "provenance_type": {"literature": {"references": [{"lit_id": "http://europepmc.org/abstract/MED/8281160"}]}, "expert": {"status": True, "statement": "Primary submitter of data"}, "database": {"id": "EVA", "dbxref": {"url": "http://identifiers.org/clinvar.record/RCV000000851", "id": "http://identifiers.org/clinvar", "version": "2015-04"}, "version": "1.0"}}, "evidence_codes": ["http://purl.obolibrary.org/obo/ECO_0000205"], "date_asserted": "2016-02-17T00:00:00", "urls": [{"url": "http://www.ncbi.nlm.nih.gov/clinvar/RCV000000851", "nice_name": "Further details in ClinVar database"}], "known_mutations": [{"preferred_name": "frameshift_variant", "functional_consequence": "http://purl.obolibrary.org/obo/SO_0001589"}], "resource_score": {"type": "probability", "value": 1}}}
 
-        test_ev_string = evidence_strings.CTTVEvidenceString(test_dict)
+        test_ev_string = evidence_strings.CTTVEvidenceString(test_dict, trait=self.test_args[2])
 
         self.assertEqual(set(self.evidence_string.__dict__.values()), set(test_ev_string.__dict__.values()))
 

--- a/tests/test_evidence_strings.py
+++ b/tests/test_evidence_strings.py
@@ -31,8 +31,8 @@ def get_args_CTTVGeneticsEvidenceString_init():
 
     trait = SimpleNamespace()
     trait.trait_counter = 0
-    trait.clinvar_trait_list = [[]]
-    trait.efo_list = ['http://www.orpha.net/ORDO/Orphanet_88991']
+    trait.clinvar_name = ""
+    trait.ontology_name = 'http://www.orpha.net/ORDO/Orphanet_88991'
 
     ensembl_gene_id = "ENSG00000197616"
 
@@ -64,8 +64,8 @@ def get_args_CTTVSomaticEvidenceString_init():
 
     trait = SimpleNamespace()
     trait.trait_counter = 0
-    trait.clinvar_trait_list = [[]]
-    trait.efo_list = ['http://www.ebi.ac.uk/efo/EFO_0003840']
+    trait.clinvar_name = ""
+    trait.ontology_name = 'http://www.ebi.ac.uk/efo/EFO_0003840'
 
     ensembl_gene_id = "ENSG00000135486"
 

--- a/tests/test_evidence_strings.py
+++ b/tests/test_evidence_strings.py
@@ -162,8 +162,8 @@ class CTTVGeneticsEvidenceStringTest(unittest.TestCase):
     def test_disease(self):
         disease_id = "Ciliary dyskinesia, primary, 26"
 
-        self.test_ges.disease = disease_id
-        self.assertEqual(self.test_ges.disease, efo_term.EFOTerm(disease_id))
+        self.test_ges.disease_id = disease_id
+        self.assertEqual(self.test_ges.disease_id, efo_term.EFOTerm(disease_id))
 
     def test_evidence_codes(self):
         evidence_codes = ["http://purl.obolibrary.org/obo/ECO_0000205"]


### PR DESCRIPTION
- New trait class to better handle the clinvar name, ontology id, and ontology name across the codebase
- Now reads in a third column from the trait to term mapping for the ontology label, in addition to the ontology id
- Removed unused ignore and adapt ontology term code
- Ontology label, and original clinvar trait name now put into evidence string as "name" and "source_name" elements respectively