### PR TITLE
EVA-1938 — Integrate repeat expansion pipeline

### DIFF
--- a/docs/submit-opentargets-batch.md
+++ b/docs/submit-opentargets-batch.md
@@ -222,7 +222,9 @@ cat \
   + If the PR is submitted, check that there are no breaking changes in the schema version
   + If the PR is submitted, tests must be updated as well
 * There shouldn't be any warnings such as “Error on last attempt, skipping” in the logs. This might mean that one of the servers was down during processing, and potentially not all information has been gathered.
-* The final file with the genes & consequences contains both “normal variants”, and a few dozen repeat variants, including `short_tandem_repeat_expansion` and `trinucleotide_repeat_expansion` ones.
+* Functional consequences
+  + The final file with the genes & consequences contains both “normal variants”, and a few dozen repeat variants, including `short_tandem_repeat_expansion` and `trinucleotide_repeat_expansion` ones.
+  + The `${BATCH_ROOT}/logs/consequence_repeat_expansion.err` log will record all repeat expansion variants which could not be parsed using any of the regular expressions. Verify that there are no new such variants compared to the previous batch.
 
 ## Step 2. Manual curation
 See separate protocol, [Manual curation](manual-curation.md).

--- a/docs/submit-opentargets-batch.md
+++ b/docs/submit-opentargets-batch.md
@@ -70,11 +70,24 @@ export CLINVAR_RELEASE=${CLINVAR_RELEASE_YEAR}-${CLINVAR_RELEASE_MONTH}
 
 Before proceeding with executing the commands, update code on the cluster and create the necessary directories:
 ```bash
+# By modifying those four variables, you can run arbitrary versions of both the main and the VEP pipeline
+export MAIN_REMOTE=origin
+export MAIN_BRANCH=master
+export VEP_REMOTE=origin
+export VEP_BRANCH=master
+
 cd $CODE_ROOT
-git fetch
-git checkout master
-git reset --hard origin/master
+git fetch ${MAIN_REMOTE}
+git checkout ${MAIN_BRANCH}
+git reset --hard ${MAIN_REMOTE}/${MAIN_BRANCH}
+
 git submodule update --init --recursive
+cd vep-mapping-pipeline
+git fetch ${VEP_REMOTE}
+git checkout ${VEP_BRANCH}
+git reset --hard ${VEP_REMOTE}/${VEP_BRANCH}
+cd ..
+
 python3 setup.py install
 mkdir -p ${BATCH_ROOT}
 cd ${BATCH_ROOT}

--- a/docs/submit-opentargets-batch.md
+++ b/docs/submit-opentargets-batch.md
@@ -85,13 +85,31 @@ Note that most of the commands below use `bsub` to submit jobs to LSF cluster ra
 
 ## Step 1. Process ClinVar data
 
-### 1.1 Download data: XML dump & VCF summary
+### 1.1 Download data
 
-Two files are required (full release XML and VCF variant summary) and are downloaded from the ClinVar FTP into the `clinvar` subfolder:
+ClinVar data is available in several formats. Different formats are convenient for different use cases, hence we download three of them: XML dump; VCF summary; and TSV summary.
 ```bash
+
+CLINVAR_PATH_BASE="ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar"
+
+# ClinVar FTP paths are different depending on whether the current year is the same as the year of the ClinVar release
+# which we are trying to download.
+if [[ `date +"%Y"` = ${CLINVAR_RELEASE_YEAR} ]]
+then
+  # Same year
+  CLINVAR_XML="/xml/ClinVarFullRelease_${CLINVAR_RELEASE}.xml.gz"
+  CLINVAR_TSV="/tab_delimited/archive/variant_summary_${CLINVAR_RELEASE}.txt.gz"
+else
+  # Different (past) year
+  CLINVAR_XML="/xml/archive/${CLINVAR_RELEASE_YEAR}/ClinVarFullRelease_${CLINVAR_RELEASE}.xml.gz"
+  CLINVAR_TSV="/tab_delimited/archive/${CLINVAR_RELEASE_YEAR}/variant_summary_${CLINVAR_RELEASE}.txt.gz"
+fi
+
+# Download three files
 wget --directory-prefix ${BATCH_ROOT}/clinvar/ \
-  ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/xml/archive/${CLINVAR_RELEASE_YEAR}/ClinVarFullRelease_${CLINVAR_RELEASE}.xml.gz \
-  ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz
+  "${CLINVAR_PATH_BASE}/${CLINVAR_XML}" \
+  "${CLINVAR_PATH_BASE}/${CLINVAR_TSV}" \
+  "${CLINVAR_PATH_BASE}/vcf_GRCh38/clinvar.vcf.gz" \
 ```
 
 ### 1.2. Update ClinVar XML schema version (if necessary)

--- a/eva_cttv_pipeline/evidence_string_generation/consequence_type.py
+++ b/eva_cttv_pipeline/evidence_string_generation/consequence_type.py
@@ -103,7 +103,8 @@ class SoTerm(object):
                               'gene_variant': 1564,
                               'sequence_variant': 1060,
                               'trinucleotide_repeat_microsatellite_feature': 291,
-                              'trinucleotide_repeat_expansion': 2165}
+                              'trinucleotide_repeat_expansion': 2165,
+                              'short_tandem_repeat_expansion': 2162}
 
     ranked_so_names_list = ['transcript_ablation',
                             'splice_acceptor_variant',


### PR DESCRIPTION
* **Integrated the repeat expansion pipeline**
  + Download the third file type from ClinVar, TSV summary.
  + Added commands to run the pipeline and to unite its results with the VEP pipeline.
  + Pair variants and consequences using RCV by default. This is done to avoid ingesting any incorrect mappings produced by VEP for the same variants using the coordinate notation. Added a comment with the detailed explanation.
  + Added `short_tandem_repeat_expansion` to the list of supported variant types.
  + Amended review checklist.
* **Other protocol adjustments**
  + Added commands to run the code for both main & VEP pipelines using arbitrary remote and branch—very useful for debugging purposes.
  + Revised commands to download ClinVar data so that FTP paths are correctly formed in all cases.
  + Added mention of a [spreadsheet](https://docs.google.com/spreadsheets/d/1m4ld3y3Pfust5JSOJOX9ZmImRCKRGi-fGYj_dExoGj8/edit) containing known problematic trait-to-ontology mappings and amended review checklist.