### PR TITLE
EVA-1471 — Bugfix for empty Zooma result, improved logging

### DIFF
--- a/bin/trait_mapping.py
+++ b/bin/trait_mapping.py
@@ -9,7 +9,7 @@ def launch():
 
     main.main(parser.input_filepath, parser.output_mappings_filepath,
               parser.output_curation_filepath, parser.filters, parser.zooma_host,
-              parser.oxo_target_list, parser.oxo_distance)
+              parser.oxo_target_list, parser.oxo_distance, parser.unattended)
 
 
 class ArgParser:
@@ -39,6 +39,8 @@ class ArgParser:
                             help="target ontologies to use with OxO")
         parser.add_argument("-d", dest="oxo_distance", default=3,
                             help="distance to use to query OxO.")
+        parser.add_argument('-u', dest="unattended", action='store_true',
+                            help="unattended launch, hide ETA estimates")
 
         args = parser.parse_args(args=argv[1:])
 
@@ -53,6 +55,7 @@ class ArgParser:
         self.zooma_host = args.zooma_host
         self.oxo_target_list = [target.strip() for target in args.oxo_target_list.split(",")]
         self.oxo_distance = args.oxo_distance
+        self.unattended = args.unattended
 
 
 if __name__ == '__main__':

--- a/eva_cttv_pipeline/__init__.py
+++ b/eva_cttv_pipeline/__init__.py
@@ -1,3 +1,0 @@
-import logging
-logger = logging.getLogger(__package__)
-logger.setLevel(level=logging.INFO)

--- a/eva_cttv_pipeline/__init__.py
+++ b/eva_cttv_pipeline/__init__.py
@@ -1,0 +1,3 @@
+import logging
+logger = logging.getLogger(__package__)
+logger.setLevel(level=logging.INFO)

--- a/eva_cttv_pipeline/trait_mapping/__init__.py
+++ b/eva_cttv_pipeline/trait_mapping/__init__.py
@@ -1,0 +1,4 @@
+import logging
+logging.basicConfig()
+logger = logging.getLogger(__package__)
+logger.setLevel(level=logging.INFO)

--- a/eva_cttv_pipeline/trait_mapping/main.py
+++ b/eva_cttv_pipeline/trait_mapping/main.py
@@ -60,7 +60,7 @@ def process_trait(trait: Trait, filters: dict, zooma_host: str, oxo_target_list:
 
 
 def main(input_filepath, output_mappings_filepath, output_curation_filepath, filters, zooma_host,
-         oxo_target_list, oxo_distance):
+         oxo_target_list, oxo_distance, unattended):
     trait_names_list = parse_trait_names(input_filepath)
     trait_names_counter = Counter(trait_names_list)
 
@@ -70,10 +70,13 @@ def main(input_filepath, output_mappings_filepath, output_curation_filepath, fil
         mapping_writer.writerow(["#clinvar_trait_name", "uri", "label"])
         curation_writer = csv.writer(curation_file, delimiter="\t")
 
-        bar = progressbar.ProgressBar(max_value=len(trait_names_counter),
-                                      widgets=[progressbar.AdaptiveETA(samples=1000)])
+        trait_names_iterator = trait_names_counter.items()
+        if not unattended:
+            trait_names_iterator = progressbar.ProgressBar(
+                max_value=len(trait_names_counter), widgets=[progressbar.AdaptiveETA(samples=1000)]
+            )
 
-        for trait_name, freq in bar(trait_names_counter.items()):
+        for i, (trait_name, freq) in enumerate(trait_names_iterator):
             trait = Trait(trait_name, freq)
             trait = process_trait(trait, filters, zooma_host, oxo_target_list,
                                   oxo_distance)

--- a/eva_cttv_pipeline/trait_mapping/main.py
+++ b/eva_cttv_pipeline/trait_mapping/main.py
@@ -81,7 +81,8 @@ def main(input_filepath, output_mappings_filepath, output_curation_filepath, fil
         trait_names_iterator = trait_names_counter.items()
         if not unattended:
             trait_names_iterator = progressbar.ProgressBar(
-                max_value=len(trait_names_counter), widgets=[progressbar.AdaptiveETA(samples=1000)]
+                trait_names_iterator, max_value=len(trait_names_counter),
+                widgets=[progressbar.AdaptiveETA(samples=1000)]
             )
 
         logger.info("Loaded {} trait names".format(len(trait_names_counter)))

--- a/eva_cttv_pipeline/trait_mapping/ols.py
+++ b/eva_cttv_pipeline/trait_mapping/ols.py
@@ -6,6 +6,9 @@ import urllib
 from eva_cttv_pipeline.trait_mapping.utils import request_retry_helper
 
 
+logger = logging.getLogger(__package__)
+
+
 def get_label_from_ols(url: str) -> str:
     """
     Given a url for OLS, make a get request and return the label for the term, from the response
@@ -20,7 +23,7 @@ def get_label_from_ols(url: str) -> str:
             if term["is_defining_ontology"]:
                 return term["label"]
     except Exception as e:
-        logging.warning(e)
+        logger.warning(e)
     return None
 
 

--- a/eva_cttv_pipeline/trait_mapping/oxo.py
+++ b/eva_cttv_pipeline/trait_mapping/oxo.py
@@ -1,10 +1,14 @@
 from functools import total_ordering, lru_cache
 import json
+import logging
 import re
 import requests
 
 from eva_cttv_pipeline.trait_mapping.ols import get_ontology_label_from_ols, is_in_efo
 from eva_cttv_pipeline.trait_mapping.ols import is_current_and_in_efo
+
+
+logger = logging.getLogger(__package__)
 
 
 class OntologyUri:
@@ -183,9 +187,9 @@ def oxo_request_retry_helper(retry_count: int, url: str, id_list: list, target_l
         return_value = oxo_query_helper(url, payload)
         if return_value is not None:
             return return_value
-        print("attempt {}: failed running function oxo_query_helper with url {}".format(retry_num,
-                                                                                        url))
-    print("error on last attempt, skipping")
+        logger.warning("attempt {}: failed running function oxo_query_helper with url {}".format(
+            retry_num, url))
+    logger.warning("error on last attempt, skipping")
     return None
 
 
@@ -249,8 +253,8 @@ def get_oxo_results(id_list: list, target_list: list, distance: int) -> list:
         return []
 
     if "_embedded" not in oxo_response:
-        print("Cannot parse the response from OxO for the following identifiers: ")
-        print(id_list)
+        logger.warning("Cannot parse the response from OxO for the following identifiers:")
+        logger.warning(','.join(id_list))
         return []
 
     return get_oxo_results_from_response(oxo_response)

--- a/eva_cttv_pipeline/trait_mapping/utils.py
+++ b/eva_cttv_pipeline/trait_mapping/utils.py
@@ -1,3 +1,7 @@
+import logging
+logger = logging.getLogger(__package__)
+
+
 def request_retry_helper(function, retry_count: int, url: str):
     """
     Given a function make a number of attempts to call function for it to successfully return a
@@ -13,6 +17,7 @@ def request_retry_helper(function, retry_count: int, url: str):
         return_value = function(url)
         if return_value is not None:
             return return_value
-        print("attempt {}: failed running function {} with url {}".format(retry_num, function, url))
-    print("error on last attempt, skipping")
+        logger.warning("attempt {}: failed running function {} with url {}".format(
+            retry_num, function, url))
+    logger.warning("error on last attempt, skipping")
     return None

--- a/eva_cttv_pipeline/trait_mapping/zooma.py
+++ b/eva_cttv_pipeline/trait_mapping/zooma.py
@@ -9,6 +9,9 @@ from eva_cttv_pipeline.trait_mapping.ols import get_ontology_label_from_ols, \
 from eva_cttv_pipeline.trait_mapping.utils import request_retry_helper
 
 
+logger = logging.getLogger(__package__)
+
+
 @total_ordering
 class ZoomaConfidence(Enum):
     """Enum to represent the confidence of a mapping in Zooma."""
@@ -126,7 +129,7 @@ def get_zooma_results(trait_name: str, filters: dict, zooma_host: str) -> list:
             if label is not None:
                 zooma_mapping.ontology_label = label
             else:
-                logging.warning("Couldn't retrieve ontology label from OLS for trait '{}'".format(trait_name))
+                logger.warning("Couldn't retrieve ontology label from OLS for trait '{}'".format(trait_name))
 
             uri_is_current_and_in_efo = is_current_and_in_efo(zooma_mapping.uri)
             if not uri_is_current_and_in_efo:

--- a/eva_cttv_pipeline/trait_mapping/zooma.py
+++ b/eva_cttv_pipeline/trait_mapping/zooma.py
@@ -115,7 +115,7 @@ def get_zooma_results(trait_name: str, filters: dict, zooma_host: str) -> list:
     zooma_response_list = request_retry_helper(zooma_query_helper, 4, url)
 
     if zooma_response_list is None:
-        return None
+        return []
 
     zooma_result_list = get_zooma_results_for_trait(zooma_response_list)
 


### PR DESCRIPTION
* Fixed crash when Zooma returns an empty result set. The bug manifested itself when all results from Zooma for a given query had `is_defining_ontology = False` (such results are ignored). Although it happened for only a few records, a subroutine returned None, which was then propagated and the module crashed when trying to iterate over None. This is now fixed by returning `[]` instead of None; an appropriate warning message is issued in such a situation.
* Rewrote logging in `trait_mapping` to consistently use the `logging` module; all `print` calls used for logging purposes were removed.
* Added option `-u` for running the pipeline on the cluster. This disables ETA outputs, which were clogging the logs by thousands of lines.