### PR TITLE
EVA-1701 — Update documentation for manual curation

### DIFF
--- a/docs/manual-curation.md
+++ b/docs/manual-curation.md
@@ -73,6 +73,7 @@ The “Status” column has the following acceptable values:
 * **IMPORT** — an acceptable trait has been found from the MONDO/ORDO/HP ontologies which is not contained in EFO and must be imported
 * **NEW** — new term must be created in EFO
 * **SKIP** — trait is going to be skipped in this iteration, due to being too non-specific, or just having a low frequency
+* **UNSURE** — temporary status; traits to be discussed with reviewers/the team
 
 “Comment” field can contain arbitrary additional information.
 

--- a/docs/manual-curation.md
+++ b/docs/manual-curation.md
@@ -69,6 +69,11 @@ The new manual workflow can be shortened if necessary, while the quality of the 
 * If necessary, section 1 can be skipped completely, i. e. copy-paste previous mappings into “Mapping to use” column, but skip the review.
 * Sections 2.2 and 3 can only be applied to some variants (e. g. based on frequency), depending on the time available.
 
+## Entering the curation results
+
+### Adding new mappings
+To select a new mapping which does not appear in the list of automatically generated mappings, use the following format: `URL|LABEL|||EFO_STATUS`. Example: `http://www.ebi.ac.uk/efo/EFO_0006329|response to citalopram|||EFO_CURRENT`. The last value can be either `EFO_CURRENT` (trait is present in the latest EFO version available in OLS), or `NOT_CONTAINED` if the term is not contained in the EFO.
+
 ### Marking the status of curated terms
 The “Status” column has the following acceptable values:
 * **DONE** — an acceptable trait contained in EFO has been found for the trait

--- a/docs/manual-curation.md
+++ b/docs/manual-curation.md
@@ -2,6 +2,8 @@
 
 The goal is for traits with occurence ≥ 10 to have 100% coverage after the manual curation. For the rest of the traits, curate as many as possible.
 
+Before executing the subsequent commands, make sure to set up environment (described in the “Set up environment” section of the main protocol.)
+
 ## Extract information about previous mappings
 At this step, mappings produced by the pipeline on the previous iteration (including automated and manual) are downloaded to be used to aid the manual curation process.
 

--- a/docs/manual-curation.md
+++ b/docs/manual-curation.md
@@ -6,8 +6,6 @@ The goal is for traits with occurence ≥ 10 to have 100% coverage after the man
 At this step, mappings produced by the pipeline on the previous iteration (including automated and manual) are downloaded to be used to aid the manual curation process.
 
 ```bash
-# Set the variable below for year and month of the OpenTargets batch release
-export BATCH_ROOT=/nfs/production3/eva/opentargets/batch-YYYY-MM
 # Download the latest eva_clinvar release from FTP
 wget -qO- ftp://ftp.ebi.ac.uk/pub/databases/eva/ClinVar/latest/eva_clinvar.txt \
   | cut -f4-5 | sort -u > ${BATCH_ROOT}/trait_mapping/previous_mappings.tsv
@@ -68,6 +66,18 @@ The new manual workflow can be shortened if necessary, while the quality of the 
 * All subsections 1.\* involve review of mappings previously selected by ourselves. Because we trust them (to an extent), this review can be applied not to all mappings, but only to some (selected on a basis of frequency, or just randomly sampled/eyeballed).
 * If necessary, section 1 can be skipped completely, i. e. copy-paste previous mappings into “Mapping to use” column, but skip the review.
 * Sections 2.2 and 3 can only be applied to some variants (e. g. based on frequency), depending on the time available.
+
+### Marking the status of curated terms
+The “Status” column has the following acceptable values:
+* **DONE** — an acceptable trait contained in EFO has been found for the trait
+* **IMPORT** — an acceptable trait has been found from the MONDO/ORDO/HP ontologies which is not contained in EFO and must be imported
+* **NEW** — new term must be created in EFO
+* **SKIP** — trait is going to be skipped in this iteration, due to being too non-specific, or just having a low frequency
+
+“Comment” field can contain arbitrary additional information.
+
+### Note on spaces and line breaks
+Sometimes, especially when copy-pasting information from external sources, a mapping label or URL can contain an additional space symbol (at the beginning or end) or an accidental line break. This causes problems in the downstream processing and must be manually removed. To minimise the occurences of this, Google Sheets template includes a validation formula for the first two columns (“URI of selected mapping” and “Label of selected mapping”). If it detects an extra space symbol or a line break, the cell will be highlighted in red.
 
 ## Exporting curation results
 Once the manual curation is complete, export the results to a file named `finished_mappings_curation.tsv` and save it to `${BATCH_ROOT}/trait_mapping` directory. This file must consist of three columns from the curation spreadsheet: “ClinVar label”; “URI of selected mapping”; “Label of selected mapping”, in that order. Make sure to only export the mappings which the curator marked as done.

--- a/docs/submit-opentargets-batch.md
+++ b/docs/submit-opentargets-batch.md
@@ -14,7 +14,7 @@ export OT_RELEASE=YYYY-MM
 
 # Year and month of ClinVar release used (see step 1.1 Download ClinVar data).
 # Note that this is *different* from the OpenTargets release year/month.
-export CLINVAR_RELEASE=YYYY_MM
+export CLINVAR_RELEASE=YYYY-MM
 
 # This variable should point to the directory where this repository clone is located on the cluster.
 export CODE_ROOT=/nfs/production3/eva/software/eva-cttv-pipeline
@@ -189,7 +189,7 @@ See separate protocol, [Manual curation](manual-curation.md).
 * The mappings selected for each trait are adequate
 * Good/bad criteria for curation are observed (see the manual curation protocol, section “Criteria to manually evaluate mapping quality”)
 * The number of traits in the `finished_mappings_curation.tsv` file is the same as in the spreadsheet after applying all relevant filters
-* Spreadhseet does not contain line endings in trait names (can be checked by a regexp search)
+* _Important:_ spreadhseet does not contain line endings, or extraneous space symbols, in trait names (can be checked by a regexp search)
 
 ## Step 5. Generate evidence strings [(issue template)](https://www.ebi.ac.uk/panda/jira/browse/EVA-1473)
 


### PR DESCRIPTION
Updated spreadsheet template for manual curation and documentation:
* Replaced the binary “Done/Not done” with the new "Status" column for more flexibility. Described the acceptable range of values for it in the documentation.
* Clarified how to add new mappings (as opposed to copy-pasting mappings suggested by the pipeline). Fixed formulas in the spreadsheet to correctly handle manually entered mappings.
* Empathised the importance of removing extra space symbols and line breaks in the manually entered terms. Implemented automatic validation in the spreadsheet.
* Following comment by @jmmut clarified how to set up environment for the manual curation protocol.