### PR TITLE
EVA-703 : Update Open Targets pipeline for new json schema version 1.2.5 - PART 2

### DIFF
--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -4,7 +4,6 @@ import sys
 from collections import defaultdict
 from types import SimpleNamespace
 
-import progressbar
 import jsonschema
 
 from eva_cttv_pipeline import cellbase_records
@@ -188,24 +187,13 @@ def output(report, dir_out):
     print(report)
 
 
-def file_len(fpath):
-    i = -1
-    with utilities.open_file(fpath, mode="rt") as f:
-        for i, l in enumerate(f):
-            pass
-    return i + 1
-
-
 def clinvar_to_evidence_strings(allowed_clinical_significance, mappings, json_file):
 
     report = Report(mappings.unavailable_efo)
 
     cell_recs = cellbase_records.CellbaseRecords(json_file=json_file)
 
-    num_cell_recs = file_len(json_file)
-
-    bar = progressbar.ProgressBar(max_value=num_cell_recs)
-    for cellbase_record in bar(cell_recs):
+    for cellbase_record in cell_recs:
         n_ev_strings_per_record = 0
         clinvar_record = clinvar.ClinvarRecord(cellbase_record['clinvarSet'])
 

--- a/eva_cttv_pipeline/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/clinvar_to_evidence_strings.py
@@ -4,6 +4,7 @@ import sys
 from collections import defaultdict
 from types import SimpleNamespace
 
+import progressbar
 import jsonschema
 
 from eva_cttv_pipeline import cellbase_records
@@ -187,13 +188,24 @@ def output(report, dir_out):
     print(report)
 
 
+def file_len(fpath):
+    i = -1
+    with utilities.open_file(fpath, mode="rt") as f:
+        for i, l in enumerate(f):
+            pass
+    return i + 1
+
+
 def clinvar_to_evidence_strings(allowed_clinical_significance, mappings, json_file):
 
     report = Report(mappings.unavailable_efo)
 
     cell_recs = cellbase_records.CellbaseRecords(json_file=json_file)
 
-    for cellbase_record in cell_recs:
+    num_cell_recs = file_len(json_file)
+
+    bar = progressbar.ProgressBar(max_value=num_cell_recs)
+    for cellbase_record in bar(cell_recs):
         n_ev_strings_per_record = 0
         clinvar_record = clinvar.ClinvarRecord(cellbase_record['clinvarSet'])
 

--- a/eva_cttv_pipeline/resources/CTTVGeneticsEvidenceString.json
+++ b/eva_cttv_pipeline/resources/CTTVGeneticsEvidenceString.json
@@ -6,7 +6,7 @@
     "type": null,
     "id": []
   },
-  "validated_against_schema_version": "1.2.4",
+  "validated_against_schema_version": "1.2.5",
   "disease": {
     "id": []
   },

--- a/eva_cttv_pipeline/resources/CTTVSomaticEvidenceString.json
+++ b/eva_cttv_pipeline/resources/CTTVSomaticEvidenceString.json
@@ -2,7 +2,7 @@
   "type": "somatic_mutation",
   "access_level": "public",
   "sourceID": "eva_somatic",
-  "validated_against_schema_version": "1.2.4",
+  "validated_against_schema_version": "1.2.5",
   "disease": {
     "id": []
   },


### PR DESCRIPTION
Original PR found here: https://github.com/EBIvariation/eva-cttv-pipeline/pull/34

Changed the version numbers on the template json files and updated the json_schema submodule.