### PR TITLE
EVA-697 : Output zooma file from pipeline

### DIFF
--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -27,13 +27,16 @@ class Report:
     One instance of this class is instantiated in the running of the pipeline.
     """
 
-    def __init__(self, trait_mappings, unavailable_efo=None):
+    def __init__(self, trait_mappings=None, unavailable_efo=None):
         if unavailable_efo is None:
             self.unavailable_efo = set()
         else:
             self.unavailable_efo = unavailable_efo
 
-        self.trait_mappings = trait_mappings
+        if trait_mappings is None:
+            self.trait_mappings = {}
+        else:
+            self.trait_mappings = trait_mappings
 
         self.unrecognised_clin_sigs = set()
         self.ensembl_gene_id_uris = set()

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -152,22 +152,22 @@ class Report:
             for evidence_string in self.evidence_string_list:
                 fdw.write(json.dumps(evidence_string) + '\n')
 
-        self.write_zooma_and_record_files(dir_out)
+        self.write_zooma_file(dir_out)
 
-    def write_zooma_and_record_files(self, dir_out):
-        """Write evidence records and zooma records to evidence_records and zooma files"""
+    def write_zooma_file(self, dir_out):
+        """Write zooma records to zooma file"""
         with utilities.open_file(os.path.join(dir_out, config.ZOOMA_FILE_NAME), "wt") as zooma_fh:
 
             zooma_fh.write("STUDY\tBIOENTITY\tPROPERTY_TYPE\tPROPERTY_VALUE\tSEMANTIC_TAG\tANNOTATOR\tANNOTATION_DATE\n")
             date = strftime("%d/%m/%y %H:%M", gmtime())
             for evidence_record in self.evidence_list:
-                self.write_evidence_record_to_record_zooma_files(evidence_record, zooma_fh, date)
+                self.write_zooma_record_to_zooma_file(evidence_record, zooma_fh, date)
 
             for trait_name, ontology_tuple_list in self.trait_mappings.items():
-                self.write_extra_trait_to_zooma(ontology_tuple_list, trait_name, date, zooma_fh)
+                self.write_extra_trait_to_zooma_file(ontology_tuple_list, trait_name, date, zooma_fh)
 
-    def write_evidence_record_to_record_zooma_files(self, evidence_record, zooma_fh, date):
-        """Write an evidence record to evidence_record file and zooma file"""
+    def write_zooma_record_to_zooma_file(self, evidence_record, zooma_fh, date):
+        """Write an zooma record to zooma file"""
         evidence_record_to_output = ['.' if ele is None else ele for ele in evidence_record]
 
         if evidence_record_to_output[1] != ".":
@@ -185,7 +185,7 @@ class Report:
 
         zooma_fh.write('\t'.join(zooma_output_list) + '\n')
 
-    def write_extra_trait_to_zooma(self, ontology_tuple_list, trait_name, date, zooma_fh):
+    def write_extra_trait_to_zooma_file(self, ontology_tuple_list, trait_name, date, zooma_fh):
         """Write the trait name to ontology mappings, which weren't used in any evidence string, to
         zooma file """
         for ontology_tuple in ontology_tuple_list:

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -152,28 +152,32 @@ class Report:
             for evidence_string in self.evidence_string_list:
                 fdw.write(json.dumps(evidence_string) + '\n')
 
-        with utilities.open_file(os.path.join(dir_out, config.ZOOMA_FILE_NAME), "wt") as zooma_fh:
+        self.write_zooma_and_record_files(dir_out)
+
+    def write_zooma_and_record_files(self, dir_out):
+        with utilities.open_file(os.path.join(dir_out, config.ZOOMA_FILE_NAME), "wt") as zooma_fh, \
+                utilities.open_file(dir_out + '/' + config.EVIDENCE_RECORDS_FILE_NAME, 'wt') as fdw:
+
             zooma_fh.write("STUDY\tBIOENTITY\tPROPERTY_TYPE\tPROPERTY_VALUE\tSEMANTIC_TAG\tANNOTATOR\tANNOTATION_DATE\n")
             date = strftime("%d/%m/%y %H:%M", gmtime())
-            with utilities.open_file(dir_out + '/' + config.EVIDENCE_RECORDS_FILE_NAME, 'wt') as fdw:
-                for evidence_record in self.evidence_list:
-                    evidence_record_to_output = ['.' if ele is None else ele for ele in evidence_record]
-                    fdw.write('\t'.join(evidence_record_to_output) + '\n')
+            for evidence_record in self.evidence_list:
+                evidence_record_to_output = ['.' if ele is None else ele for ele in evidence_record]
+                fdw.write('\t'.join(evidence_record_to_output) + '\n')
 
-                    if evidence_record_to_output[1] != ".":
-                        rs_for_zooma = evidence_record_to_output[1]
-                    else:
-                        rs_for_zooma = ""
+                if evidence_record_to_output[1] != ".":
+                    rs_for_zooma = evidence_record_to_output[1]
+                else:
+                    rs_for_zooma = ""
 
-                    zooma_output_list = [evidence_record_to_output[0],
-                                         rs_for_zooma,
-                                         "disease",
-                                         evidence_record_to_output[2],
-                                         evidence_record_to_output[3],
-                                         "eva",
-                                         date]
+                zooma_output_list = [evidence_record_to_output[0],
+                                     rs_for_zooma,
+                                     "disease",
+                                     evidence_record_to_output[2],
+                                     evidence_record_to_output[3],
+                                     "eva",
+                                     date]
 
-                    zooma_fh.write('\t'.join(zooma_output_list) + '\n')
+                zooma_fh.write('\t'.join(zooma_output_list) + '\n')
 
             for trait_name, ontology_tuple_list in self.trait_mappings.items():
                 for ontology_tuple in ontology_tuple_list:

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -1,7 +1,9 @@
 import itertools
 import json
 import sys
+import os
 from collections import defaultdict
+from time import gmtime, strftime
 from types import SimpleNamespace
 
 import jsonschema
@@ -145,9 +147,27 @@ class Report:
                 fdw.write(json.dumps(evidence_string) + '\n')
 
         with utilities.open_file(dir_out + '/' + config.EVIDENCE_RECORDS_FILE_NAME, 'wt') as fdw:
-            for evidence_record in self.evidence_list:
-                evidence_record_to_output = ['.' if ele is None else ele for ele in evidence_record]
-                fdw.write('\t'.join(evidence_record_to_output) + '\n')
+            with utilities.open_file(os.path.join(dir_out, config.ZOOMA_FILE_NAME), "wt") as zooma_fh:
+                date = strftime("%d/%m/%y %H:%M", gmtime())
+                for evidence_record in self.evidence_list:
+                    evidence_record_to_output = ['.' if ele is None else ele for ele in evidence_record]
+                    fdw.write('\t'.join(evidence_record_to_output) + '\n')
+
+                    if evidence_record_to_output[1] != ".":
+                        rs_for_zooma = evidence_record_to_output[1]
+                    else:
+                        rs_for_zooma = ""
+
+                    zooma_output_list = [evidence_record_to_output[0],
+                                         rs_for_zooma,
+                                         "disease",
+                                         evidence_record_to_output[2],
+                                         evidence_record_to_output[3],
+                                         "eva",
+                                         date]
+
+                    zooma_fh.write('\t'.join(zooma_output_list) + '\n')
+
 
     @staticmethod
     def __get_counters():

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -174,16 +174,17 @@ class Report:
 
                     zooma_fh.write('\t'.join(zooma_output_list) + '\n')
 
-            for trait_name, ontology_tuple in self.trait_mappings.items():
-                zooma_output_list = ["",
-                                     "",
-                                     "disease",
-                                     trait_name,
-                                     ontology_tuple[0],
-                                     "eva",
-                                     date]
+            for trait_name, ontology_tuple_list in self.trait_mappings.items():
+                for ontology_tuple in ontology_tuple_list:
+                    zooma_output_list = ["",
+                                         "",
+                                         "disease",
+                                         trait_name,
+                                         ontology_tuple[0],
+                                         "eva",
+                                         date]
 
-                zooma_fh.write('\t'.join(zooma_output_list) + '\n')
+                    zooma_fh.write('\t'.join(zooma_output_list) + '\n')
 
     def remove_trait_mapping(self, trait_name):
         if trait_name in self.trait_mappings:

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -156,22 +156,19 @@ class Report:
 
     def write_zooma_and_record_files(self, dir_out):
         """Write evidence records and zooma records to evidence_records and zooma files"""
-        with utilities.open_file(os.path.join(dir_out, config.ZOOMA_FILE_NAME), "wt") as zooma_fh, \
-                utilities.open_file(dir_out + '/' + config.EVIDENCE_RECORDS_FILE_NAME, 'wt') as fdw:
+        with utilities.open_file(os.path.join(dir_out, config.ZOOMA_FILE_NAME), "wt") as zooma_fh:
 
             zooma_fh.write("STUDY\tBIOENTITY\tPROPERTY_TYPE\tPROPERTY_VALUE\tSEMANTIC_TAG\tANNOTATOR\tANNOTATION_DATE\n")
             date = strftime("%d/%m/%y %H:%M", gmtime())
             for evidence_record in self.evidence_list:
-                self.write_evidence_record_to_record_zooma_files(evidence_record, fdw, zooma_fh,
-                                                                 date)
+                self.write_evidence_record_to_record_zooma_files(evidence_record, zooma_fh, date)
 
             for trait_name, ontology_tuple_list in self.trait_mappings.items():
                 self.write_extra_trait_to_zooma(ontology_tuple_list, trait_name, date, zooma_fh)
 
-    def write_evidence_record_to_record_zooma_files(self, evidence_record, fdw, zooma_fh, date):
+    def write_evidence_record_to_record_zooma_files(self, evidence_record, zooma_fh, date):
         """Write an evidence record to evidence_record file and zooma file"""
         evidence_record_to_output = ['.' if ele is None else ele for ele in evidence_record]
-        fdw.write('\t'.join(evidence_record_to_output) + '\n')
 
         if evidence_record_to_output[1] != ".":
             rs_for_zooma = evidence_record_to_output[1]

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -185,7 +185,8 @@ class Report:
                 zooma_fh.write('\t'.join(zooma_output_list) + '\n')
 
     def remove_trait_mapping(self, trait_name):
-        del self.trait_mappings[trait_name]
+        if trait_name in self.trait_mappings:
+            del self.trait_mappings[trait_name]
 
 
     @staticmethod

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -155,41 +155,52 @@ class Report:
         self.write_zooma_and_record_files(dir_out)
 
     def write_zooma_and_record_files(self, dir_out):
+        """Write evidence records and zooma records to evidence_records and zooma files"""
         with utilities.open_file(os.path.join(dir_out, config.ZOOMA_FILE_NAME), "wt") as zooma_fh, \
                 utilities.open_file(dir_out + '/' + config.EVIDENCE_RECORDS_FILE_NAME, 'wt') as fdw:
 
             zooma_fh.write("STUDY\tBIOENTITY\tPROPERTY_TYPE\tPROPERTY_VALUE\tSEMANTIC_TAG\tANNOTATOR\tANNOTATION_DATE\n")
             date = strftime("%d/%m/%y %H:%M", gmtime())
             for evidence_record in self.evidence_list:
-                evidence_record_to_output = ['.' if ele is None else ele for ele in evidence_record]
-                fdw.write('\t'.join(evidence_record_to_output) + '\n')
-
-                if evidence_record_to_output[1] != ".":
-                    rs_for_zooma = evidence_record_to_output[1]
-                else:
-                    rs_for_zooma = ""
-
-                zooma_output_list = [evidence_record_to_output[0],
-                                     rs_for_zooma,
-                                     "disease",
-                                     evidence_record_to_output[2],
-                                     evidence_record_to_output[3],
-                                     "eva",
-                                     date]
-
-                zooma_fh.write('\t'.join(zooma_output_list) + '\n')
+                self.write_evidence_record_to_record_zooma_files(evidence_record, fdw, zooma_fh,
+                                                                 date)
 
             for trait_name, ontology_tuple_list in self.trait_mappings.items():
-                for ontology_tuple in ontology_tuple_list:
-                    zooma_output_list = ["",
-                                         "",
-                                         "disease",
-                                         trait_name,
-                                         ontology_tuple[0],
-                                         "eva",
-                                         date]
+                self.write_extra_trait_to_zooma(ontology_tuple_list, trait_name, date, zooma_fh)
 
-                    zooma_fh.write('\t'.join(zooma_output_list) + '\n')
+    def write_evidence_record_to_record_zooma_files(self, evidence_record, fdw, zooma_fh, date):
+        """Write an evidence record to evidence_record file and zooma file"""
+        evidence_record_to_output = ['.' if ele is None else ele for ele in evidence_record]
+        fdw.write('\t'.join(evidence_record_to_output) + '\n')
+
+        if evidence_record_to_output[1] != ".":
+            rs_for_zooma = evidence_record_to_output[1]
+        else:
+            rs_for_zooma = ""
+
+        zooma_output_list = [evidence_record_to_output[0],
+                             rs_for_zooma,
+                             "disease",
+                             evidence_record_to_output[2],
+                             evidence_record_to_output[3],
+                             "eva",
+                             date]
+
+        zooma_fh.write('\t'.join(zooma_output_list) + '\n')
+
+    def write_extra_trait_to_zooma(self, ontology_tuple_list, trait_name, date, zooma_fh):
+        """Write the trait name to ontology mappings, which weren't used in any evidence string, to
+        zooma file """
+        for ontology_tuple in ontology_tuple_list:
+            zooma_output_list = ["",
+                                 "",
+                                 "disease",
+                                 trait_name,
+                                 ontology_tuple[0],
+                                 "eva",
+                                 date]
+
+            zooma_fh.write('\t'.join(zooma_output_list) + '\n')
 
     def remove_trait_mapping(self, trait_name):
         if trait_name in self.trait_mappings:

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -1,4 +1,5 @@
 import itertools
+import copy
 import json
 import sys
 import os
@@ -36,7 +37,7 @@ class Report:
         if trait_mappings is None:
             self.trait_mappings = {}
         else:
-            self.trait_mappings = trait_mappings.copy()
+            self.trait_mappings = copy.deepcopy(trait_mappings)
 
         self.unrecognised_clin_sigs = set()
         self.ensembl_gene_id_uris = set()

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -153,6 +153,7 @@ class Report:
                 fdw.write(json.dumps(evidence_string) + '\n')
 
         with utilities.open_file(os.path.join(dir_out, config.ZOOMA_FILE_NAME), "wt") as zooma_fh:
+            zooma_fh.write("STUDY\tBIOENTITY\tPROPERTY_TYPE\tPROPERTY_VALUE\tSEMANTIC_TAG\tANNOTATOR\tANNOTATION_DATE\n")
             date = strftime("%d/%m/%y %H:%M", gmtime())
             with utilities.open_file(dir_out + '/' + config.EVIDENCE_RECORDS_FILE_NAME, 'wt') as fdw:
                 for evidence_record in self.evidence_list:

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -36,7 +36,7 @@ class Report:
         if trait_mappings is None:
             self.trait_mappings = {}
         else:
-            self.trait_mappings = trait_mappings
+            self.trait_mappings = trait_mappings.copy()
 
         self.unrecognised_clin_sigs = set()
         self.ensembl_gene_id_uris = set()

--- a/eva_cttv_pipeline/config.py
+++ b/eva_cttv_pipeline/config.py
@@ -16,6 +16,7 @@ HOST = 'wwwdev.ebi.ac.uk'
 # output settings
 EVIDENCE_STRINGS_FILE_NAME = 'evidence_strings.json'
 EVIDENCE_RECORDS_FILE_NAME = 'evidence_records.tsv'
+ZOOMA_FILE_NAME = 'eva_clinvar.txt'
 UNMAPPED_TRAITS_FILE_NAME = 'unmappedTraits.tsv'
 UNAVAILABLE_EFO_FILE_NAME = 'unavailableefo.tsv'
 NSV_LIST_FILE = 'nsvlist.txt'

--- a/eva_cttv_pipeline/consequence_type.py
+++ b/eva_cttv_pipeline/consequence_type.py
@@ -98,7 +98,8 @@ class SoTerm(object):
                               'protein_altering_variant': 1818,
                               'gene_fusion': 1565,
                               'gene_variant': 1564,
-                              'sequence_variant': 1060}
+                              'sequence_variant': 1060,
+                              'trinucleotide_repeat_microsatellite_feature': 291}
 
     ranked_so_names_list = ['transcript_ablation',
                             'splice_acceptor_variant',


### PR DESCRIPTION
This should hopefully solve the issue of duplicate entries in the zooma file. Rather than Gary creating the zooma file based upon the evidence records file a file is output ready for Zooma-consumption. 