### PR TITLE
EVA-872 Generate and submit evidence strings

### DIFF
--- a/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
@@ -249,11 +249,11 @@ def clinvar_to_evidence_strings(allowed_clinical_significance, mappings, json_fi
     cell_recs = cellbase_records.CellbaseRecords(json_file=json_file)
 
     for cellbase_record in cell_recs:
+        report.counters["record_counter"] += 1
         n_ev_strings_per_record = 0
         clinvar_record = clinvar.ClinvarRecord(cellbase_record['clinvarSet'])
 
         for clinvar_record_measure in clinvar_record.measures:
-            report.counters["record_counter"] += 1
             report.counters["n_nsvs"] += (clinvar_record_measure.nsv_id is not None)
             append_nsv(report.nsv_list, clinvar_record_measure)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 def get_package_data():
     package_data = []
-    for root, dirnames, filenames in os.walk('./eva_cttv_pipeline/evidence_string_generation/resources/json_schema'):
+    for root, dirnames, filenames in os.walk('./eva_cttv_pipeline/evidence_string_generation/resources'):
         root = root.replace("./eva_cttv_pipeline/", "")
         for filename in filenames:
             new_fn = os.path.join(root, filename)


### PR DESCRIPTION
- Moved "record_counter" to outer loop to only count ClinVar records and not records' measures
- Changed path in setup.py to top level of evidence_string_generation/resources rather than json_schema directory, so the JSON skeleton files are installed when using "python setup.py install"