### PR TITLE
EVA-1483 — Update dependencies to mitigate vulnerabilities

### DIFF
--- a/clinvar-xml-parser/pom.xml
+++ b/clinvar-xml-parser/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.0</version>
+      <version>2.9.8</version>
     </dependency>
     <dependency>
       <groupId>com.beust</groupId>

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,10 +11,9 @@ pytest==2.9.1
 pytest-cov==2.2.1
 pytest-runner==2.7
 pytz==2015.7
-PyYAML==3.11
 query-string==0.0.4
 request==0.0.2
-requests==2.9.1
+requests>=2.20.0
 requests_mock
 setuptools-git==1.1
 sh==1.11


### PR DESCRIPTION
* Remove `PyYAML` 3.11: dependency not used.
* Update `requests`: 2.9.1 → 2.20.0+. Compatibility of simple methods that we use, such as `get()` and `post()`, should not be affected.
* Update `com.fasterxml.jackson.databind`: 2.9.0 → 2.9.8. This is a patch update, compatibility should not be affected.