### PR TITLE
EVA-1999 — Prioritise repeat expansion variant traits in manual curation

### DIFF
--- a/docs/manual-curation/step1-fetch-clinvar-data.md
+++ b/docs/manual-curation/step1-fetch-clinvar-data.md
@@ -38,7 +38,7 @@ cd ${CODE_ROOT} && python3 bin/trait_mapping/create_table_for_manual_curation.py
 few traits have that many mappings, and in virtually all cases these extra mappings are not meaningful. However, having
 a very large table degrades the performance of Google Sheets substantially.
 cut -f-50 ${CURATION_RELEASE_ROOT}/table_for_manual_curation.tsv \
-  | sort -t$'\t' -k2,2rn > ${CURATION_RELEASE_ROOT}/google_sheets_table.tsv
+  | sort -t$'\t' -k2,2rV > ${CURATION_RELEASE_ROOT}/google_sheets_table.tsv
 ```
 
 ## Create a Google spreadsheet for curation

--- a/docs/manual-curation/step2-manual-curation.md
+++ b/docs/manual-curation/step2-manual-curation.md
@@ -2,7 +2,7 @@
 
 The goals of the manual curation:
 * All traits which are linked to NT expansion (nucleotide repeat expansion) variants must be curated. Those are marked as "NT expansion" in the frequency column.
-* All traits with occurence ≥ **5** must have 100% coverage of manual curation.
+* All traits with occurrence ≥ **10** must be curated. Additionally, if there are less than **200** such terms, then the top 200 terms must be curated.
 * For the rest of the traits, we curate as many as possible.
 
 Good mappings must be eyeballed to ensure they are actually good. Alternative mappings for medium or low quality mappings can be searched for using OLS. If a mapping can't be found in EFO, look for a mapping to a HP, ORDO, or MONDO trait name. Most HP/ORDO/MONDO terms will also be in EFO but some are not. These can be imported to EFO using the Webulous submission service.

--- a/docs/manual-curation/step2-manual-curation.md
+++ b/docs/manual-curation/step2-manual-curation.md
@@ -1,6 +1,9 @@
 # Manual curation, part II, biological: perform manual curation
 
-The final goal of manual curation is for traits with occurence ≥ **5** to have 100% coverage. For the rest of the traits, we curate as many as possible.
+The goals of the manual curation:
+* All traits which are linked to NT expansion (nucleotide repeat expansion) variants must be curated. Those are marked as "NT expansion" in the frequency column.
+* All traits with occurence ≥ **5** must have 100% coverage of manual curation.
+* For the rest of the traits, we curate as many as possible.
 
 Good mappings must be eyeballed to ensure they are actually good. Alternative mappings for medium or low quality mappings can be searched for using OLS. If a mapping can't be found in EFO, look for a mapping to a HP, ORDO, or MONDO trait name. Most HP/ORDO/MONDO terms will also be in EFO but some are not. These can be imported to EFO using the Webulous submission service.
 

--- a/docs/manual-curation/step2-manual-curation.md
+++ b/docs/manual-curation/step2-manual-curation.md
@@ -1,6 +1,6 @@
 # Manual curation, part II, biological: perform manual curation
 
-The final goal of manual curation is for traits with occurence ≥ 10 to have 100% coverage. For the rest of the traits, we curate as many as possible.
+The final goal of manual curation is for traits with occurence ≥ **5** to have 100% coverage. For the rest of the traits, we curate as many as possible.
 
 Good mappings must be eyeballed to ensure they are actually good. Alternative mappings for medium or low quality mappings can be searched for using OLS. If a mapping can't be found in EFO, look for a mapping to a HP, ORDO, or MONDO trait name. Most HP/ORDO/MONDO terms will also be in EFO but some are not. These can be imported to EFO using the Webulous submission service.
 

--- a/eva_cttv_pipeline/trait_mapping/main.py
+++ b/eva_cttv_pipeline/trait_mapping/main.py
@@ -70,9 +70,8 @@ def process_trait(trait: Trait, filters: dict, zooma_host: str, oxo_target_list:
 def main(input_filepath, output_mappings_filepath, output_curation_filepath, filters, zooma_host, oxo_target_list,
          oxo_distance):
     logger.info('Started parsing trait names')
-    trait_names_list = parse_trait_names(input_filepath)
-    trait_names_counter = Counter(trait_names_list)
-    logger.info("Loaded {} trait names".format(len(trait_names_counter)))
+    trait_list = parse_trait_names(input_filepath)
+    logger.info("Loaded {} trait names".format(len(trait_list)))
 
     with open(output_mappings_filepath, "w", newline='') as mapping_file, \
             open(output_curation_filepath, "wt") as curation_file:
@@ -81,9 +80,7 @@ def main(input_filepath, output_mappings_filepath, output_curation_filepath, fil
         curation_writer = csv.writer(curation_file, delimiter="\t")
 
         logger.info('Processing trait names in parallel')
-        trait_list = [Trait(trait_name, freq) for trait_name, freq in trait_names_counter.items()]
         trait_process_pool = multiprocessing.Pool(processes=12)
-
         processed_trait_list = [
             trait_process_pool.apply(
                 process_trait,

--- a/eva_cttv_pipeline/trait_mapping/output.py
+++ b/eva_cttv_pipeline/trait_mapping/output.py
@@ -33,7 +33,11 @@ def output_for_curation(trait: Trait, curation_writer: csv.writer):
     :param trait: A Trait with no finished ontology mappings in finished_mapping_set
     :param curation_writer: A csv.writer to write non-finished ontology mappings for manual curation
     """
-    output_row = [trait.name, trait.frequency]
+
+    # Traits which are associated with NT expansion variants are of highest importance, and they need to be curated
+    # even if the number of records they are associated with is low.
+    trait_frequency = 'NT expansion' if trait.associated_with_nt_expansion else trait.frequency
+    output_row = [trait.name, trait_frequency]
 
     zooma_mapping_list = get_mappings_for_curation(trait.zooma_result_list)
 

--- a/eva_cttv_pipeline/trait_mapping/trait.py
+++ b/eva_cttv_pipeline/trait_mapping/trait.py
@@ -29,12 +29,13 @@ class Trait:
     Object to hold data for one trait name. Including the number of ClinVar record's traits it
     appears in, any Zooma and OxO mappings, and any mappings which are ready to be output.
     """
-    def __init__(self, name, frequency):
+    def __init__(self, name, frequency, associated_with_nt_expansion):
         self.name = name
         self.frequency = frequency
         self.zooma_result_list = []
         self.oxo_result_list = []
         self.finished_mapping_set = set()
+        self.associated_with_nt_expansion = associated_with_nt_expansion
 
     @property
     def is_finished(self):
@@ -42,6 +43,14 @@ class Trait:
         Return boolean which confirms whether the trait has finished mappings ready to be output
         """
         return len(self.finished_mapping_set) > 0
+
+    @property
+    def is_associated_with_nt_expansion(self):
+        """
+        Returns a boolean property which indicates whether the trait is associated with a NT expansion (nucleotide
+        repeat expansion) variant.
+        """
+        return self.associated_with_nt_expansion
 
     def process_zooma_results(self):
         """

--- a/eva_cttv_pipeline/trait_mapping/trait.py
+++ b/eva_cttv_pipeline/trait_mapping/trait.py
@@ -29,7 +29,7 @@ class Trait:
     Object to hold data for one trait name. Including the number of ClinVar record's traits it
     appears in, any Zooma and OxO mappings, and any mappings which are ready to be output.
     """
-    def __init__(self, name, frequency, associated_with_nt_expansion):
+    def __init__(self, name, frequency, associated_with_nt_expansion=False):
         self.name = name
         self.frequency = frequency
         self.zooma_result_list = []

--- a/eva_cttv_pipeline/trait_mapping/trait_names_parsing.py
+++ b/eva_cttv_pipeline/trait_mapping/trait_names_parsing.py
@@ -1,5 +1,8 @@
+from collections import Counter
 import gzip
 import json
+
+from eva_cttv_pipeline.trait_mapping.trait import Trait
 
 
 # TODO: unify the acceptable clinical significance levels project-wide
@@ -9,20 +12,30 @@ ACCEPTABLE_CLINICAL_SIGNIFICANCE = ['pathogenic', 'likely pathogenic', 'protecti
 
 def parse_trait_names(filepath: str) -> list:
     """
-    For a file containing ClinVar records in the TSV format, return a list of the trait names for the records in the
-    file.
+    For a file containing ClinVar records in the TSV format, return a list of Traits for the records in the file. Each
+    Trait object contains trait name, how many times it occurs in the input file, and whether it is linked to an NT
+    expansion variant.
+
+    Trait occurrence count is calculated based on all unique (AlleleID, RCV, trait name) tuples in the input file. This
+    is because each such tuple will, generally speaking, correspond to one output evidence string. So if we want to
+    gauge which trait names are more important to curate, we need to consider how many such tuples it appears in.
+
+    The reason we need to keep track of only *unique* tuples is because some (most) alleles will appear twice in the
+    document with coordinates for GRCh37 and GRCh38, and we don't want to count them twice.
+
+    Traits which are implicated in "NT expansion" variants are marked using a special field, because their curation is
+    of highest importance even if the number of records which they are linked to is low.
 
     :param filepath: Path to a gzipped file containing ClinVar TSV summary.
-    :return: A list of traits. It is important that it is a list and not a set, as it is used to calculate the
-        frequencies of each trait later on.
+    :return: A list of Trait objects.
     """
 
-    # This set stores all unique (AlleleID, RCV, trait name) tuples. The reason for that is each such tuple will,
-    # generally speaking, correspond to one output evidence string. So if we want to gauge which trait names are more
-    # important to curate, we need to consider how many such tuples it appears in. The reason we need to keep track of
-    # only unique tuples is because some (most) alleles will appear twice in the document with coordinates for GRCh37
-    # and GRCh38, and we don't want to count them twice.
-    unique_association_records = set()
+    # Tracks unique (AlleleID, RCV, trait name) tuples
+    unique_association_tuples = set()
+
+    # Tracks all traits which are at least once implicated in "NT expansion", or nucleotide repeat expansion, variants.
+    # Their curation is of highest importantce regardless of how many records they are actually associated with.
+    nt_expansion_traits = set()
 
     with gzip.open(filepath, "rt") as clinvar_summary:
         header = clinvar_summary.readline().rstrip().split('\t')
@@ -38,16 +51,24 @@ def parse_trait_names(filepath: str) -> list:
             if not acceptable_clinical_significance_present:
                 continue
 
-            # Extract relevant tuple elements
+            # Extract relevant fields
+            is_nt_expansion_variant = data['Type'] == 'NT expansion'
             allele_id = data['#AlleleID']
             traits = set(data['PhenotypeList'].split(';'))
             rcv_ids = set(data['RCVaccession'].split(';'))
+
+            # Process all (trait, rcv) records
             for trait, rcv_id in zip(traits, rcv_ids):
-                unique_association_records |= {(allele_id, trait, rcv_id)}
+                unique_association_tuples |= {(trait, rcv_id, allele_id)}
+                if is_nt_expansion_variant:
+                    nt_expansion_traits |= {trait}
 
-    # Now combine all traits into a single list
-    trait_name_list = []
-    for _, trait, _ in unique_association_records:
-        trait_name_list.extend(traits)
+    # Count trait occurrences
+    trait_names = [t[0] for t in unique_association_tuples]
+    traits = []
+    for trait_name, trait_frequency in Counter(trait_names).items():
+        associated_with_nt_expansion = trait_name in nt_expansion_traits
+        traits.append(Trait(name=trait_name.lower(), frequency=trait_frequency,
+                            associated_with_nt_expansion=associated_with_nt_expansion))
 
-    return [t.lower() for t in trait_name_list]
+    return traits

--- a/eva_cttv_pipeline/trait_mapping/trait_names_parsing.py
+++ b/eva_cttv_pipeline/trait_mapping/trait_names_parsing.py
@@ -59,9 +59,9 @@ def parse_trait_names(filepath: str) -> list:
 
             # Process all (trait, rcv) records
             for trait, rcv_id in zip(traits, rcv_ids):
-                unique_association_tuples |= {(trait, rcv_id, allele_id)}
+                unique_association_tuples.add((trait, rcv_id, allele_id))
                 if is_nt_expansion_variant:
-                    nt_expansion_traits |= {trait}
+                    nt_expansion_traits.add(trait)
 
     # Count trait occurrences
     trait_names = [t[0] for t in unique_association_tuples]

--- a/tests/trait_mapping/test_trait_names_parsing.py
+++ b/tests/trait_mapping/test_trait_names_parsing.py
@@ -10,9 +10,9 @@ class TestGetTraitNames(unittest.TestCase):
         # Test file contains two records: one with a Pathogenic variant another with a Benign one. Only trait names
         # from the Pathogenic one should get into the
         test_filename = os.path.join(os.path.dirname(__file__), 'resources/variant_summary.tsv.gz')
-        traits = trait_names_parsing.parse_trait_names(test_filename)
+        trait_names = [trait.name for trait in trait_names_parsing.parse_trait_names(test_filename)]
         self.assertEqual(
-            sorted(traits),
+            sorted(trait_names),
             sorted([
                 'breast-ovarian cancer, familial 1', 'hereditary breast and ovarian cancer syndrome',
                 'hereditary cancer-predisposing syndrome', 'not provided'])


### PR DESCRIPTION
* Prioritise traits which link to repeat expansion variants. Instead of number of records, they will just display a "NT expansion" in the frequency column. Also updated the protocol to reflect the importance of these traits.
* Lower threshold for trait occurrence from 10 to 5: as our protocols improve, we can and should curate more traits now.
* Count trait name frequency slighly more accurately, taking into account that a trait name can appear _multiple_ times in the same row for the same allele ID.
* Preserve all mappings from the previous iterations, even if they are not present in the latest ClinVar version use for manual curation.