### PR TITLE
EVA-707 Allow multiple mappings for single traits in OT pipeline

### DIFF
--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -316,6 +316,8 @@ def create_traits(clinvar_traits, trait_2_efo_dict, report):
 
 def create_new_trait_list(trait_counter, name_list, trait_2_efo_dict):
     trait_string, mappings = trait.map_efo(trait_2_efo_dict, name_list)
+    if mappings is None:
+        return None
     new_trait_list = []
     for mapping in mappings:
         new_trait_list.append(trait.Trait(trait_string, mapping[0], mapping[1], trait_counter))

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -13,7 +13,7 @@ from eva_cttv_pipeline import evidence_strings
 from eva_cttv_pipeline import clinvar
 from eva_cttv_pipeline import utilities
 from eva_cttv_pipeline import consequence_type as CT
-from eva_cttv_pipeline.trait import Trait
+from eva_cttv_pipeline import trait
 
 
 class Report:
@@ -304,9 +304,9 @@ def get_consequence_types(clinvar_record_measure, consequence_type_dict):
 def create_traits(clinvar_traits, trait_2_efo_dict, report):
     traits = []
     for trait_counter, name_list in enumerate(clinvar_traits):
-        new_trait = create_trait(trait_counter, name_list, trait_2_efo_dict)
-        if new_trait:
-            traits.append(new_trait)
+        new_trait_list = create_new_trait_list(trait_counter, name_list, trait_2_efo_dict)
+        if new_trait_list:
+            traits.extend(new_trait_list)
         else:
             report.counters["n_missed_strings_unmapped_traits"] += 1
             for name in name_list:
@@ -314,13 +314,16 @@ def create_traits(clinvar_traits, trait_2_efo_dict, report):
     return traits
 
 
-def create_trait(trait_counter, name_list, trait_2_efo_dict):
-    trait = Trait(name_list, trait_counter, trait_2_efo_dict)
+def create_new_trait_list(trait_counter, name_list, trait_2_efo_dict):
+    trait_string, mappings = trait.map_efo(trait_2_efo_dict, name_list)
+    new_trait_list = []
+    for mapping in mappings:
+        new_trait_list.append(trait.Trait(trait_string, mapping[0], mapping[1], trait_counter))
     # Only ClinVar records associated to a
     # trait with mapped EFO term will generate evidence_strings
-    if trait.ontology_id is None:
+    if new_trait_list is None:
         return None
-    return trait
+    return new_trait_list
 
 
 def write_string_list_to_file(string_list, filename):
@@ -336,7 +339,7 @@ def append_nsv(nsv_list, clinvar_record_measure):
 
 
 def load_efo_mapping(efo_mapping_file):
-    trait_2_efo = {}
+    trait_2_efo = defaultdict(list)
     unavailable_efo = set()
     n_efo_mappings = 0
 
@@ -347,9 +350,10 @@ def load_efo_mapping(efo_mapping_file):
             line_list = line.rstrip().split("\t")
             clinvar_name = line_list[0].lower()
             if len(line_list) > 1:
-                ontology_id = line_list[1]
-                ontology_label = line_list[2] if len(line_list) > 2 else None
-                trait_2_efo[clinvar_name] = (ontology_id, ontology_label)
+                ontology_id_list = line_list[1].split("|")
+                ontology_label_list = line_list[2].split("|") if len(line_list) > 2 else [None] * len(ontology_id_list)
+                for ontology_id, ontology_label in zip(ontology_id_list, ontology_label_list):
+                    trait_2_efo[clinvar_name].append((ontology_id, ontology_label))
                 n_efo_mappings += 1
             else:
                 unavailable_efo.add(clinvar_name)

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -304,7 +304,7 @@ def get_consequence_types(clinvar_record_measure, consequence_type_dict):
 def create_traits(clinvar_traits, trait_2_efo_dict, report):
     traits = []
     for trait_counter, name_list in enumerate(clinvar_traits):
-        new_trait_list = create_new_trait_list(trait_counter, name_list, trait_2_efo_dict)
+        new_trait_list = create_trait_list(name_list, trait_2_efo_dict, trait_counter)
         if new_trait_list:
             traits.extend(new_trait_list)
         else:
@@ -314,7 +314,7 @@ def create_traits(clinvar_traits, trait_2_efo_dict, report):
     return traits
 
 
-def create_new_trait_list(trait_counter, name_list, trait_2_efo_dict):
+def create_trait_list(name_list, trait_2_efo_dict, trait_counter):
     trait_string, mappings = trait.map_efo(trait_2_efo_dict, name_list)
     if mappings is None:
         return None
@@ -323,7 +323,7 @@ def create_new_trait_list(trait_counter, name_list, trait_2_efo_dict):
         new_trait_list.append(trait.Trait(trait_string, mapping[0], mapping[1], trait_counter))
     # Only ClinVar records associated to a
     # trait with mapped EFO term will generate evidence_strings
-    if new_trait_list is None:
+    if not new_trait_list:
         return None
     return new_trait_list
 

--- a/eva_cttv_pipeline/trait.py
+++ b/eva_cttv_pipeline/trait.py
@@ -16,24 +16,21 @@ def map_efo(trait_2_efo_dict, name_list):
     """
     trait_string = name_list[0].lower()  # Try first element, which should be preferred name if it exists
     if trait_string in trait_2_efo_dict:
-        ontology_id = trait_2_efo_dict[trait_string][0]
-        ontology_label = trait_2_efo_dict[trait_string][1]
-        return trait_string, ontology_id, ontology_label
+        return trait_string, trait_2_efo_dict[trait_string]
     else:
         # Otherwise cycle through the list, the first name that is in the dict
         # is returned along with the ontology id and label from the dict
         for trait in name_list[1:]:
             trait_string = trait.lower()
             if trait_string in trait_2_efo_dict:
-                ontology_id = trait_2_efo_dict[trait_string][0]
-                ontology_label = trait_2_efo_dict[trait_string][1]
-                return trait_string, ontology_id, ontology_label
+                return trait_string, trait_2_efo_dict[trait_string]
 
-    return None, None, None  # If none of the names in the list are keys in the dict then None is returned
+    return None  # If none of the names in the list are keys in the dict then None is returned
 
 
 class Trait:
-    def __init__(self, clinvar_trait_name_list, trait_counter, trait_2_efo_dict):
+    def __init__(self, trait_string, ontology_id, ontology_label, trait_counter):
         self.trait_counter = trait_counter  # number of trait for record
-        self.clinvar_name, self.ontology_id, self.ontology_label = map_efo(trait_2_efo_dict,
-                                                                           clinvar_trait_name_list)
+        self.clinvar_name = trait_string
+        self.ontology_id = ontology_id
+        self.ontology_label = ontology_label

--- a/eva_cttv_pipeline/trait.py
+++ b/eva_cttv_pipeline/trait.py
@@ -28,3 +28,15 @@ class Trait:
         self.clinvar_name = clinvar_name
         self.ontology_id = ontology_id
         self.ontology_label = ontology_label
+
+    def __str__(self):
+        return "clinvar name: {} ontology id: {} ontology label: {} trait_counter: {}".format(self.clinvar_name,
+                                                                                              self.ontology_id,
+                                                                                              self.ontology_label,
+                                                                                              self.trait_counter)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        else:
+            return False

--- a/eva_cttv_pipeline/trait.py
+++ b/eva_cttv_pipeline/trait.py
@@ -19,7 +19,7 @@ def map_efo(trait_2_efo_dict, name_list):
         if trait_string in trait_2_efo_dict:
             return trait_string, trait_2_efo_dict[trait_string]
 
-    return name_list[0].lower(), None  # If none of the names in the list are keys in the dict then None is returned
+    return None, None  # If none of the names in the list are keys in the dict then None is returned
 
 
 class Trait:

--- a/eva_cttv_pipeline/trait.py
+++ b/eva_cttv_pipeline/trait.py
@@ -10,27 +10,21 @@ def map_efo(trait_2_efo_dict, name_list):
     that id.
     :param name_list: List of clinvar trait names for the trait, with the preferred trait name (if
     one exists) in the first element.
-    :return: The clinvar name, ontology id, and ontology label, for the clinvar name in the
+    :return: The clinvar name, and mapping to an ontology id and term, for the clinvar name in the
     name_list with the lowest element that is in the trait_2_efo_dict. If none of the names in the
     name_list are keys in the trait_2_efo_dict then None is returned in each position.
     """
-    trait_string = name_list[0].lower()  # Try first element, which should be preferred name if it exists
-    if trait_string in trait_2_efo_dict:
-        return trait_string, trait_2_efo_dict[trait_string]
-    else:
-        # Otherwise cycle through the list, the first name that is in the dict
-        # is returned along with the ontology id and label from the dict
-        for trait in name_list[1:]:
-            trait_string = trait.lower()
-            if trait_string in trait_2_efo_dict:
-                return trait_string, trait_2_efo_dict[trait_string]
+    for trait in name_list:
+        trait_string = trait.lower()
+        if trait_string in trait_2_efo_dict:
+            return trait_string, trait_2_efo_dict[trait_string]
 
-    return trait_string, None  # If none of the names in the list are keys in the dict then None is returned
+    return name_list[0].lower(), None  # If none of the names in the list are keys in the dict then None is returned
 
 
 class Trait:
-    def __init__(self, trait_string, ontology_id, ontology_label, trait_counter):
+    def __init__(self, clinvar_name, ontology_id, ontology_label, trait_counter):
         self.trait_counter = trait_counter  # number of trait for record
-        self.clinvar_name = trait_string
+        self.clinvar_name = clinvar_name
         self.ontology_id = ontology_id
         self.ontology_label = ontology_label

--- a/eva_cttv_pipeline/trait.py
+++ b/eva_cttv_pipeline/trait.py
@@ -25,7 +25,7 @@ def map_efo(trait_2_efo_dict, name_list):
             if trait_string in trait_2_efo_dict:
                 return trait_string, trait_2_efo_dict[trait_string]
 
-    return None  # If none of the names in the list are keys in the dict then None is returned
+    return trait_string, None  # If none of the names in the list are keys in the dict then None is returned
 
 
 class Trait:

--- a/tests/resources/feb16_jul16_combined_trait_to_url.tsv
+++ b/tests/resources/feb16_jul16_combined_trait_to_url.tsv
@@ -490,7 +490,6 @@ PAROXYSMAL NOCTURNAL HEMOGLOBINURIA 2	http://www.orpha.net/ORDO/Orphanet_447
 Infantile cortical hyperostosis	http://www.orpha.net/ORDO/Orphanet_1310
 Peroxisome biogenesis disorder 8A	http://www.orpha.net/ORDO/Orphanet_79189
 CONGENITAL HEART DISEASE	http://purl.obolibrary.org/obo/HP_0001682
-CORONARY ARTERY DISEASE/MYOCARDIAL INFARCTION	http://www.ebi.ac.uk/efo/EFO_0000378
 Autosomal recessive cutis laxa type 3B	http://www.orpha.net/ORDO/Orphanet_209
 DIABETES INSIPIDUS	http://www.ebi.ac.uk/efo/EFO_0000400
 Hypotrichosis 12	http://purl.obolibrary.org/obo/HP_0100840
@@ -2419,7 +2418,6 @@ HYPOMAGNESEMIA 6	http://purl.obolibrary.org/obo/HP_0002321
 PROSTATE CANCER SUSCEPTIBILITY	http://www.ebi.ac.uk/efo/EFO_0001663
 Complement 1s deficiency	http://www.orpha.net/ORDO/Orphanet_308400
 Spastic paraplegia 15	http://purl.obolibrary.org/obo/HP_0001258
-BARRETT ESOPHAGUS/ESOPHAGEAL ADENOCARCINOMA	http://www.ebi.ac.uk/efo/EFO_0000311
 Diffuse palmoplantar keratoderma	http://www.orpha.net/ORDO/Orphanet_307141
 NATIVE AMERICAN MYOPATHY	http://www.orpha.net/ORDO/Orphanet_168572
 HARTSFIELD SYNDROME	http://purl.obolibrary.org/obo/HP_0000508
@@ -5439,3 +5437,5 @@ Parathyroid adenoma, somatic	http://www.orpha.net/ORDO/Orphanet_99877
 DIABETES MELLITUS, TYPE II, AUTOSOMAL DOMINANT	http://www.orpha.net/ORDO/Orphanet_99886
 Hydatidiform mole, recurrent, 2	http://www.orpha.net/ORDO/Orphanet_99927
 Esophageal squamous cell carcinoma, somatic	http://www.orpha.net/ORDO/Orphanet_99977
+coronary artery disease/myocardial infarction	http://www.ebi.ac.uk/efo/EFO_0000612|http://www.ebi.ac.uk/efo/EFO_0001645	myocardial infarction|coronary heart disease
+barrett esophagus/esophageal adenocarcinoma	http://www.ebi.ac.uk/efo/EFO_0000478|http://www.ebi.ac.uk/efo/EFO_0000280	esophageal adenocarcinoma|Barrett's esophagus

--- a/tests/test_clinvar_to_evidence_strings.py
+++ b/tests/test_clinvar_to_evidence_strings.py
@@ -3,6 +3,7 @@ import unittest
 
 from eva_cttv_pipeline import consequence_type as CT
 from eva_cttv_pipeline import clinvar_to_evidence_strings
+from eva_cttv_pipeline import trait as Trait
 from tests import test_clinvar
 from tests import config
 
@@ -38,6 +39,11 @@ class GetMappingsTest(unittest.TestCase):
             self.mappings.trait_2_efo["3 beta-hydroxysteroid dehydrogenase deficiency"][0],
             ('http://www.orpha.net/ORDO/Orphanet_90791', None))
 
+        self.assertEqual(
+            self.mappings.trait_2_efo["coronary artery disease/myocardial infarction"],
+            [('http://www.ebi.ac.uk/efo/EFO_0000612', 'myocardial infarction'),
+             ('http://www.ebi.ac.uk/efo/EFO_0001645', 'coronary heart disease')])
+
     def test_consequence_type_dict(self):
         self.assertEqual(len(self.mappings.consequence_type_dict), 34)
 
@@ -62,6 +68,20 @@ class CreateTraitTest(unittest.TestCase):
 
     def test_efo_list(self):
         self.assertEqual(self.trait.ontology_id, 'http://www.ebi.ac.uk/efo/EFO_0003900')
+
+    def test_multiple_mappings(self):
+        trait1 = Trait.Trait("barrett esophagus/esophageal adenocarcinoma",
+                             "http://www.ebi.ac.uk/efo/EFO_0000478",
+                             "esophageal adenocarcinoma", 1)
+        trait2 = Trait.Trait("barrett esophagus/esophageal adenocarcinoma",
+                             "http://www.ebi.ac.uk/efo/EFO_0000280",
+                             "Barrett's esophagus", 1)
+
+        test_trait_list = clinvar_to_evidence_strings.create_trait_list(
+            ["barrett esophagus/esophageal adenocarcinoma"], MAPPINGS.trait_2_efo, 1)
+
+        self.assertEqual([trait1, trait2], test_trait_list)
+
 
     def test_return_none(self):
         none_trait = clinvar_to_evidence_strings.create_trait_list(["not a real trait"],

--- a/tests/test_clinvar_to_evidence_strings.py
+++ b/tests/test_clinvar_to_evidence_strings.py
@@ -30,12 +30,12 @@ class GetMappingsTest(unittest.TestCase):
     def test_efo_mapping(self):
         self.assertEqual(len(self.mappings.trait_2_efo), 5283)
 
-        self.assertEqual(self.mappings.trait_2_efo["renal-hepatic-pancreatic dysplasia 2"],
+        self.assertEqual(self.mappings.trait_2_efo["renal-hepatic-pancreatic dysplasia 2"][0],
                          ('http://www.orpha.net/ORDO/Orphanet_294415', None))
-        self.assertEqual(self.mappings.trait_2_efo["frontotemporal dementia"],
-                         ('http://purl.obolibrary.org/obo/HP_0000713', None))
+        self.assertEqual(self.mappings.trait_2_efo["frontotemporal dementia"][0],
+                         ('http://purl.obolibrary.org/obo/HP_0000733', None))
         self.assertEqual(
-            self.mappings.trait_2_efo["3 beta-hydroxysteroid dehydrogenase deficiency"],
+            self.mappings.trait_2_efo["3 beta-hydroxysteroid dehydrogenase deficiency"][0],
             ('http://www.orpha.net/ORDO/Orphanet_90791', None))
 
     def test_consequence_type_dict(self):
@@ -54,8 +54,9 @@ class GetMappingsTest(unittest.TestCase):
 class CreateTraitTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.trait = clinvar_to_evidence_strings.create_trait(9, ["Ciliary dyskinesia, primary, 7"],
-                                                             MAPPINGS.trait_2_efo)
+        cls.trait = clinvar_to_evidence_strings.create_new_trait_list(9,
+                                                                      ["Ciliary dyskinesia, primary, 7"],
+                                                                      MAPPINGS.trait_2_efo)[0]
 
     def test_clinvar_trait_list(self):
         self.assertEqual(self.trait.clinvar_name, 'ciliary dyskinesia, primary, 7')
@@ -64,8 +65,9 @@ class CreateTraitTest(unittest.TestCase):
         self.assertEqual(self.trait.ontology_id, 'http://www.ebi.ac.uk/efo/EFO_0003900')
 
     def test_return_none(self):
-        none_trait = \
-            clinvar_to_evidence_strings.create_trait(9, ["not a real trait"], MAPPINGS.trait_2_efo)
+        none_trait = clinvar_to_evidence_strings.create_new_trait_list(9,
+                                                                       ["not a real trait"],
+                                                                       MAPPINGS.trait_2_efo)
         self.assertIsNone(none_trait)
 
 

--- a/tests/test_clinvar_to_evidence_strings.py
+++ b/tests/test_clinvar_to_evidence_strings.py
@@ -54,9 +54,8 @@ class GetMappingsTest(unittest.TestCase):
 class CreateTraitTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.trait = clinvar_to_evidence_strings.create_new_trait_list(9,
-                                                                      ["Ciliary dyskinesia, primary, 7"],
-                                                                      MAPPINGS.trait_2_efo)[0]
+        cls.trait = clinvar_to_evidence_strings.create_trait_list(
+            ["Ciliary dyskinesia, primary, 7"], MAPPINGS.trait_2_efo, 9)[0]
 
     def test_clinvar_trait_list(self):
         self.assertEqual(self.trait.clinvar_name, 'ciliary dyskinesia, primary, 7')
@@ -65,9 +64,8 @@ class CreateTraitTest(unittest.TestCase):
         self.assertEqual(self.trait.ontology_id, 'http://www.ebi.ac.uk/efo/EFO_0003900')
 
     def test_return_none(self):
-        none_trait = clinvar_to_evidence_strings.create_new_trait_list(9,
-                                                                       ["not a real trait"],
-                                                                       MAPPINGS.trait_2_efo)
+        none_trait = clinvar_to_evidence_strings.create_trait_list(["not a real trait"],
+                                                                   MAPPINGS.trait_2_efo, 9)
         self.assertIsNone(none_trait)
 
 


### PR DESCRIPTION
Trait mapping file allowed to have multiple mappings for one trait, e.g.:

coronary artery disease/myocardial infarction http://www.ebi.ac.uk/efo/EFO_0000612 | http://www.ebi.ac.uk/efo/EFO_0001645 myocardial infarction|coronary heart disease

each column separated by a pipe character. There are now one evidence string per ontology mapping.