### PR TITLE
EVA-1744 — Update docs for generating EFO table

### DIFF
--- a/bin/trait_mapping/create_efo_table.py
+++ b/bin/trait_mapping/create_efo_table.py
@@ -52,7 +52,6 @@ def uri_to_curie(uri):
 def get_cross_references(curie):
     """Queries OxO to return the list of cross-references for a given term curie."""
     url = oxo_url_template.format(curie=curie)
-    print(url)
     mappings = requests.get(url).json()['_embedded']['searchResults'][0]['mappingResponseList']
     return [m['curie'] for m in mappings]
 

--- a/docs/submit-opentargets-batch.md
+++ b/docs/submit-opentargets-batch.md
@@ -320,16 +320,26 @@ If everything has been done correctly, hash sums will be the same. Note that the
 
 
 ## Step 7. Adding novel trait names to EFO
-Traits remaining unmapped or poorly mapped can be submitted to EFO if a suitable parent term is available. Any new terms added will be picked up by ZOOMA in the next iteration of the trait mapping pipeline.
+Traits remaining unmapped or poorly mapped can be submitted to EFO if a suitable parent term is available. Any new terms added will be picked up by ZOOMA in the next iteration of the trait mapping pipeline. Novel traits can be submitted to EFO using the [Webulous templates](https://www.ebi.ac.uk/efo/webulous/) **Add EFO disease** and **Import HP term**. Open a new Google spreadsheet and connect with the server using the Webulous Add-on.
 
-Novel traits can be submitted to EFO using the [Webulous templates](https://www.ebi.ac.uk/efo/webulous/) **Add EFO disease** and **Import HP term**. Open a new Google spreadsheet and connect with the server using the Webulous Add-on.
+There is a helpqer script available for preparing the table. The input file  `${BATCH_ROOT}/trait_mapping/efo_ontology_terms.txt ` must contain a list of ontology URIs for EFO import, one entry per line. Example of such a file:
 
-There is a helper script available for preparing the table. `ontology_mappings` must contain a list of ontology identifiers for EFO import (such as `MONDO_123456`, `Orphanet:123456`, etc.), one entry per line. The output file will contains a partially ready table for EFO import.
-```bash
-python bin/trait_mapping/create_efo_table.py \ 
-  -i ontology_mappings.txt \
-  -o efo_table.tsv
 ```
+http://purl.obolibrary.org/obo/HP_0002647
+http://purl.obolibrary.org/obo/MONDO_0000727
+http://www.orpha.net/ORDO/Orphanet_199306
+...
+```
+
+Before running the script, make sure to set up the environment (see above).
+
+```bash
+python ${CODE_ROOT}/bin/trait_mapping/create_efo_table.py \
+  -i ${BATCH_ROOT}/trait_mapping/efo_ontology_terms.txt \
+  -o ${BATCH_ROOT}/trait_mapping/efo_import_table.tsv
+```
+
+The file `${BATCH_ROOT}/trait_mapping/efo_import_table.tsv` will contains a partially ready table for EFO import.
 
 The table needs to be amended manually:
 * Some terms will lack descriptions, because ontologies don't always contain a description field for a particular term. If possible, descriptions should be added for all traits.

--- a/docs/submit-opentargets-batch.md
+++ b/docs/submit-opentargets-batch.md
@@ -339,7 +339,7 @@ python ${CODE_ROOT}/bin/trait_mapping/create_efo_table.py \
   -o ${BATCH_ROOT}/trait_mapping/efo_import_table.tsv
 ```
 
-The file `${BATCH_ROOT}/trait_mapping/efo_import_table.tsv` will contains a partially ready table for EFO import.
+The file `${BATCH_ROOT}/trait_mapping/efo_import_table.tsv` will contain a partially ready table for EFO import.
 
 The table needs to be amended manually:
 * Some terms will lack descriptions, because ontologies don't always contain a description field for a particular term. If possible, descriptions should be added for all traits.

--- a/tests/trait_mapping/test_zooma.py
+++ b/tests/trait_mapping/test_zooma.py
@@ -46,10 +46,10 @@ class TestGetZoomaResults(unittest.TestCase):
 
     def test_get_result_without_ols_label(self):
         """If OLS does not provide a label for a trait, ZOOMA original label must be used instead."""
-        requested_trait_name = 'DEFICIENCY OF PHOSPHOLIPASE A2 GROUP IV A'
-        expected_trait_label = 'Phospholipase a2, group IV a, deficiency of'
+        requested_trait_name = 'Mucopolysaccharidosis type VI'
+        expected_trait_label = 'Mucopolysaccharidosis type 6'
         zooma_result = zooma.get_zooma_results(requested_trait_name, self.filters, self.zooma_host)
         self.assertEqual(len(zooma_result), 1)
         mappings = zooma_result[0].mapping_list
-        self.assertEqual(len(mappings), 1)
-        self.assertEqual(mappings[0].ontology_label, expected_trait_label)
+        self.assertEqual(len(mappings), 3)
+        self.assertIn(expected_trait_label, [m.ontology_label for m in mappings])


### PR DESCRIPTION
Previously OLS supported two kinds of queries: either by URI, e.g. `http://www.orpha.net/ORDO/Orphanet_425`, or by curie, e. g. `Orphanet:425`. Our calls were using curie format; now only URI format is supported. I adjusted documentation accordingly. No changes to the script itself are necessary.

Secondary change: when running builds for this PR, I discovered that the ZOOMA tests are failing. This is because the ClinVar has modified names for some traits. I have now chosen a different trait to do this test.