### PR TITLE
EVA-1700 — fixes to trait mapping pipeline

### DIFF
--- a/bin/clinvar_jsons/traits_to_zooma_format.py
+++ b/bin/clinvar_jsons/traits_to_zooma_format.py
@@ -11,7 +11,7 @@ import progressbar
 import requests
 
 from clinvar_jsons_shared_lib import clinvar_jsons, get_traits_from_json, has_allowed_clinical_significance
-from eva_cttv_pipeline.trait_mapping.utils import request_retry_helper
+from eva_cttv_pipeline.trait_mapping.utils import json_request
 
 
 DATE = strftime("%d/%m/%y %H:%M", gmtime())
@@ -110,7 +110,7 @@ def get_clinvar_accession(clinvar_json):
 
 def get_zooma_uris(trait_name, zooma_host, filters):
     url = build_zooma_query(trait_name, filters, zooma_host)
-    json_response = request_retry_helper(url)
+    json_response = json_request(url)
 
     if json_response is None:
         return None

--- a/bin/trait_mapping.py
+++ b/bin/trait_mapping.py
@@ -9,7 +9,7 @@ def launch():
 
     main.main(parser.input_filepath, parser.output_mappings_filepath,
               parser.output_curation_filepath, parser.filters, parser.zooma_host,
-              parser.oxo_target_list, parser.oxo_distance, parser.unattended)
+              parser.oxo_target_list, parser.oxo_distance)
 
 
 class ArgParser:
@@ -39,8 +39,6 @@ class ArgParser:
                             help="target ontologies to use with OxO")
         parser.add_argument("-d", dest="oxo_distance", default=3,
                             help="distance to use to query OxO.")
-        parser.add_argument('-u', dest="unattended", action='store_true',
-                            help="unattended launch, hide ETA estimates")
 
         args = parser.parse_args(args=argv[1:])
 
@@ -55,7 +53,6 @@ class ArgParser:
         self.zooma_host = args.zooma_host
         self.oxo_target_list = [target.strip() for target in args.oxo_target_list.split(",")]
         self.oxo_distance = args.oxo_distance
-        self.unattended = args.unattended
 
 
 if __name__ == '__main__':

--- a/docs/submit-opentargets-batch.md
+++ b/docs/submit-opentargets-batch.md
@@ -87,7 +87,7 @@ A new Java package will be generated in the directory `clinvar-xml-parser/src/ma
 Here we transform ClinVar's XML file into a JSON file which can be parsed by the downstream tools, using an XML parser which we (if necessary) updated during the previous step.
 
 ```bash
-cd ${CODE_ROOT} && ${BSUB_CMDLINE} -M 4G \
+cd ${CODE_ROOT} && ${BSUB_CMDLINE} -n 8 -M 4G \
   -o ${BATCH_ROOT}/logs/convert_clinvar_files.out \
   -e ${BATCH_ROOT}/logs/convert_clinvar_files.err \
   java -jar ${CODE_ROOT}/clinvar-xml-parser/target/clinvar-parser-1.0-SNAPSHOT-jar-with-dependencies.jar \
@@ -168,10 +168,10 @@ The TSV file eventually returned by OpenTargets has these columns:
 See information about the trait mapping pipeline [here](trait-mapping-pipeline.md). It is run with the following command:
 
 ```bash
-cd ${CODE_ROOT} && ${BSUB_CMDLINE} \
+cd ${CODE_ROOT} && ${BSUB_CMDLINE} -M 4G \
   -o ${BATCH_ROOT}/logs/trait_mapping.out \
   -e ${BATCH_ROOT}/logs/trait_mapping.err \
-  python bin/trait_mapping.py -u \
+  python bin/trait_mapping.py \
   -i ${BATCH_ROOT}/clinvar/clinvar.filtered.json.gz \
   -o ${BATCH_ROOT}/trait_mapping/automated_trait_mappings.tsv \
   -c ${BATCH_ROOT}/trait_mapping/traits_requiring_curation.tsv

--- a/eva_cttv_pipeline/evidence_string_generation/__init__.py
+++ b/eva_cttv_pipeline/evidence_string_generation/__init__.py
@@ -1,4 +1,4 @@
 import logging
 logging.basicConfig()
 logger = logging.getLogger(__package__)
-logger.setLevel(level=logging.INFO)
+logger.setLevel(level=logging.DEBUG)

--- a/eva_cttv_pipeline/trait_mapping/__init__.py
+++ b/eva_cttv_pipeline/trait_mapping/__init__.py
@@ -1,4 +1,4 @@
 import logging
 logging.basicConfig()
 logger = logging.getLogger(__package__)
-logger.setLevel(level=logging.INFO)
+logger.setLevel(level=logging.DEBUG)

--- a/eva_cttv_pipeline/trait_mapping/main.py
+++ b/eva_cttv_pipeline/trait_mapping/main.py
@@ -45,8 +45,8 @@ def process_trait(trait: Trait, filters: dict, zooma_host: str, oxo_target_list:
                          "distance" parameter.
     :return: The original trait after querying Zooma and possibly OxO, with any results found.
     """
-
     logger.debug('Processing trait {}'.format(trait.name))
+
     trait.zooma_result_list = get_zooma_results(trait.name, filters, zooma_host)
     trait.process_zooma_results()
     if (trait.is_finished
@@ -55,15 +55,14 @@ def process_trait(trait: Trait, filters: dict, zooma_host: str, oxo_target_list:
                     for mapping in trait.zooma_result_list
                     for entry in mapping.mapping_list])):
         return trait
+
     uris_for_oxo_set = get_uris_for_oxo(trait.zooma_result_list)
-    if len(uris_for_oxo_set) == 0:
-        return trait
     oxo_input_id_list = uris_to_oxo_format(uris_for_oxo_set)
+    if len(oxo_input_id_list) == 0:
+        return trait
     trait.oxo_result_list = get_oxo_results(oxo_input_id_list, oxo_target_list, oxo_distance)
-
     if not trait.oxo_result_list:
-        logger.warning('No OxO mapping for trait {}'.format(trait.name))
-
+        logger.debug('No OxO mapping for trait {}'.format(trait.name))
     trait.process_oxo_mappings()
 
     return trait

--- a/eva_cttv_pipeline/trait_mapping/ols.py
+++ b/eva_cttv_pipeline/trait_mapping/ols.py
@@ -3,7 +3,7 @@ import logging
 import requests
 import urllib
 
-from eva_cttv_pipeline.trait_mapping.utils import request_retry_helper
+from eva_cttv_pipeline.trait_mapping.utils import json_request
 
 
 OLS_EFO_SERVER = 'https://www.ebi.ac.uk/ols'
@@ -30,7 +30,7 @@ def get_ontology_label_from_ols(ontology_uri: str) -> str:
     :return: Term label for the ontology URI provided in the parameters.
     """
     url = build_ols_query(ontology_uri)
-    json_response = request_retry_helper(url)
+    json_response = json_request(url)
 
     if not json_response:
         return None

--- a/eva_cttv_pipeline/trait_mapping/ols.py
+++ b/eva_cttv_pipeline/trait_mapping/ols.py
@@ -37,7 +37,8 @@ def get_ontology_label_from_ols(ontology_uri: str) -> str:
 
     # If the '_embedded' section is missing from the response, it means that the term is not found in OLS
     if '_embedded' not in json_response:
-        logger.warning('OLS queried OK but did not return any results for URL {}'.format(url))
+        if '/medgen/' not in url and '/omim/' not in url:
+            logger.warning('OLS queried OK but did not return any results for URL {}'.format(url))
         return None
 
     # Go through all terms found by the requested identifier and try to find the one where the _identifier_ and the
@@ -48,7 +49,8 @@ def get_ontology_label_from_ols(ontology_uri: str) -> str:
         if term["is_defining_ontology"]:
             return term["label"]
 
-    logger.warning('OLS queried OK, but there is no defining ontology in its results for URL {}'.format(url))
+    if '/medgen/' not in url and '/omim/' not in url:
+        logger.warning('OLS queried OK, but there is no defining ontology in its results for URL {}'.format(url))
     return None
 
 

--- a/eva_cttv_pipeline/trait_mapping/utils.py
+++ b/eva_cttv_pipeline/trait_mapping/utils.py
@@ -1,37 +1,14 @@
 import logging
 import requests
+from retry import retry
 logger = logging.getLogger(__package__)
 
 
-def json_request(url: str, payload: dict) -> dict:
-    """Makes a GET request with the specified URL and payload, attempts to parse the result as a JSON string and
-    return it as a dictionary, on failure raises an exception."""
-    result = requests.get(url, data=payload)
-    assert result.ok
+@retry(exceptions=(ConnectionError, requests.RequestException), logger=logger,
+       tries=4, delay=2, backoff=1.2, jitter=(1, 3))
+def json_request(url: str, payload: dict = None, method=requests.get) -> dict:
+    """Makes a request of a specified type (by default GET) with the specified URL and payload, attempts to parse the
+    result as a JSON string and return it as a dictionary, on failure raises an exception."""
+    result = method(url, data=payload)
+    result.raise_for_status()
     return result.json()
-
-
-def retry_helper(function, kwargs: dict, retry_count: int):
-    """
-    Given a function, make a `retry_count` number of attempts to call it until it returns a value without raising
-    an exception, and subsequently return this value. If all attempts to run the function are unsuccessful, return None.
-
-    :param function: Function that could need multiple attempts to return a value
-    :param kwargs: Dictionary with function's keyword arguments
-    :param retry_count: Number of attempts to make
-    :return: Returned value of the function.
-    """
-    for retry_num in range(retry_count):
-        try:
-            return function(**kwargs)
-        except Exception as e:
-            logger.warning("Attempt {}: failed running function {} with kwargs {}".format(retry_num, function, kwargs))
-            logger.warning(e)
-    logger.warning("Error on last attempt, skipping")
-    return None
-
-
-def request_retry_helper(url: str, payload: dict = None, retry_count: int = 4):
-    """Makes a GET request with the specified URL and payload via `json_request`, makes several attempts and handles
-    the exceptions via `retry_helper`."""
-    return retry_helper(json_request, {'url': url, 'payload': payload}, retry_count)

--- a/eva_cttv_pipeline/trait_mapping/zooma.py
+++ b/eva_cttv_pipeline/trait_mapping/zooma.py
@@ -3,7 +3,7 @@ from functools import total_ordering
 import logging
 
 from eva_cttv_pipeline.trait_mapping.ols import get_ontology_label_from_ols, is_current_and_in_efo, is_in_efo
-from eva_cttv_pipeline.trait_mapping.utils import request_retry_helper
+from eva_cttv_pipeline.trait_mapping.utils import json_request
 
 
 logger = logging.getLogger(__package__)
@@ -98,7 +98,7 @@ def get_zooma_results(trait_name: str, filters: dict, zooma_host: str) -> list:
     """
 
     url = build_zooma_query(trait_name, filters, zooma_host)
-    zooma_response_list = request_retry_helper(url)
+    zooma_response_list = json_request(url)
 
     if zooma_response_list is None:
         return []

--- a/eva_cttv_pipeline/trait_mapping/zooma.py
+++ b/eva_cttv_pipeline/trait_mapping/zooma.py
@@ -112,8 +112,6 @@ def get_zooma_results(trait_name: str, filters: dict, zooma_host: str) -> list:
                 zooma_mapping.ontology_label = label
             else:
                 # If no label is returned (because OLS failed to provide it), keep the existing one from ZOOMA
-                logger.warning(("Couldn't retrieve ontology label from OLS for trait '{}', using label specified "
-                                "by ZOOMA instead").format(trait_name))
                 zooma_mapping.ontology_label = zooma_result.zooma_label
 
             uri_is_current_and_in_efo = is_current_and_in_efo(zooma_mapping.uri)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ query-string==0.0.4
 request==0.0.2
 requests>=2.20.0
 requests_mock
+retry==0.9.2
 setuptools-git==1.1
 sh==1.11
 six==1.12.0


### PR DESCRIPTION
* Refactor & code cleanup
  + Traits are now processed in parallel, increasing performance (approx. 8× boost, from 0.5 traits/s to 4 traits/s)
  + Simplify retry policy for `json_request`, remove unnecessary helpers. Now using an external `retry` library
  + Configure correct handling of different error types; do not ignore any request errors unless directly specified.
* Fixes for OxO queries
  + OxO requests now always use POST instead of GET
  + Do not try to query OxO when the identifier list is empty, as this causes predictable errors which show up in the logs
  + Correctly handle occasional OxO errors. There is a bug which I discovered and reported: https://github.com/EBISPOT/OXO/issues/26
* Logs cleanup
  + Remove double warning for the same error when OLS didn't return a term label
  + Don't show expected OLS query errors for OMIM and MedGen ontologies (since those two are not present in OLS)
  + Demote "OxO no mappings found" from warning to debug level, because this by itself is not an error — OxO does not guarantee that any cross-refs will be found for any particular input term
  + Default logging level is now DEBUG. This provides the most information, while verbose DEBUG entries can be easily filtered out