### PR TITLE
EVA-872 Generate and submit evidence strings

### DIFF
--- a/eva_cttv_pipeline/evidence_string_generation/consequence_type.py
+++ b/eva_cttv_pipeline/evidence_string_generation/consequence_type.py
@@ -99,7 +99,8 @@ class SoTerm(object):
                               'gene_fusion': 1565,
                               'gene_variant': 1564,
                               'sequence_variant': 1060,
-                              'trinucleotide_repeat_microsatellite_feature': 291}
+                              'trinucleotide_repeat_microsatellite_feature': 291,
+                              'trinucleotide_repeat_expansion': 2165}
 
     ranked_so_names_list = ['transcript_ablation',
                             'splice_acceptor_variant',

--- a/eva_cttv_pipeline/evidence_string_generation/resources/CTTVGeneticsEvidenceString.json
+++ b/eva_cttv_pipeline/evidence_string_generation/resources/CTTVGeneticsEvidenceString.json
@@ -6,7 +6,7 @@
     "type": null,
     "id": []
   },
-  "validated_against_schema_version": "1.2.6",
+  "validated_against_schema_version": "1.2.7",
   "disease": {
     "id": []
   },
@@ -33,7 +33,7 @@
           "dbxref": {
             "url": null,
             "id": "http://identifiers.org/clinvar",
-            "version": "2017-04"
+            "version": "2017-08"
           },
           "id": "EVA",
           "version": "1.0"
@@ -68,7 +68,7 @@
           "dbxref": {
             "url": null,
             "id": "http://identifiers.org/clinvar",
-            "version": "2017-04"
+            "version": "2017-08"
           },
           "id": "EVA",
           "version": "1.0"

--- a/eva_cttv_pipeline/evidence_string_generation/resources/CTTVSomaticEvidenceString.json
+++ b/eva_cttv_pipeline/evidence_string_generation/resources/CTTVSomaticEvidenceString.json
@@ -2,7 +2,7 @@
   "type": "somatic_mutation",
   "access_level": "public",
   "sourceID": "eva_somatic",
-  "validated_against_schema_version": "1.2.6",
+  "validated_against_schema_version": "1.2.7",
   "disease": {
     "id": []
   },
@@ -29,7 +29,7 @@
         "dbxref": {
           "url": null,
           "id": "http://identifiers.org/clinvar",
-          "version": "2017-04"
+          "version": "2017-08"
         },
         "id": "EVA",
         "version": "1.0"


### PR DESCRIPTION
Evidence string generation update for new Open Target data and schema
- Added trinucleotide_repeat_expansion to so_terms
- Updated jsons
- Updated json_schema submodule