### PR TITLE
EVA-1445 — Search in MONDO during automated trait mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ This can be done using the following command:
 sudo docker run -p 8080:8080 simonjupp/efo3-ols:3.4.0
 ```
 
-To use the local deployment, make note of the IP address of the machine where OLS is deployed. Then in
-`/eva_cttv_pipeline/trait_mapping/ols.py` uncomment the configuration section to specify the URL of the local
-installation (don't forget to substitute the correct IP address where the OLS installation is deployed).
+To use the local deployment, uncomment the configuration section at the top of `/eva_cttv_pipeline/trait_mapping/ols.py`
+to specify the URL of the local installation. If you have deployed OLS on the different machine than the one you're 
+using to run the pipeline, substitute the correct IP address of the machine where the OLS installation is deployed.
 
 Contact Simon Jupp <jupp@ebi.ac.uk> or somebody from SPOT if you have questions about local OLS installation.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ Eyeball input & output files to ensure that the ClinVar format has not changed s
 enough to render this snippet invalid. Then put the generated files into
 `clinvar-xml-parser/src/test/resources/` directory.
 
+Deploying local OLS installation
+-------
+
+During the preparation of 2019_04 release, which had to be synchronized with EFO v3, OLS had to be deployed
+locally because the production deployment of OLS on www.ebi.ac.uk/ols only supported EFO v2 at the time.
+This can be done using the following command:
+
+```bash
+sudo docker run -p 8080:8080 simonjupp/efo3-ols:3.4.0
+```
+
+To use the local deployment, make note of the IP address of the machine where OLS is deployed. Then in
+`/eva_cttv_pipeline/trait_mapping/ols.py` uncomment the configuration section to specify the URL of the local
+installation (don't forget to substitute the correct IP address where the OLS installation is deployed).
+
+Contact Simon Jupp <jupp@ebi.ac.uk> or somebody from SPOT if you have questions about local OLS installation.
+
+
 Building python pipeline and (optional) Setting up virtual environment
 -------
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ To use the local deployment, uncomment the configuration section at the top of `
 to specify the URL of the local installation. If you have deployed OLS on the different machine than the one you're 
 using to run the pipeline, substitute the correct IP address of the machine where the OLS installation is deployed.
 
-Contact Simon Jupp <jupp@ebi.ac.uk> or somebody from SPOT if you have questions about local OLS installation.
+Please contact the semantic data integration team at [SPOT](https://www.ebi.ac.uk/about/spot-team) if you have questions
+about local OLS installation.
 
 
 Building python pipeline and (optional) Setting up virtual environment

--- a/bin/clinvar_jsons/traits_to_zooma_format.py
+++ b/bin/clinvar_jsons/traits_to_zooma_format.py
@@ -173,20 +173,14 @@ class OntologyUri:
         "efo": "http://www.ebi.ac.uk/efo/{}",
         "mesh": "http://identifiers.org/mesh/{}",
         "medgen": "http://identifiers.org/medgen/{}",
-        "human phenotype ontology": "http://purl.obolibrary.org/obo/HP_{}",
         "mondo": "http://purl.obolibrary.org/obo/MONDO_{}",
     }
 
     def __init__(self, id_, db):
         self.id_ = id_
         self.db = db
-        # This separate condition for "human phenotype ontology" is needed because these IDs are
-        # prefixed with "HP:" which should be ignored when creating uri
-        if self.db.lower() == "human phenotype ontology":
-            logging.warning('Found <human phenotype ontology>, this should not really happen')
-            self.uri = self.db_to_uri_dict[self.db.lower()].format(self.id_[3:])
-        else:
-            self.uri = self.db_to_uri_dict[self.db.lower()].format(self.id_)
+        self.uri = self.db_to_uri_dict[self.db.lower()].format(self.id_)
+
 
     def __str__(self):
         return self.uri

--- a/bin/clinvar_jsons/traits_to_zooma_format.py
+++ b/bin/clinvar_jsons/traits_to_zooma_format.py
@@ -3,6 +3,7 @@ import gzip
 import itertools
 import json
 from functools import lru_cache
+import logging
 import sys
 from time import gmtime, strftime
 
@@ -172,7 +173,8 @@ class OntologyUri:
         "efo": "http://www.ebi.ac.uk/efo/{}",
         "mesh": "http://identifiers.org/mesh/{}",
         "medgen": "http://identifiers.org/medgen/{}",
-        "human phenotype ontology": "http://purl.obolibrary.org/obo/HP_{}"
+        "human phenotype ontology": "http://purl.obolibrary.org/obo/HP_{}",
+        "mondo": "http://purl.obolibrary.org/obo/MONDO_{}",
     }
 
     def __init__(self, id_, db):
@@ -181,6 +183,7 @@ class OntologyUri:
         # This separate condition for "human phenotype ontology" is needed because these IDs are
         # prefixed with "HP:" which should be ignored when creating uri
         if self.db.lower() == "human phenotype ontology":
+            logging.warning('Found <human phenotype ontology>, this should not really happen')
             self.uri = self.db_to_uri_dict[self.db.lower()].format(self.id_[3:])
         else:
             self.uri = self.db_to_uri_dict[self.db.lower()].format(self.id_)
@@ -199,7 +202,7 @@ def parse_args(argv):
     parser.add_argument("-i", dest="infile_path", required=True, help="Path to a file containing one CellBase ClinVar JSON per line.'")
     parser.add_argument("-o", dest="outfile_path", required=True, help="Path to file to output trait names in the zooma-accepted format")
 
-    parser.add_argument("-n", dest="ontologies", default="efo,ordo,hp",
+    parser.add_argument("-n", dest="ontologies", default="efo,ordo,hp,mondo",
                         help="ontologies to use in query")
     parser.add_argument("-r", dest="required", default="cttv,eva-clinvar,gwas",
                         help="data sources to use in query.")

--- a/bin/trait_mapping.py
+++ b/bin/trait_mapping.py
@@ -27,7 +27,7 @@ class ArgParser:
                             help="path to output file for mappings")
         parser.add_argument("-c", dest="output_curation_filepath", required=True,
                             help="path to output file for curation")
-        parser.add_argument("-n", dest="ontologies", default="efo,ordo,hp",
+        parser.add_argument("-n", dest="ontologies", default="efo,ordo,hp,mondo",
                             help="ontologies to use in query")
         parser.add_argument("-r", dest="required", default="cttv,eva-clinvar,clinvar-xrefs,gwas",
                             help="data sources to use in query.")
@@ -35,7 +35,7 @@ class ArgParser:
                             help="preference for data sources, with preferred data source first.")
         parser.add_argument("-z", dest="zooma_host", default="https://www.ebi.ac.uk",
                             help="the host to use for querying zooma")
-        parser.add_argument("-t", dest="oxo_target_list", default="Orphanet,efo,hp",
+        parser.add_argument("-t", dest="oxo_target_list", default="Orphanet,efo,hp,mondo",
                             help="target ontologies to use with OxO")
         parser.add_argument("-d", dest="oxo_distance", default=3,
                             help="distance to use to query OxO.")

--- a/bin/trait_mapping/traits_to_zooma.py
+++ b/bin/trait_mapping/traits_to_zooma.py
@@ -162,7 +162,7 @@ class ArgParser:
 
         parser.add_argument("-i", dest="input_filepath", required=True, help="path to input file, with trait names in first column, number of variants the trait name appears in in the second column. delimeted using tab")
         parser.add_argument("-o", dest="output_filepath", required=True, help="path to output file (not just the directory). outputs a file with a header (line starting with \"#\") which shows the filters used. then the first column is trait name, then number of variants for the trait, then zooma label, uri(s), confidence, source. these zooma columns repeat when there are multiple mappings.")
-        parser.add_argument("-n", dest="ontologies", default="efo,ordo,hp", help="ontologies to use in query")
+        parser.add_argument("-n", dest="ontologies", default="efo,ordo,hp,mondo", help="ontologies to use in query")
         parser.add_argument("-r", dest="required", default="cttv,eva-clinvar,gwas", help="data sources to use in query.")
         parser.add_argument("-p", dest="preferred", default="eva-clinvar,cttv,gwas", help="preference for data sources, with preferred data source first.")
         parser.add_argument("-z", dest="zooma_host", default="http://snarf.ebi.ac.uk:8580", help="the host to use for querying zooma")  # alternate to default is https://www.ebi.ac.uk

--- a/eva_cttv_pipeline/trait_mapping/main.py
+++ b/eva_cttv_pipeline/trait_mapping/main.py
@@ -45,6 +45,8 @@ def process_trait(trait: Trait, filters: dict, zooma_host: str, oxo_target_list:
                          "distance" parameter.
     :return: The original trait after querying Zooma and possibly OxO, with any results found.
     """
+
+    logger.debug('Processing trait {}'.format(trait.name))
     trait.zooma_result_list = get_zooma_results(trait.name, filters, zooma_host)
     trait.process_zooma_results()
     if (trait.is_finished
@@ -91,5 +93,5 @@ def main(input_filepath, output_mappings_filepath, output_curation_filepath, fil
             trait = process_trait(trait, filters, zooma_host, oxo_target_list,
                                   oxo_distance)
             output_trait(trait, mapping_writer, curation_writer)
-            if unattended and i % 10000 == 0:
+            if unattended and i % 100 == 0:
                 logger.info("Processed {} records".format(i))

--- a/eva_cttv_pipeline/trait_mapping/ols.py
+++ b/eva_cttv_pipeline/trait_mapping/ols.py
@@ -11,7 +11,7 @@ OLS_EFO_SERVER = 'https://www.ebi.ac.uk/ols'
 # for the local deployment is different from the production link in three regards: (1) it must use
 # HTTP instead of HTTPS; (2) it must include the port which you used when deploying the Docker
 # container; (3) it does *not* include /ols in its path.
-# OLS_EFO_SERVER = 'http://172.22.70.138:8080'
+# OLS_EFO_SERVER = 'http://127.0.0.1:8080'
 
 logger = logging.getLogger(__package__)
 

--- a/eva_cttv_pipeline/trait_mapping/ols.py
+++ b/eva_cttv_pipeline/trait_mapping/ols.py
@@ -6,6 +6,13 @@ import urllib
 from eva_cttv_pipeline.trait_mapping.utils import request_retry_helper
 
 
+OLS_EFO_SERVER = 'https://www.ebi.ac.uk/ols'
+# The setting for local OLS installation should be uncommented if necessary. Note that the link
+# for the local deployment is different from the production link in three regards: (1) it must use
+# HTTP instead of HTTPS; (2) it must include the port which you used when deploying the Docker
+# container; (3) it does *not* include /ols in its path.
+# OLS_EFO_SERVER = 'http://172.22.70.138:8080'
+
 logger = logging.getLogger(__package__)
 
 
@@ -60,7 +67,7 @@ def ols_efo_query(uri: str) -> requests.Response:
     """
     double_encoded_uri = double_encode_uri(uri)
     return requests.get(
-        "https://www.ebi.ac.uk/ols/api/ontologies/efo/terms/{}".format(double_encoded_uri))
+        "{}/api/ontologies/efo/terms/{}".format(OLS_EFO_SERVER, double_encoded_uri))
 
 
 @lru_cache(maxsize=16384)

--- a/eva_cttv_pipeline/trait_mapping/output.py
+++ b/eva_cttv_pipeline/trait_mapping/output.py
@@ -19,7 +19,8 @@ def get_mappings_for_curation(result_list) -> list:
     curation_mapping_list = []
     for result in result_list:
         for mapping in result.mapping_list:
-            curation_mapping_list.append(mapping)
+            if (mapping.in_efo and mapping.is_current) or (not mapping.in_efo):
+                curation_mapping_list.append(mapping)
     curation_mapping_list.sort(reverse=True)
     return curation_mapping_list
 
@@ -38,14 +39,14 @@ def output_for_curation(trait: Trait, curation_writer: csv.writer):
 
     for zooma_mapping in zooma_mapping_list:
         cell = [zooma_mapping.uri, zooma_mapping.ontology_label, str(zooma_mapping.confidence),
-                zooma_mapping.source]
+                zooma_mapping.source, 'EFO_CURRENT' if zooma_mapping.in_efo else 'NOT_CONTAINED']
         output_row.append("|".join(cell))
 
     oxo_mapping_list = get_mappings_for_curation(trait.oxo_result_list)
 
     for oxo_mapping in oxo_mapping_list:
         cell = [str(oxo_mapping.uri), oxo_mapping.ontology_label, str(oxo_mapping.distance),
-                oxo_mapping.query_id]
+                oxo_mapping.query_id, 'EFO_CURRENT' if oxo_mapping.in_efo else 'NOT_CONTAINED']
         output_row.append("|".join(cell))
 
     curation_writer.writerow(output_row)

--- a/eva_cttv_pipeline/trait_mapping/output.py
+++ b/eva_cttv_pipeline/trait_mapping/output.py
@@ -19,8 +19,7 @@ def get_mappings_for_curation(result_list) -> list:
     curation_mapping_list = []
     for result in result_list:
         for mapping in result.mapping_list:
-            if mapping.in_efo and mapping.is_current:
-                curation_mapping_list.append(mapping)
+            curation_mapping_list.append(mapping)
     curation_mapping_list.sort(reverse=True)
     return curation_mapping_list
 

--- a/eva_cttv_pipeline/trait_mapping/oxo.py
+++ b/eva_cttv_pipeline/trait_mapping/oxo.py
@@ -51,6 +51,7 @@ class OxOMapping:
         self.distance = distance
         self.query_id = query_id
         self.in_efo = False
+        # For non-EFO mappings, `is_current` property does not make sense and it not used
         self.is_current = False
         self.ontology_label = ""
 

--- a/eva_cttv_pipeline/trait_mapping/oxo.py
+++ b/eva_cttv_pipeline/trait_mapping/oxo.py
@@ -18,7 +18,6 @@ class OntologyUri:
         "efo": "http://www.ebi.ac.uk/efo/EFO_{}",
         "mesh": "http://identifiers.org/mesh/{}",
         "medgen": "http://identifiers.org/medgen/{}",
-        "human phenotype ontology": "http://purl.obolibrary.org/obo/HP_{}",
         "hp": "http://purl.obolibrary.org/obo/HP_{}",
         "doid": "http://purl.obolibrary.org/obo/DOID_{}",
         "mondo": "http://purl.obolibrary.org/obo/MONDO_{}",
@@ -27,11 +26,7 @@ class OntologyUri:
     def __init__(self, id_, db):
         self.id_ = id_
         self.db = db
-        if self.db.lower() == "human phenotype ontology":
-            logging.warning('Found <human phenotype ontology>, this should not really happen')
-            self.uri = self.db_to_uri_dict[self.db.lower()].format(self.id_[3:])
-        else:
-            self.uri = self.db_to_uri_dict[self.db.lower()].format(self.id_)
+        self.uri = self.db_to_uri_dict[self.db.lower()].format(self.id_)
 
     def __str__(self):
         return self.uri

--- a/eva_cttv_pipeline/trait_mapping/oxo.py
+++ b/eva_cttv_pipeline/trait_mapping/oxo.py
@@ -20,13 +20,15 @@ class OntologyUri:
         "medgen": "http://identifiers.org/medgen/{}",
         "human phenotype ontology": "http://purl.obolibrary.org/obo/HP_{}",
         "hp": "http://purl.obolibrary.org/obo/HP_{}",
-        "doid": "http://purl.obolibrary.org/obo/DOID_{}"
+        "doid": "http://purl.obolibrary.org/obo/DOID_{}",
+        "mondo": "http://purl.obolibrary.org/obo/MONDO_{}",
     }
 
     def __init__(self, id_, db):
         self.id_ = id_
         self.db = db
         if self.db.lower() == "human phenotype ontology":
+            logging.warning('Found <human phenotype ontology>, this should not really happen')
             self.uri = self.db_to_uri_dict[self.db.lower()].format(self.id_[3:])
         else:
             self.uri = self.db_to_uri_dict[self.db.lower()].format(self.id_)
@@ -98,7 +100,8 @@ URI_DB_TO_DB_DICT = {
     "efo": "EFO",
     "mesh": "MeSH",
     "hp": "HP",
-    "doid": "DOID"
+    "doid": "DOID",
+    "mondo": "MONDO",
 }
 
 

--- a/eva_cttv_pipeline/trait_mapping/trait.py
+++ b/eva_cttv_pipeline/trait_mapping/trait.py
@@ -1,3 +1,9 @@
+import logging
+
+
+logger = logging.getLogger(__package__)
+
+
 class OntologyEntry:
     """
     A representation of an ontology term mapped to using this pipeline. Includes a uri and a label
@@ -62,4 +68,5 @@ class Trait:
                     uri = str(mapping.uri)
                     ontology_label = mapping.ontology_label
                     ontology_entry = OntologyEntry(uri, ontology_label)
+                    logger.debug('Found an OxO finished mapping: {}'.format(uri))
                     self.finished_mapping_set.add(ontology_entry)

--- a/eva_cttv_pipeline/trait_mapping/zooma.py
+++ b/eva_cttv_pipeline/trait_mapping/zooma.py
@@ -41,6 +41,7 @@ class ZoomaMapping:
         self.source = source
         self.ontology_label = ""
         self.in_efo = False
+        # For non-EFO mappings, `is_current` property does not make sense and it not used
         self.is_current = False
 
     def __eq__(self, other):

--- a/tests/trait_mapping/test_output.py
+++ b/tests/trait_mapping/test_output.py
@@ -43,37 +43,47 @@ class TestOutputTraitMapping(unittest.TestCase):
 
 class TestGetMappingsForCuration(unittest.TestCase):
     def test_get_mappings_for_curation(self):
-        test_result_list = []
 
-        test_zooma_result = zooma.ZoomaResult(['http://purl.obolibrary.org/obo/HP_0001892'],
+        # This mapping is not in EFO, in which case `is_current` flag should *not* be checked,
+        # and the mapping *should* be selected for curation.
+        test_zooma_result_1 = zooma.ZoomaResult(['http://purl.obolibrary.org/obo/HP_0001892'],
                                                   'abnormal bleeding', 'HIGH', 'eva-clinvar')
-        mapping = test_zooma_result.mapping_list[0]
-        mapping.confidence = zooma.ZoomaConfidence.HIGH
-        mapping.in_efo = False
-        mapping.is_current = False
-        mapping.ontology_label = ""
-        mapping.source = 'eva-clinvar'
-        mapping.uri = 'http://purl.obolibrary.org/obo/HP_0000483'
+        mapping_1 = test_zooma_result_1.mapping_list[0]
+        mapping_1.confidence = zooma.ZoomaConfidence.HIGH
+        mapping_1.in_efo = False
+        mapping_1.is_current = False
+        mapping_1.ontology_label = ""
+        mapping_1.source = 'eva-clinvar'
+        mapping_1.uri = 'http://purl.obolibrary.org/obo/HP_0000483'
 
-        test_result_list.append(test_zooma_result)
+        # This mapping is in EFO, but is not current, it should *not* be selected for curation.
+        test_zooma_result_2 = zooma.ZoomaResult(['http://www.orpha.net/ORDO/Orphanet_976'],
+                                                 'Adenine phosphoribosyltransferase deficiency',
+                                                 'HIGH', 'eva-clinvar')
+        mapping_2 = test_zooma_result_2.mapping_list[0]
+        mapping_2.confidence = zooma.ZoomaConfidence.HIGH
+        mapping_2.in_efo = True
+        mapping_2.is_current = False
+        mapping_2.ontology_label = "Adenine phosphoribosyltransferase deficiency"
+        mapping_2.source = 'eva-clinvar'
+        mapping_2.uri = 'http://www.orpha.net/ORDO/Orphanet_976'
 
-        test_zooma_result = zooma.ZoomaResult(['http://www.orpha.net/ORDO/Orphanet_976'],
-                                              'Adenine phosphoribosyltransferase deficiency',
-                                              'HIGH', 'eva-clinvar')
-        mapping = test_zooma_result.mapping_list[0]
-        mapping.confidence = zooma.ZoomaConfidence.HIGH
-        mapping.in_efo = True
-        mapping.is_current = True
-        mapping.ontology_label = "Adenine phosphoribosyltransferase deficiency"
-        mapping.source = 'eva-clinvar'
-        mapping.uri = 'http://www.orpha.net/ORDO/Orphanet_976'
+        # This mapping is in EFO and is current, is *should* be selected for curation.
+        test_zooma_result_3 = zooma.ZoomaResult(['http://purl.obolibrary.org/obo/MONDO_0008091'],
+                                                'Abnormal neutrophil chemotactic response',
+                                                'MEDIUM', 'eva-clinvar')
+        mapping_3 = test_zooma_result_3.mapping_list[0]
+        mapping_3.confidence = zooma.ZoomaConfidence.HIGH
+        mapping_3.in_efo = True
+        mapping_3.is_current = True
+        mapping_3.ontology_label = "Abnormal neutrophil chemotactic response"
+        mapping_3.source = 'eva-clinvar'
+        mapping_3.uri = 'http://purl.obolibrary.org/obo/MONDO_0008091'
 
-        test_result_list.append(test_zooma_result)
-
-        expected_curation_mapping_list = [mapping]
-
+        test_result_list = [test_zooma_result_1, test_zooma_result_2, test_zooma_result_3]
+        expected_curation_mapping_list = sorted([mapping_1, mapping_3])
         self.assertEqual(expected_curation_mapping_list,
-                         output.get_mappings_for_curation(test_result_list))
+                         sorted(output.get_mappings_for_curation(test_result_list)))
 
 
 class TestOutputForCuration(unittest.TestCase):
@@ -98,10 +108,11 @@ class TestOutputForCuration(unittest.TestCase):
 
         with open(tempfile_path, "rt") as curation_file:
             curation_reader = csv.reader(curation_file, delimiter="\t")
-
-            self.assertEqual(["transitional cell carcinoma of the bladder", "276",
-                              "http://www.ebi.ac.uk/efo/EFO_0006544|bladder transitional cell carcinoma|2|HP:0006740"],
-                             next(curation_reader))
+            expected_record = [
+                "transitional cell carcinoma of the bladder", "276",
+                "http://www.ebi.ac.uk/efo/EFO_0006544|bladder transitional cell carcinoma|2|HP:0006740|EFO_CURRENT"
+            ]
+            self.assertEqual(expected_record, next(curation_reader))
 
 
 if __name__ == '__main__':

--- a/tests/trait_mapping/test_output.py
+++ b/tests/trait_mapping/test_output.py
@@ -42,48 +42,47 @@ class TestOutputTraitMapping(unittest.TestCase):
 
 
 class TestGetMappingsForCuration(unittest.TestCase):
-    def test_get_mappings_for_curation(self):
+    def test_get_non_efo_mapping(self):
+        """If mapping is not in EFO, its `is_current` flag should *not* be checked, and the mapping
+        *should* be selected for curation."""
+        test_zooma_result = zooma.ZoomaResult(['http://purl.obolibrary.org/obo/HP_0001892'],
+                                              'abnormal bleeding', 'HIGH', 'eva-clinvar')
+        mapping = test_zooma_result.mapping_list[0]
+        mapping.confidence = zooma.ZoomaConfidence.HIGH
+        mapping.in_efo = False
+        mapping.is_current = False
+        mapping.ontology_label = ""
+        mapping.source = 'eva-clinvar'
+        mapping.uri = 'http://purl.obolibrary.org/obo/HP_0000483'
+        self.assertEqual([mapping], output.get_mappings_for_curation([test_zooma_result]))
 
-        # This mapping is not in EFO, in which case `is_current` flag should *not* be checked,
-        # and the mapping *should* be selected for curation.
-        test_zooma_result_1 = zooma.ZoomaResult(['http://purl.obolibrary.org/obo/HP_0001892'],
-                                                  'abnormal bleeding', 'HIGH', 'eva-clinvar')
-        mapping_1 = test_zooma_result_1.mapping_list[0]
-        mapping_1.confidence = zooma.ZoomaConfidence.HIGH
-        mapping_1.in_efo = False
-        mapping_1.is_current = False
-        mapping_1.ontology_label = ""
-        mapping_1.source = 'eva-clinvar'
-        mapping_1.uri = 'http://purl.obolibrary.org/obo/HP_0000483'
+    def test_get_obsolete_efo_mapping(self):
+        """If mapping is in EFO, but is not current, it *should not* be selected for curation."""
+        test_zooma_result = zooma.ZoomaResult(['http://www.orpha.net/ORDO/Orphanet_976'],
+                                              'Adenine phosphoribosyltransferase deficiency',
+                                              'HIGH', 'eva-clinvar')
+        mapping = test_zooma_result.mapping_list[0]
+        mapping.confidence = zooma.ZoomaConfidence.HIGH
+        mapping.in_efo = True
+        mapping.is_current = False
+        mapping.ontology_label = "Adenine phosphoribosyltransferase deficiency"
+        mapping.source = 'eva-clinvar'
+        mapping.uri = 'http://www.orpha.net/ORDO/Orphanet_976'
+        self.assertEqual([], output.get_mappings_for_curation([test_zooma_result]))
 
-        # This mapping is in EFO, but is not current, it should *not* be selected for curation.
-        test_zooma_result_2 = zooma.ZoomaResult(['http://www.orpha.net/ORDO/Orphanet_976'],
-                                                 'Adenine phosphoribosyltransferase deficiency',
-                                                 'HIGH', 'eva-clinvar')
-        mapping_2 = test_zooma_result_2.mapping_list[0]
-        mapping_2.confidence = zooma.ZoomaConfidence.HIGH
-        mapping_2.in_efo = True
-        mapping_2.is_current = False
-        mapping_2.ontology_label = "Adenine phosphoribosyltransferase deficiency"
-        mapping_2.source = 'eva-clinvar'
-        mapping_2.uri = 'http://www.orpha.net/ORDO/Orphanet_976'
-
-        # This mapping is in EFO and is current, is *should* be selected for curation.
-        test_zooma_result_3 = zooma.ZoomaResult(['http://purl.obolibrary.org/obo/MONDO_0008091'],
-                                                'Abnormal neutrophil chemotactic response',
-                                                'MEDIUM', 'eva-clinvar')
-        mapping_3 = test_zooma_result_3.mapping_list[0]
-        mapping_3.confidence = zooma.ZoomaConfidence.HIGH
-        mapping_3.in_efo = True
-        mapping_3.is_current = True
-        mapping_3.ontology_label = "Abnormal neutrophil chemotactic response"
-        mapping_3.source = 'eva-clinvar'
-        mapping_3.uri = 'http://purl.obolibrary.org/obo/MONDO_0008091'
-
-        test_result_list = [test_zooma_result_1, test_zooma_result_2, test_zooma_result_3]
-        expected_curation_mapping_list = sorted([mapping_1, mapping_3])
-        self.assertEqual(expected_curation_mapping_list,
-                         sorted(output.get_mappings_for_curation(test_result_list)))
+    def test_get_current_efo_mapping(self):
+        """If mapping is in EFO and is current, is *should* be selected for curation."""
+        test_zooma_result = zooma.ZoomaResult(['http://purl.obolibrary.org/obo/MONDO_0008091'],
+                                              'Abnormal neutrophil chemotactic response',
+                                              'MEDIUM', 'eva-clinvar')
+        mapping = test_zooma_result.mapping_list[0]
+        mapping.confidence = zooma.ZoomaConfidence.HIGH
+        mapping.in_efo = True
+        mapping.is_current = True
+        mapping.ontology_label = "Abnormal neutrophil chemotactic response"
+        mapping.source = 'eva-clinvar'
+        mapping.uri = 'http://purl.obolibrary.org/obo/MONDO_0008091'
+        self.assertEqual([mapping], output.get_mappings_for_curation([test_zooma_result]))
 
 
 class TestOutputForCuration(unittest.TestCase):

--- a/tests/trait_mapping/test_oxo.py
+++ b/tests/trait_mapping/test_oxo.py
@@ -31,6 +31,10 @@ class TestUriToOxoFormat(unittest.TestCase):
         self.assertEqual(oxo.uri_to_oxo_format("http://purl.obolibrary.org/obo/HP_0030731"),
                          "HP:0030731")
 
+    def test_mondo(self):
+        self.assertEqual(oxo.uri_to_oxo_format("http://purl.obolibrary.org/obo/MONDO_0019531"),
+                         "MONDO:0019531")
+
     def test_nonexistent(self):
         self.assertEqual(oxo.uri_to_oxo_format("not_a_real_uri"),
                          None)

--- a/tests/trait_mapping/test_trait_names_parsing.py
+++ b/tests/trait_mapping/test_trait_names_parsing.py
@@ -19,7 +19,3 @@ class TestGetTraitNames(unittest.TestCase):
 
         self.assertEqual(trait_names_parsing.get_trait_names(clinvar_json),
                          expected_trait_names_list)
-
-
-
-


### PR DESCRIPTION
* Ontology terms from MONDO are now supported and added to the output where appropriate.
* Added support on how to deploy a local OLS server and how to use it.
* When mappings are selected for manual curation, output those who are either present in EFO and not obsolete, or not present in EFO at all. (Previously: only non-obsolete EFO mappings were selected for curation.)
  + Added a field which contains a status of the record in relation to EFO (either `EFO_CURRENT` or `NOT_CONTAINED`).
  + Also updated tests `TestGetMappingsForCuration` and `TestOutputForCuration` to reflect the new logic.
* Further improved logging for debugging.
* Drop support for "human phenotype ontology", an obsolete OxO alias for HP.